### PR TITLE
[runtime] inverse text normalizer (ITN)

### DIFF
--- a/runtime/core/backend/inverse_text_normalizer.cc
+++ b/runtime/core/backend/inverse_text_normalizer.cc
@@ -1,0 +1,238 @@
+// Copyright (c) 2021.
+// Author: sxc19@mails.tsinghua.edu.cn (Xingchen Song)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "inverse_text_normalizer.h"
+
+#include <set>
+
+#include "utils/log.h"
+#include "utils/flags.h"
+
+namespace wenet {
+
+void InverseTextNormalizer::Initialize(
+    const std::string& far_path,
+    const std::string& rules,
+    const std::string& input_mode,
+    const std::string& output_mode) {
+  CHECK(grm_.LoadArchive(far_path));
+  rules_ = thrax::StringSplit(rules, ',');
+  if (rules_.empty()) LOG(FATAL) << "rules must be specified";
+  for (size_t i = 0; i < rules_.size(); ++i) {
+    thrax::RuleTriple triple(rules_[i]);
+    const auto *fst = grm_.GetFst(triple.main_rule);
+    if (!fst) {
+      LOG(FATAL) << "grm.GetFst() must be non nullptr for rule: "
+                 << triple.main_rule;
+    }
+    fst::StdVectorFst vfst(*fst);
+    // If the input transducers in the FAR have symbol tables then we need to
+    // add the appropriate symbol table(s) to the input strings, according to
+    // the parse mode.
+    if (vfst.InputSymbols()) {
+      if (!byte_symtab_ &&
+          vfst.InputSymbols()->Name() ==
+          thrax::function::kByteSymbolTableName) {
+        byte_symtab_ = std::shared_ptr<fst::SymbolTable>(
+            vfst.InputSymbols()->Copy());
+      } else if (!utf8_symtab_ &&
+                 vfst.InputSymbols()->Name() ==
+                 thrax::function::kUtf8SymbolTableName) {
+        utf8_symtab_ = std::shared_ptr<fst::SymbolTable>(
+            vfst.InputSymbols()->Copy());
+      }
+    }
+    if (!triple.pdt_parens_rule.empty()) {
+      fst = grm_.GetFst(triple.pdt_parens_rule);
+      if (!fst) {
+        LOG(FATAL) << "grm.GetFst() must be non nullptr for rule: "
+                   << triple.pdt_parens_rule;
+      }
+    }
+    if (!triple.mpdt_assignments_rule.empty()) {
+      fst = grm_.GetFst(triple.mpdt_assignments_rule);
+      if (!fst) {
+        LOG(FATAL) << "grm.GetFst() must be non nullptr for rule: "
+                   << triple.mpdt_assignments_rule;
+      }
+    }
+  }
+
+  GetGeneratedSymbolTable();
+  if (input_mode == "byte") {
+    compiler_ = std::shared_ptr<Compiler>(
+        new Compiler(fst::StringTokenType::BYTE));
+  } else if (input_mode == "utf8") {
+    compiler_ = std::shared_ptr<Compiler>(
+        new Compiler(fst::StringTokenType::UTF8));
+  } else {
+    input_symtab_ = std::shared_ptr<fst::SymbolTable>(
+        fst::SymbolTable::ReadText(input_mode));
+    if (!input_symtab_) LOG(FATAL) << "Invalid mode or symbol table path.";
+    compiler_ = std::shared_ptr<Compiler>(
+        new Compiler(fst::StringTokenType::SYMBOL,
+                     fst::SymbolTable::ReadText(input_mode)));
+  }
+
+  if (output_mode == "byte") {
+    type_ = BYTE;
+  } else if (output_mode == "utf8") {
+    type_ = UTF8;
+  } else {
+    type_ = SYMBOL;
+    output_symtab_ = std::shared_ptr<fst::SymbolTable>(
+        fst::SymbolTable::ReadText(output_mode));
+    if (!output_symtab_) LOG(FATAL) << "Invalid mode or symbol table path.";
+  }
+}
+
+const std::string InverseTextNormalizer::ProcessInput(
+    const std::string& input) {
+  fst::StdVectorFst input_fst, output_fst;
+  if (!(compiler_->operator()(input, &input_fst))) {
+    return "Unable to parse input string.";
+  }
+  FormatFst(&input_fst);
+  string return_val = "";
+  // Set symbols for the input, if appropriate
+  if (byte_symtab_ && type_ == BYTE) {
+    input_fst.SetInputSymbols(byte_symtab_.get());
+    input_fst.SetOutputSymbols(byte_symtab_.get());
+  } else if (utf8_symtab_ && type_ == UTF8) {
+    input_fst.SetInputSymbols(utf8_symtab_.get());
+    input_fst.SetOutputSymbols(utf8_symtab_.get());
+  } else if (input_symtab_ && type_ == SYMBOL) {
+    input_fst.SetInputSymbols(input_symtab_.get());
+    input_fst.SetOutputSymbols(input_symtab_.get());
+  }
+
+  bool succeeded = true;
+  for (size_t i = 0; i < rules_.size(); ++i) {
+    thrax::RuleTriple triple(rules_[i]);
+    if (grm_.Rewrite(triple.main_rule, input_fst, &output_fst,
+                     triple.pdt_parens_rule, triple.mpdt_assignments_rule)) {
+      input_fst = output_fst;
+    } else {
+      succeeded = false;
+      break;
+    }
+  }
+
+  std::vector<std::pair<string, float> > strings;
+  std::set<string> seen;
+  if (succeeded && FstToStrings(output_fst, 1, &strings)) {
+    std::vector<std::pair<string, float> >::iterator itr = strings.begin();
+    for (; itr != strings.end(); ++itr) {
+      std::set<string>::iterator sx = seen.find(itr->first);
+      if (sx != seen.end()) continue;
+      return_val += itr->first;
+      seen.insert(itr->first);
+      // for noutput > 1, add space separator
+      if (itr + 1 != strings.end()) return_val += " ";
+    }
+    return return_val;
+  } else {
+    return "Rewrite failed.";
+  }
+}
+
+void InverseTextNormalizer::GetGeneratedSymbolTable() {
+  const auto* symbolfst = grm_.GetFst("*StringFstSymbolTable");
+  if (symbolfst != nullptr) {
+    generated_symtab_ = std::shared_ptr<fst::SymbolTable>(
+        symbolfst->InputSymbols()->Copy());
+  }
+}
+
+void InverseTextNormalizer::FormatFst(fst::StdVectorFst *vfst) {
+  for (fst::StateIterator<fst::StdVectorFst> state_iter(*vfst);
+       !state_iter.Done(); state_iter.Next()) {
+    int state_id = state_iter.Value();
+    for (fst::MutableArcIterator<fst::StdVectorFst> arc_iter(vfst, state_id);
+         !arc_iter.Done(); arc_iter.Next()) {
+       const fst::StdArc arc = arc_iter.Value();
+       fst::StdArc new_arc(arc.ilabel & 0xff, arc.olabel & 0xff,
+                           arc.weight, arc.nextstate);
+       arc_iter.SetValue(new_arc);
+    }
+  }
+}
+
+bool InverseTextNormalizer::FstToStrings(
+    const fst::StdVectorFst& vfst, const int& n,
+    std::vector<std::pair<string, float>>* strings) {
+  fst::StdVectorFst shortest_path;
+  if (n == 1) {
+    fst::ShortestPath(vfst, &shortest_path, n);
+  } else {
+    // The uniqueness feature of ShortestPath requires us to have an acceptor,
+    // so we project and remove epsilon arcs.
+    fst::StdVectorFst temp(vfst);
+    fst::Project(&temp, fst::PROJECT_OUTPUT);
+    fst::RmEpsilon(&temp);
+    fst::ShortestPath(temp, &shortest_path, n, /* unique */ true);
+  }
+  if (shortest_path.Start() == fst::kNoStateId) return false;
+  for (fst::PathIterator<fst::StdArc> iter(shortest_path,
+                                          /* check_acyclic */ false);
+       !iter.Done(); iter.Next()) {
+    std::string path;
+    for (const auto label : iter.OLabels()) {
+      if (!AppendLabel(label, &path)) {
+        return false;
+      }
+    }
+    strings->emplace_back(std::move(path), iter.Weight().Value());
+  }
+  return true;
+}
+
+bool InverseTextNormalizer::AppendLabel(const fst::StdArc::Label& label,
+                                        std::string* path) {
+  if (label != 0) {
+    // Check first to see if this label is in the generated symbol set. Note
+    // that this should not conflict with a user-provided symbol table since
+    // the parser used by GrmCompiler doesn't generate extra labels if a
+    // string is parsed using a user-provided symbol table.
+    if (generated_symtab_ && !generated_symtab_->Find(label).empty()) {
+      string sym = generated_symtab_->Find(label);
+      *path += "[" + sym + "]";
+    } else if (type_ == SYMBOL) {
+      string sym = output_symtab_->Find(label);
+      if (sym == "") {
+        LOG(ERROR) << "Missing symbol in symbol table for id: " << label;
+        return false;
+      }
+      // For non-byte, non-UTF8 symbols, one overwhelmingly wants these to be
+      // space-separated.
+      if (!path->empty()) *path += " ";
+      *path += sym;
+    } else if (type_ == BYTE) {
+      path->push_back(label);
+    } else if (type_ == UTF8) {
+      std::string utf8_string;
+      std::vector<fst::StdArc::Label> labels;
+      labels.push_back(label);
+      if (!fst::LabelsToUTF8String(labels, &utf8_string)) {
+        LOG(ERROR) << "LabelsToUTF8String: Bad code point: " << label;
+        return false;
+      }
+      *path += utf8_string;
+    }
+  }
+  return true;
+}
+
+}  // namespace wenet

--- a/runtime/core/backend/inverse_text_normalizer.cc
+++ b/runtime/core/backend/inverse_text_normalizer.cc
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "inverse_text_normalizer.h"
+#include "backend/inverse_text_normalizer.h"
 
 #include <set>
 

--- a/runtime/core/backend/inverse_text_normalizer.h
+++ b/runtime/core/backend/inverse_text_normalizer.h
@@ -1,0 +1,84 @@
+// Copyright (c) 2021.
+// Author: sxc19@mails.tsinghua.edu.cn (Xingchen Song)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BACKEND_INVERSE_TEXT_NORMALIZER_H_
+#define BACKEND_INVERSE_TEXT_NORMALIZER_H_
+
+#include <fst/compat.h>
+#include <fst/vector-fst.h>
+#include <fst/arc.h>
+#include <fst/fst.h>
+#include <fst/string.h>
+#include <fst/symbol-table.h>
+#include <thrax/compat/compat.h>
+#include <thrax/grm-manager.h>
+#include <thrax/algo/paths.h>
+#include <thrax/compat/utils.h>
+#include <thrax/symbols.h>
+
+#include <string>
+#include <vector>
+#include <utility>
+#include <memory>
+
+#include "utils/utils.h"
+
+enum ItnTokenType { SYMBOL = 1, BYTE = 2, UTF8 = 3 };
+
+namespace wenet {
+
+class InverseTextNormalizer {
+  typedef fst::StringCompiler<fst::StdArc> Compiler;
+
+ public:
+  InverseTextNormalizer() = default;
+
+  void Initialize(const std::string& far_path,
+                  const std::string& rules,
+                  const std::string& input_mode,
+                  const std::string& output_mode);
+  // Runs the input through the FSTs.
+  const string ProcessInput(const std::string& input);
+  // Init generated_symlab_ from fsts in grm_.
+  void GetGeneratedSymbolTable();
+  // Make sure ilabel and olabel are non-negative values.
+  void FormatFst(fst::StdVectorFst* vfst);
+  // Computes the n-shortest paths and returns a vector of strings, each string
+  // corresponding to each path. The mapping of labels to strings is controlled
+  // by the type and the symtab. Elements that are in the generated label set
+  // from the grammar are output as "[name]" where "name" is the name of the
+  // generated label. Paths are sorted in ascending order of weights.
+  bool FstToStrings(const fst::VectorFst<fst::StdArc>& vfst, const int& n,
+                    std::vector<std::pair<string, float> >* strings);
+  // Add label to path
+  bool AppendLabel(const fst::StdArc::Label& label, std::string* path);
+
+ private:
+  thrax::GrmManagerSpec<fst::StdArc> grm_;
+  ItnTokenType type_ = BYTE;
+  std::vector<string> rules_;
+  std::shared_ptr<Compiler> compiler_ = nullptr;
+  std::shared_ptr<fst::SymbolTable> generated_symtab_ = nullptr;
+  std::shared_ptr<fst::SymbolTable> output_symtab_ = nullptr;
+  std::shared_ptr<fst::SymbolTable> byte_symtab_ = nullptr;
+  std::shared_ptr<fst::SymbolTable> utf8_symtab_ = nullptr;
+  std::shared_ptr<fst::SymbolTable> input_symtab_ = nullptr;
+
+  WENET_DISALLOW_COPY_AND_ASSIGN(InverseTextNormalizer);
+};  // class InverseTextNormalizer
+
+}  // namespace wenet
+
+#endif  // BACKEND_INVERSE_TEXT_NORMALIZER_H_

--- a/runtime/core/backend/inverse_text_normalizer_test.cc
+++ b/runtime/core/backend/inverse_text_normalizer_test.cc
@@ -1,0 +1,295 @@
+// Copyright (c) 2021.
+// Author: sxc19@mails.tsinghua.edu.cn (Xingchen Song)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "backend/inverse_text_normalizer.h"
+#include "backend/params.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+TEST(InverseTextNormalizeTest, TestCases53) {
+  const std::string far_path =
+      "../fc_base/chinese_text_normalization-src/thrax/src/cn/itn.far";
+  std::unique_ptr<wenet::InverseTextNormalizer> model(
+      new wenet::InverseTextNormalizer());
+  model->Initialize(far_path, FLAGS_rules, FLAGS_input_mode, FLAGS_output_mode);
+  std::string text, result;
+
+  // case 1
+  text = "一";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "1");
+
+  // case 2
+  text = "二";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "2");
+
+  // case 3
+  text = "三";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "3");
+
+  // case 4
+  text = "四";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "4");
+
+  // case 5
+  text = "五";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "5");
+
+  // case 6
+  text = "六";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "6");
+
+  // case 7
+  text = "七";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "7");
+
+  // case 8
+  text = "八";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "8");
+
+  // case 9
+  text = "九";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "9");
+
+  // case 10
+  text = "十";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "10");
+
+  // case 11
+  text = "十九";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "19");
+
+  // case 12
+  text = "二十";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "20");
+
+  // case 13
+  text = "二十八";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "28");
+
+  // case 14
+  text = "三十";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "30");
+
+  // case 15
+  text = "三十七";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "37");
+
+  // case 16
+  text = "四十";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "40");
+
+  // case 17
+  text = "四十六";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "46");
+
+  // case 18
+  text = "五十";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "50");
+
+  // case 19
+  text = "五十五";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "55");
+
+  // case 20
+  text = "六十";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "60");
+
+  // case 21
+  text = "六十四";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "64");
+
+  // case 22
+  text = "七十";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "70");
+
+  // case 23
+  text = "七十三";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "73");
+
+  // case 24
+  text = "八十";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "80");
+
+  // case 25
+  text = "八十二";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "82");
+
+  // case 26
+  text = "九十";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "90");
+
+  // case 27
+  text = "九十一";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "91");
+
+  // case 28
+  text = "一百";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "100");
+
+  // case 29
+  text = "一百零一";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "101");
+
+  // case 30
+  text = "一百一";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "110");
+
+  // case 31
+  text = "一百一十二";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "112");
+
+  // case 32
+  text = "两百二";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "220");
+
+  // case 33
+  text = "二百二十三";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "223");
+
+  // case 34
+  text = "三百三";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "330");
+
+  // case 35
+  text = "三百三十四";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "334");
+
+  // case 36
+  text = "四百四";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "440");
+
+  // case 37
+  text = "四百四十五";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "445");
+
+  // case 38
+  text = "一千五百五";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "1550");
+
+  // case 39
+  text = "两千五百五十六";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "2556");
+
+  // case 40
+  text = "三千六百六";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "3660");
+
+  // case 41
+  text = "四千六百六十七";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "4667");
+
+  // case 42
+  text = "五千七百七";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "5770");
+
+  // case 43
+  text = "六千七百七十八";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "6778");
+
+  // case 44
+  text = "七千八百八";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "7880");
+
+  // case 45
+  text = "八千八百八十九";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "8889");
+
+  // case 46
+  text = "九千九百九";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "9990");
+
+  // case 47
+  text = "九千九百九十一";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "9991");
+
+  // case 48
+  text = "二零一九年九月十二日";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "2019年9月12日");
+
+  // case 49
+  text = "两千零五年八月五号";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "2005年8月5号");
+
+  // case 50
+  text = "八五年二月二十七日";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "85年2月27日");
+
+  // case 51
+  text = "公元一六三年";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "公元163年");
+
+  // case 52
+  text = "零六年一月二号";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "06年1月2号");
+
+  // case 53
+  text = "有百分之六十二的人认为";
+  result = model->ProcessInput(text);
+  EXPECT_EQ(result, "有62%的人认为");
+}
+

--- a/runtime/core/backend/inverse_text_normalizer_test.cc
+++ b/runtime/core/backend/inverse_text_normalizer_test.cc
@@ -20,8 +20,7 @@
 #include "gtest/gtest.h"
 
 TEST(InverseTextNormalizeTest, TestCases53) {
-  const std::string far_path =
-      "../fc_base/chinese_text_normalization-src/thrax/src/cn/itn.far";
+  const std::string far_path = "itn.far";
   std::unique_ptr<wenet::InverseTextNormalizer> model(
       new wenet::InverseTextNormalizer());
   model->Initialize(far_path, FLAGS_rules, FLAGS_input_mode, FLAGS_output_mode);

--- a/runtime/core/backend/params.h
+++ b/runtime/core/backend/params.h
@@ -1,0 +1,36 @@
+// Copyright 2021 Mobvoi Inc. All Rights Reserved.
+// Author: sxc19@mails.tsinghua.edu.cn (Xingchen Song)
+
+#ifndef BACKEND_PARAMS_H_
+#define BACKEND_PARAMS_H_
+
+#include <memory>
+
+#include "backend/inverse_text_normalizer.h"
+#include "utils/flags.h"
+
+// InverseTextNormalizer flags
+DEFINE_string(far, "", "Path to load FAR.");
+DEFINE_string(rules, "ITN", "Names of the rewrite rules.");
+DEFINE_string(input_mode, "byte", "Either \"byte\", \"utf8\", or the path to a "
+              "symbol table for input parsing.");
+DEFINE_string(output_mode, "byte", "Either \"byte\", \"utf8\", or the path to "
+              "a symbol table for input parsing.");
+DEFINE_string(outdir, "", "Path to export FAR. never used.");
+
+namespace wenet {
+
+std::shared_ptr<InverseTextNormalizer> InitInverseTextNormalizerFromFlags() {
+  auto model = std::make_shared<InverseTextNormalizer>();
+  if (FLAGS_far != "") {
+    model->Initialize(FLAGS_far, FLAGS_rules,
+                      FLAGS_input_mode, FLAGS_output_mode);
+  } else {
+    model = nullptr;
+  }
+  return model;
+}
+
+}  // namespace wenet
+
+#endif  // BACKEND_PARAMS_H_

--- a/runtime/core/bin/websocket_server_main.cc
+++ b/runtime/core/bin/websocket_server_main.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "decoder/params.h"
+#include "backend/params.h"
 #include "utils/log.h"
 #include "websocket/websocket_server.h"
 
@@ -27,9 +28,11 @@ int main(int argc, char *argv[]) {
   auto decode_config = wenet::InitDecodeOptionsFromFlags();
   auto feature_config = wenet::InitFeaturePipelineConfigFromFlags();
   auto fst = wenet::InitFstFromFlags();
+  auto inverse_text_normalizer = wenet::InitInverseTextNormalizerFromFlags();
 
   wenet::WebSocketServer server(FLAGS_port, feature_config, decode_config,
-                                symbol_table, model, fst);
+                                symbol_table, model,
+                                inverse_text_normalizer, fst);
   LOG(INFO) << "Listening at port " << FLAGS_port;
   server.Start();
   return 0;

--- a/runtime/core/websocket/websocket_server.h
+++ b/runtime/core/websocket/websocket_server.h
@@ -29,6 +29,7 @@
 #include "decoder/torch_asr_decoder.h"
 #include "decoder/torch_asr_model.h"
 #include "frontend/feature_pipeline.h"
+#include "backend/inverse_text_normalizer.h"
 #include "utils/log.h"
 
 namespace wenet {
@@ -46,6 +47,7 @@ class ConnectionHandler {
                     std::shared_ptr<DecodeOptions> decode_config,
                     std::shared_ptr<fst::SymbolTable> symbol_table,
                     std::shared_ptr<TorchAsrModel> model,
+                    std::shared_ptr<InverseTextNormalizer> inverse_tn,
                     std::shared_ptr<fst::Fst<fst::StdArc>> fst);
   void operator()();
 
@@ -68,6 +70,7 @@ class ConnectionHandler {
   std::shared_ptr<DecodeOptions> decode_config_;
   std::shared_ptr<fst::SymbolTable> symbol_table_;
   std::shared_ptr<TorchAsrModel> model_;
+  std::shared_ptr<InverseTextNormalizer> inverse_tn_;
   std::shared_ptr<fst::Fst<fst::StdArc>> fst_;
 
   bool got_start_tag_ = false;
@@ -86,12 +89,14 @@ class WebSocketServer {
                   std::shared_ptr<DecodeOptions> decode_config,
                   std::shared_ptr<fst::SymbolTable> symbol_table,
                   std::shared_ptr<TorchAsrModel> model,
+                  std::shared_ptr<InverseTextNormalizer> inverse_tn,
                   std::shared_ptr<fst::Fst<fst::StdArc>> fst)
       : port_(port),
         feature_config_(std::move(feature_config)),
         decode_config_(std::move(decode_config)),
         symbol_table_(std::move(symbol_table)),
         model_(std::move(model)),
+        inverse_tn_(std::move(inverse_tn)),
         fst_(std::move(fst)) {}
 
   void Start();
@@ -104,6 +109,7 @@ class WebSocketServer {
   std::shared_ptr<DecodeOptions> decode_config_;
   std::shared_ptr<fst::SymbolTable> symbol_table_;
   std::shared_ptr<TorchAsrModel> model_;
+  std::shared_ptr<InverseTextNormalizer> inverse_tn_;
   std::shared_ptr<fst::Fst<fst::StdArc>> fst_;
   WENET_DISALLOW_COPY_AND_ASSIGN(WebSocketServer);
 };

--- a/runtime/server/x86/CMakeLists.txt
+++ b/runtime/server/x86/CMakeLists.txt
@@ -93,7 +93,9 @@ if(NOT MSVC)
     URL_HASH          SHA256=b720357a464f42e181d7e33f60867b54044007f50baedc8f4458a3926f4a5a78
     SOURCE_DIR        ${openfst_SOURCE_DIR}
     BINARY_DIR        ${openfst_BINARY_DIR}
-    CONFIGURE_COMMAND ${openfst_SOURCE_DIR}/configure --prefix=${openfst_PREFIX_DIR}
+    # far, pdt and mpdt should be enabled for thrax
+    # details see https://stackoverflow.com/questions/29253913/error-while-instaling-open-grm-thrax
+    CONFIGURE_COMMAND ${openfst_SOURCE_DIR}/configure --prefix=${openfst_PREFIX_DIR} --enable-far --enable-pdt --enable-mpdt
                         "CPPFLAGS=-I${gflags_BINARY_DIR}/include -I${glog_SOURCE_DIR}/src -I${glog_BINARY_DIR}"
                         "LDFLAGS=-L${gflags_BINARY_DIR} -L${glog_BINARY_DIR}"
                         "LIBS=-lgflags_nothreads -lglog -lpthread"
@@ -122,12 +124,57 @@ else()
 endif()
 include_directories(${openfst_SOURCE_DIR}/src/include)
 
+# third_party: thrax 1.2.9 and chinese_text_normalization
+if(NOT MSVC)
+  # thrax
+  set(thrax_SOURCE_DIR ${fc_base}/thrax-src)
+  set(thrax_BINARY_DIR ${fc_base}/thrax-build)
+  ExternalProject_Add(thrax
+    URL               http://www.openfst.org/twiki/pub/GRM/ThraxDownload/thrax-1.2.9.tar.gz
+    URL_HASH          SHA256=3cfbc003609d208d50d98659166086d4a6dd341ce6697e16370f5f7ae414f2b0
+    SOURCE_DIR        ${thrax_SOURCE_DIR}
+    BINARY_DIR        ${thrax_BINARY_DIR}
+    CONFIGURE_COMMAND ${thrax_SOURCE_DIR}/configure
+                        "LDFLAGS=-L${gflags_BINARY_DIR} -L${glog_BINARY_DIR} -L${openfst_PREFIX_DIR}/lib"
+                        "CXXFLAGS=-I${gflags_BINARY_DIR}/include -I${glog_SOURCE_DIR}/src -I${glog_BINARY_DIR} -I${openfst_SOURCE_DIR}/src/include"
+                        "LIBS=-lgflags_nothreads -lglog -lpthread"
+    BUILD_COMMAND     make -j 4
+    INSTALL_COMMAND   ""
+  )
+  add_dependencies(thrax openfst)
+  target_link_libraries(utils PUBLIC ${thrax_BINARY_DIR}/src/lib/.libs/libthrax.a)
+  # chinese_text_normalization
+  set(chinese_text_normalization_SOURCE_DIR ${fc_base}/chinese_text_normalization-src)
+  ExternalProject_Add(chinese_text_normalization
+    GIT_REPOSITORY    https://github.com/speechio/chinese_text_normalization.git
+    GIT_TAG           9e92c7bf2d6b5a7974305406d8e240045beac51c
+    SOURCE_DIR        ${chinese_text_normalization_SOURCE_DIR}
+    BUILD_IN_SOURCE   1
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND     cd thrax/src/cn && PATH=${thrax_BINARY_DIR}/src/bin:/usr/bin make -j 4
+    INSTALL_COMMAND   ""
+  )
+  add_dependencies(chinese_text_normalization thrax)
+endif()
+include_directories(${thrax_SOURCE_DIR}/src/include)
+
 # frontend
 add_library(frontend STATIC
   frontend/feature_pipeline.cc
   frontend/fft.cc
 )
 target_link_libraries(frontend PUBLIC utils)
+
+if(NOT MSVC)
+  # backend
+  add_library(backend STATIC
+    backend/inverse_text_normalizer.cc
+  )
+  target_link_libraries(backend PUBLIC utils)
+  add_executable(inverse_text_normalizer_test backend/inverse_text_normalizer_test.cc)
+  target_link_libraries(inverse_text_normalizer_test PUBLIC backend gtest_main gmock)
+  add_test(INVERSE_TEXT_NORMALIZER_TEST inverse_text_normalizer_test)
+endif()
 
 # kaldi: wfst based decoder
 add_subdirectory(kaldi)
@@ -152,7 +199,9 @@ add_library(websocket STATIC
   websocket/websocket_server.cc
 )
 target_link_libraries(websocket PUBLIC decoder frontend)
-
+if(NOT MSVC)
+  target_link_libraries(websocket PUBLIC backend)
+endif()
 
 # binary
 add_executable(decoder_main bin/decoder_main.cc)

--- a/runtime/server/x86/CMakeLists.txt
+++ b/runtime/server/x86/CMakeLists.txt
@@ -124,7 +124,7 @@ else()
 endif()
 include_directories(${openfst_SOURCE_DIR}/src/include)
 
-# third_party: thrax 1.2.9 and chinese_text_normalization
+# third_party: thrax 1.2.9 and fst archive(far) for inverse_text_normalization
 if(NOT MSVC)
   # thrax
   set(thrax_SOURCE_DIR ${fc_base}/thrax-src)
@@ -143,6 +143,8 @@ if(NOT MSVC)
   )
   add_dependencies(thrax openfst)
   target_link_libraries(utils PUBLIC ${thrax_BINARY_DIR}/src/lib/.libs/libthrax.a)
+  # download pre-built fst_archive (far)
+  execute_process(COMMAND wget https://github.com.cnpmjs.org/xingchensong/FST_ARCHIVE_FOR_ITN/releases/download/2021.07.06/itn.far -O itn.far WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 include_directories(${thrax_SOURCE_DIR}/src/include)
 

--- a/runtime/server/x86/CMakeLists.txt
+++ b/runtime/server/x86/CMakeLists.txt
@@ -89,8 +89,8 @@ if(NOT MSVC)
   set(openfst_BINARY_DIR ${fc_base}/openfst-build)
   set(openfst_PREFIX_DIR ${fc_base}/openfst-subbuild/openfst-populate-prefix)
   ExternalProject_Add(openfst
-    URL               https://github.com/mjansche/openfst/archive/1.6.5.zip
-    URL_HASH          SHA256=b720357a464f42e181d7e33f60867b54044007f50baedc8f4458a3926f4a5a78
+    URL               https://github.com/mjansche/openfst/archive/1.6.7.zip
+    URL_HASH          SHA256=6ad450057ca4958de6c09358c66e2a137c5a1cbd2cb365b47866bf905fca72e2
     SOURCE_DIR        ${openfst_SOURCE_DIR}
     BINARY_DIR        ${openfst_BINARY_DIR}
     # far, pdt and mpdt should be enabled for thrax
@@ -143,18 +143,6 @@ if(NOT MSVC)
   )
   add_dependencies(thrax openfst)
   target_link_libraries(utils PUBLIC ${thrax_BINARY_DIR}/src/lib/.libs/libthrax.a)
-  # chinese_text_normalization
-  set(chinese_text_normalization_SOURCE_DIR ${fc_base}/chinese_text_normalization-src)
-  ExternalProject_Add(chinese_text_normalization
-    GIT_REPOSITORY    https://github.com/speechio/chinese_text_normalization.git
-    GIT_TAG           9e92c7bf2d6b5a7974305406d8e240045beac51c
-    SOURCE_DIR        ${chinese_text_normalization_SOURCE_DIR}
-    BUILD_IN_SOURCE   1
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND     cd thrax/src/cn && PATH=${thrax_BINARY_DIR}/src/bin:/usr/bin make -j 4
-    INSTALL_COMMAND   ""
-  )
-  add_dependencies(chinese_text_normalization thrax)
 endif()
 include_directories(${thrax_SOURCE_DIR}/src/include)
 
@@ -170,6 +158,7 @@ if(NOT MSVC)
   add_library(backend STATIC
     backend/inverse_text_normalizer.cc
   )
+  add_dependencies(backend thrax)
   target_link_libraries(backend PUBLIC utils)
   add_executable(inverse_text_normalizer_test backend/inverse_text_normalizer_test.cc)
   target_link_libraries(inverse_text_normalizer_test PUBLIC backend gtest_main gmock)

--- a/runtime/server/x86/backend
+++ b/runtime/server/x86/backend
@@ -1,0 +1,1 @@
+../../core/backend


### PR DESCRIPTION
Hi, inverse text normalization (i.e. from "有百分之六十二的人认为" to "有62%的人认为") helps improve readability of ASR result. As far as I know, Google use thrax to do both TN and  ITN, since thrax only supports command-line usage, we need some modifications to provide C++ interface which can be directly intergrated into wenet and that is what this PR has done.

Typically, thrax runtime needs a grammar model (FST) to translate input text. Thanks to [jiayu](https://github.com/dophist)'s ITN grammar (see [speechio/chinese_text_normalization](https://github.com/speechio/chinese_text_normalization)), we can now get all required resources to do ITN in wenet.

Some descriptions:

- Directory structure change
   - I add a new dir `backend` in `runtime/server/x86`, it is the opposite of `frontend`, all post-processing  related modules can be put in this dir, such as `rule-based punctuation`(I don’t want to introduce the NN model because it requires changes to the training code(*.py), rule-based model is sufficient and fast), `inverse text normalization`...
- Profile
   -  time cost of processing 20 Chinese characters : 0~1ms 
- Compilation steps
   -  compile openfst (thrax depends on it)
   -  compile thrax
   -  download itn_fst_archive, which is pre-built using jiayu's grammar (see *.grm in [this link](https://github.com/speechio/chinese_text_normalization/tree/master/thrax/src/cn)).
- Tested OS
   -  Ubuntu20.04 (both gcc 5.4 & gcc 9.3) MacOS(clang version 12.0.5)
   -  Sorry, Im not familiar with building cxx projects on windows

Since ITN is a typical "done is better than perfect" module in context of ASR, I will close this PR and leave it as a reference if it is not going to be merged.