### PR TITLE
fix bash syntax & update multi_cn clean text

### DIFF
--- a/examples/multi_cn/s0/run.sh
+++ b/examples/multi_cn/s0/run.sh
@@ -136,16 +136,16 @@ if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
     for x in train dev; do
         cp ${feat_dir}_${en_modeling_unit}/${x}/text ${feat_dir}_${en_modeling_unit}/${x}/text.org
         paste -d " " <(cut -f 1 -d" " ${feat_dir}_${en_modeling_unit}/${x}/text.org) <(cut -f 2- -d" " ${feat_dir}_${en_modeling_unit}/${x}/text.org \
-            | tr 'a-z' 'A-Z' | sed 's/\([A-Z]\) \([A-Z]\)/\1▁\2/g' | tr -d " " ) \
+            | tr 'a-z' 'A-Z' | sed 's/\([A-Z]\) \([A-Z]\)/\1▁\2/g' | sed 's/\([A-Z]\) \([A-Z]\)/\1▁\2/g' | tr -d " ") \
             > ${feat_dir}_${en_modeling_unit}/${x}/text
-    sed -i 's/\xEF\xBB\xBF//' ${feat_dir}_${en_modeling_unit}/${x}/text
+        sed -i 's/\xEF\xBB\xBF//' ${feat_dir}_${en_modeling_unit}/${x}/text
 
     done
 
     for x in ${test_sets}; do
         cp ${feat_dir}_${en_modeling_unit}/test_${x}/text ${feat_dir}_${en_modeling_unit}/test_${x}/text.org
         paste -d " " <(cut -f 1 -d" " ${feat_dir}_${en_modeling_unit}/test_${x}/text.org) <(cut -f 2- -d" " ${feat_dir}_${en_modeling_unit}/test_${x}/text.org \
-        | sed 's/\([A-Z]\) \([A-Z]\)/\1▁\2/g' | tr -d " " |  tr 'a-z' 'A-Z') \
+            | tr 'a-z' 'A-Z' | sed 's/\([A-Z]\) \([A-Z]\)/\1▁\2/g' | sed 's/\([A-Z]\) \([A-Z]\)/\1▁\2/g' | tr -d " ") \
             > ${feat_dir}_${en_modeling_unit}/test_${x}/text
         sed -i 's/\xEF\xBB\xBF//' ${feat_dir}_${en_modeling_unit}/test_${x}/text
     done

--- a/examples/multi_cn/s0/run.sh
+++ b/examples/multi_cn/s0/run.sh
@@ -293,11 +293,11 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
                 --ctc_weight $ctc_weight \
                 --result_file $test_dir/text_${en_modeling_unit} \
                 ${decoding_chunk_size:+--decoding_chunk_size $decoding_chunk_size}
-            if $en_modeling_unit = "bpe"; then
-               tools/spm_decode --model=${bpemodel}.model --input_format=piece < $test_dir/text_${en_modeling_unit} | sed -e "s/▁/ /g" > $test_dir/text
-            else
-                cat $test_dir/text_${en_modeling_unit} | sed -e "s/▁/ /g" > $test_dir/text
-            fi
+            #if $en_modeling_unit = "bpe"; then
+            #   tools/spm_decode --model=${bpemodel}.model --input_format=piece < $test_dir/text_${en_modeling_unit} | sed -e "s/▁/ /g" > $test_dir/text
+            #else
+            cat $test_dir/text_${en_modeling_unit} | sed -e "s/▁/ /g" > $test_dir/text
+            #fi
             cat ${feat_dir}_${en_modeling_unit}/test_${x}/text | sed -e "s/▁/ /g" > ${feat_dir}_${en_modeling_unit}/test_${x}/text.tmp
             python tools/compute-wer.py --char=1 --v=1 \
                 ${feat_dir}_${en_modeling_unit}/test_${x}/text.tmp $test_dir/text > $test_dir/wer


### PR DESCRIPTION
We need use `sed 's/\([A-Z]\) \([A-Z]\)/\1▁\2/g'` twice . 
eg: a="哈哈 A B C D"
`echo $a | sed 's/\([A-Z]\) \([A-Z]\)/\1▁\2/g'` -> output: `哈哈 A▁B C▁D`
`echo $a | sed 's/\([A-Z]\) \([A-Z]\)/\1▁\2/g'| sed 's/\([A-Z]\) \([A-Z]\)/\1▁\2/g'` -> output: `哈哈 A▁B▁C▁D`

`if $en_modeling_unit = "bpe"` is not bash syntax and we don't need spm_decode here.