### PR TITLE
[runtime] create bitrev and sintbl for each feature pipeline

### DIFF
--- a/runtime/core/frontend/fbank.h
+++ b/runtime/core/frontend/fbank.h
@@ -41,6 +41,13 @@ class Fbank {
         distribution_(0, 1.0),
         dither_(0.0) {
     fft_points_ = UpperPowerOfTwo(frame_length_);
+    // generate bit reversal table and trigonometric function table
+    const int fft_points_4 = fft_points_ / 4;
+    bitrev_.resize(fft_points_);
+    sintbl_.resize(fft_points_ + fft_points_4);
+    make_sintbl(fft_points_, sintbl_.data());
+    make_bitrev(fft_points_, bitrev_.data());
+
     int num_fft_bins = fft_points_ / 2;
     float fft_bin_width = static_cast<float>(sample_rate_) / fft_points_;
     int low_freq = 20, high_freq = sample_rate_ / 2;
@@ -158,7 +165,8 @@ class Fbank {
       memset(fft_real.data() + frame_length_, 0,
              sizeof(float) * (fft_points_ - frame_length_));
       memcpy(fft_real.data(), data.data(), sizeof(float) * frame_length_);
-      fft(fft_real.data(), fft_img.data(), fft_points_);
+      fft(bitrev_.data(), sintbl_.data(), fft_real.data(), fft_img.data(),
+          fft_points_);
       // power
       for (int j = 0; j < fft_points_ / 2; ++j) {
         power[j] = fft_real[j] * fft_real[j] + fft_img[j] * fft_img[j];
@@ -200,6 +208,11 @@ class Fbank {
   std::default_random_engine generator_;
   std::normal_distribution<float> distribution_;
   float dither_;
+
+  // bit reversal table
+  std::vector<int> bitrev_;
+  // trigonometric function table
+  std::vector<float> sintbl_;
 };
 
 }  // namespace wenet

--- a/runtime/core/frontend/fft.h
+++ b/runtime/core/frontend/fft.h
@@ -14,7 +14,11 @@ namespace wenet {
 
 // Fast Fourier Transform
 
-int fft(float* x, float* y, int n);
+void make_sintbl(int n, float* sintbl);
+
+void make_bitrev(int n, int* bitrev);
+
+int fft(const int* bitrev, const float* sintbl, float* x, float* y, int n);
 
 }  // namespace wenet
 


### PR DESCRIPTION
fft may crash in multi-threaded scenarios:

e.g.
```
last_n = 0

thread1:
   1) if (n != last_n || n == 0)  pass
   2) make_sintbl/make_bitrev
   3) access bitrev and sintbl

thread2:
   1）if (n != last_n || n == 0)  pass
   2) if (sintbl != NULL) free(sintbl);

```
if the order is:
- thread1: 1
- thread2: 1
- thread1: 2
- thread2: 2
- thread1: 3 (crash because `sintbl` has been freed )
