### PR TITLE
接受linux shell管道输入（wav二进制） can accept shell pipe input (bytes wav)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ tensorboard
 tensorboardX
 typeguard
 textgrid
+scipy

--- a/tools/process_pipe_input.py
+++ b/tools/process_pipe_input.py
@@ -50,7 +50,7 @@ def _process_pipe_input(
     return torch.Tensor(waveform),sample_rate
 
 if __name__ == '__main__':
-    pipestr="cat /NASdata/AudioData/AISHELL-ASR-SSB/SPEECHDATA/SSB0001/SSB00010010.wav | sox -t wav - -r 16000 -c 1 -b 16 -t wav - |"
+    pipestr="cat ./SSB00010010.wav | sox -t wav - -r 16000 -c 1 -b 16 -t wav - |"
     waveform1, sample_rate1 = _process_pipe_input(pipestr,speed=1.0)
     waveform2, sample_rate2 = _process_pipe_input(pipestr,speed=1.1)
     print("")

--- a/tools/process_pipe_input.py
+++ b/tools/process_pipe_input.py
@@ -1,0 +1,56 @@
+import subprocess
+import torch
+from scipy.io.wavfile import read as read_forpipe
+import io
+import numpy as np
+
+def _process_pipe_input(
+    pipestr: str,
+    frame_offset: int = 0,
+    num_frames: int = -1,
+    channels_first: bool = True,
+    speed: float = 1.0
+):
+    """
+    Load waveform data from pipe command. used in function _extract_feature()
+
+    The input is a pipe command, usually the format can be processed by Kaldi. 
+
+    Args:
+        pipestr: a shell pipe string (like "cat ./1.wav | sox -t wav - -r 16000 -c 1 -b 16 -t wav - |")
+        frame_offset: the begin frame index of the segment wav
+        num_frames: the frame length of the segment wav (default=-1, means no segment)
+        channels_first: if true, the first dim of waveform means channels number
+        speed: 
+    Returns:
+        (waveform, sample_rate)
+
+    """
+    if speed == 1.0:
+        input_commend=pipestr+" cat - "
+    else:
+        input_commend=pipestr+" cat - |"+" sox -t wav - -t wav - stretch " + format(speed, '.1f')
+        # here will output a warning "sox WARN wav: Length in output .wav header will be wrong since can't seek to fix it"
+    p=subprocess.Popen(input_commend,shell=True,stdout=subprocess.PIPE)
+    out=p.stdout.read()
+    # here, input_wav is a bytes object representing the wav object
+    sample_rate, waveform = read_forpipe(io.BytesIO(out))
+    waveform=np.array(waveform)
+    if(len(waveform.shape)==1):
+        waveform=np.expand_dims(waveform,axis=0)
+    else:
+        waveform=waveform.T
+    
+    if num_frames != -1:
+        waveform=waveform[:,frame_offset:frame_offset+num_frames]
+    if not channels_first:
+        waveform=waveform.transpose(0,1)
+
+    return torch.Tensor(waveform),sample_rate
+
+if __name__ == '__main__':
+    pipestr="cat /NASdata/AudioData/AISHELL-ASR-SSB/SPEECHDATA/SSB0001/SSB00010010.wav | sox -t wav - -r 16000 -c 1 -b 16 -t wav - |"
+    waveform1, sample_rate1 = _process_pipe_input(pipestr,speed=1.0)
+    waveform2, sample_rate2 = _process_pipe_input(pipestr,speed=1.1)
+    print("")
+    

--- a/tools/process_pipe_input.py
+++ b/tools/process_pipe_input.py
@@ -29,7 +29,8 @@ def _process_pipe_input(
     if speed == 1.0:
         input_commend=pipestr+" cat - "
     else:
-        input_commend=pipestr+" cat - |"+" sox -t wav - -t wav - stretch " + format(speed, '.1f')
+        input_commend=pipestr+" cat - |"+" sox -t wav - -t wav - speed " + format(speed, '.1f')
+        # input_commend=pipestr+" cat - |"+" sox -t wav - -t wav - stretch " + format(speed, '.1f')
         # here will output a warning "sox WARN wav: Length in output .wav header will be wrong since can't seek to fix it"
     p=subprocess.Popen(input_commend,shell=True,stdout=subprocess.PIPE)
     out=p.stdout.read()

--- a/tools/wav2dur.py
+++ b/tools/wav2dur.py
@@ -5,6 +5,7 @@ import sys
 
 import torchaudio
 torchaudio.set_audio_backend("sox")
+from tools.process_pipe_input import _process_pipe_input
 
 scp = sys.argv[1]
 dur_scp = sys.argv[2]
@@ -15,9 +16,12 @@ with open(scp, 'r') as f, open(dur_scp, 'w') as fout:
     for l in f:
         items = l.strip().split()
         wav_id = items[0]
-        fname = items[1]
+        fname = l.strip().lstrip(wav_id+" ")
         cnt += 1
-        waveform, rate = torchaudio.load_wav(fname)
+        if fname.endswith("|"): # if wav_path is a shell command
+            waveform, rate = _process_pipe_input(fname)
+        else:
+            waveform, rate = torchaudio.load_wav(fname)
         frames = len(waveform[0])
         duration = frames / float(rate)
         total_duration += duration


### PR DESCRIPTION
add process_pipe_input.py into tools/
change wenet/dataset/dataset.py and tools/wav2dur.py

通过subprocess执行shell命令，用scipy.io.wavfile.read来读取二进制输入
利用是否以"|"结尾判断输入为音频还是管道
do shell command by subprocess and get waveform by scipy.io.wavfile.read(io.BytesIO(out))
Use whether the input ends with "|" to determine whether the input is audio or pipe