### PR TITLE
Update to sox_io backend and replace deprecated load_wav

### DIFF
--- a/tools/compute_cmvn_stats.py
+++ b/tools/compute_cmvn_stats.py
@@ -11,7 +11,7 @@ import torch
 import torchaudio
 import torchaudio.compliance.kaldi as kaldi
 from torch.utils.data import Dataset, DataLoader
-torchaudio.set_audio_backend("sox")
+torchaudio.set_audio_backend("sox_io")
 
 
 class CollateFunc(object):
@@ -29,19 +29,21 @@ class CollateFunc(object):
             value = item[1].strip().split(",")
             assert len(value) == 3 or len(value) == 1
             wav_path = value[0]
-            sample_rate = torchaudio.backend.sox_backend.info(wav_path)[0].rate
+            sample_rate = torchaudio.backend.sox_io_backend.info(wav_path).sample_rate
             # len(value) == 3 means segmented wav.scp,
             # len(value) == 1 means original wa.scp
             if len(value) == 3:
                 start_frame = int(float(value[1]) * sample_rate)
                 end_frame = int(float(value[2]) * sample_rate)
-                waveform, sample_rate = torchaudio.backend.sox_backend.load(
+                waveform, sample_rate = torchaudio.backend.sox_io_backend.load(
                     filepath=wav_path,
                     num_frames=end_frame - start_frame,
                     offset=start_frame)
-                waveform = waveform * (1 << 15)
             else:
-                waveform, sample_rate = torchaudio.load_wav(item[1])
+                waveform, sample_rate = torchaudio.load(item[1])
+
+            waveform = waveform * (1 << 15)
+
             mat = kaldi.fbank(waveform,
                               num_mel_bins=self.feat_dim,
                               dither=0.0,

--- a/tools/wav2dur.py
+++ b/tools/wav2dur.py
@@ -4,7 +4,7 @@
 import sys
 
 import torchaudio
-torchaudio.set_audio_backend("sox")
+torchaudio.set_audio_backend("sox_io")
 
 scp = sys.argv[1]
 dur_scp = sys.argv[2]
@@ -17,7 +17,7 @@ with open(scp, 'r') as f, open(dur_scp, 'w') as fout:
         wav_id = items[0]
         fname = items[1]
         cnt += 1
-        waveform, rate = torchaudio.load_wav(fname)
+        waveform, rate = torchaudio.load(fname)
         frames = len(waveform[0])
         duration = frames / float(rate)
         total_duration += duration

--- a/wenet/dataset/dataset.py
+++ b/wenet/dataset/dataset.py
@@ -33,7 +33,7 @@ from torch.utils.data import Dataset, DataLoader
 import wenet.dataset.kaldi_io as kaldi_io
 from wenet.dataset.wav_distortion import distort_wav_conf
 from wenet.utils.common import IGNORE_ID
-torchaudio.set_audio_backend("sox")
+torchaudio.set_audio_backend("sox_io")
 
 
 def _spec_augmentation(x,
@@ -147,7 +147,7 @@ def _load_wav_with_speed(wav_file, speed):
         augmented feature
     """
     if speed == 1.0:
-        return torchaudio.load_wav(wav_file)
+        wav, sr = torchaudio.load(wav_file)
     else:
         si, _ = torchaudio.info(wav_file)
 
@@ -168,9 +168,9 @@ def _load_wav_with_speed(wav_file, speed):
                 wav_file,
                 [['speed', str(speed)], ['rate', str(si.rate)]])
 
-        # sox will normalize the waveform, scale to [-32768, 32767]
-        wav = wav * (1 << 15)
-        return wav, sr
+    # sox will normalize the waveform, scale to [-32768, 32767]
+    wav = wav * (1 << 15)
+    return wav, sr
 
 
 def _extract_feature(batch, speed_perturb, wav_distortion_conf,
@@ -206,7 +206,7 @@ def _extract_feature(batch, speed_perturb, wav_distortion_conf,
             # 1 for general wav.scp, 3 for segmented wav.scp
             assert len(value) == 1 or len(value) == 3
             wav_path = value[0]
-            sample_rate = torchaudio.backend.sox_backend.info(wav_path)[0].rate
+            sample_rate = torchaudio.backend.sox_io_backend.info(wav_path).sample_rate
             if speed_perturb:
                 if len(value) == 3:
                     logging.error(
@@ -219,13 +219,14 @@ def _extract_feature(batch, speed_perturb, wav_distortion_conf,
                 if len(value) == 3:
                     start_frame = int(float(value[1]) * sample_rate)
                     end_frame = int(float(value[2]) * sample_rate)
-                    waveform, sample_rate = torchaudio.backend.sox_backend.load(
+                    waveform, sample_rate = torchaudio.backend.sox_io_backend.load(
                         filepath=wav_path,
                         num_frames=end_frame - start_frame,
                         offset=start_frame)
-                    waveform = waveform * (1 << 15)
                 else:
-                    waveform, sample_rate = torchaudio.load_wav(wav_path)
+                    waveform, sample_rate = torchaudio.load(wav_path)
+                waveform = waveform * (1 << 15)
+
             if wav_distortion_rate > 0.0:
                 r = random.uniform(0, 1)
                 if r < wav_distortion_rate:

--- a/wenet/dataset/wav_distortion.py
+++ b/wenet/dataset/wav_distortion.py
@@ -4,7 +4,7 @@ import math
 
 import torchaudio
 import torch
-torchaudio.set_audio_backend("sox")
+torchaudio.set_audio_backend("sox_io")
 
 
 def db2amp(db):


### PR DESCRIPTION
sox backend is removed in torchaudio 0.9.0
