### PR TITLE
Masked error code

### DIFF
--- a/tools/fst/compile_lexicon_token_fst.sh
+++ b/tools/fst/compile_lexicon_token_fst.sh
@@ -16,7 +16,7 @@
 
 # This script compiles the lexicon and CTC tokens into FSTs. FST compiling slightly differs between the
 # phoneme and character-based lexicons.
-
+set -eo pipefail
 . tools/parse_options.sh
 
 if [ $# -ne 3 ]; then


### PR DESCRIPTION
Error code is masked in the pipeline, such as 
```ctc_token_fst.py ... | ...```