### PR TITLE
add onnx export for offline model

### DIFF
--- a/examples/aishell2/s0/run_onnx.sh
+++ b/examples/aishell2/s0/run_onnx.sh
@@ -1,0 +1,67 @@
+
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+stage=0
+stop_stage=1
+
+# test_feat_dir will be generated in preprocessing step
+# please refer to run.sh
+test_feat_dir=raw_wav/test
+
+# dir is model directory, which can be
+# downloaded from https://github.com/wenet-e2e/wenet/tree/main/examples/aishell2/s0
+# if you don't have one
+# Please edit ctc weight, reverse weight, global_cmvn path in config.yaml or train.yaml
+
+dir=20210618_u2pp_conformer_exp
+beam_size=10
+decode_modes="ctc_prefix_beam_search attention_rescoring"
+dict=$dir/words.txt
+
+. tools/parse_options.sh || exit 1;
+
+if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
+        python3 -c 'import onnxruntime' || exit 1;
+        echo "export to offline onnx"
+        python3 wenet/bin/export_onnx.py --config $dir/train.yaml \
+            --checkpoint $dir/final.pt \
+            --beam_size $beam_size \
+            --output_onnx_directory $dir
+fi
+
+if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
+    # check if ctc prefix beam search decoder is installed
+    python3 -c 'import swig_decoders' || exit 1;
+
+    echo "infer offline onnx"
+    for mode in ${decode_modes}; do
+    {
+        test_dir=$dir/test_${mode}
+        mkdir -p $test_dir
+        python wenet/bin/recognize_onnx.py --gpu 0 \
+            --mode $mode \
+            --config $dir/train.yaml \
+            --encoder_onnx $dir/encoder.onnx \
+            --decoder_onnx $dir/decoder.onnx \
+            --test_data $test_feat_dir/format.data \
+            --batch_size 20 \
+            --dict $dict \
+            --result_file $test_dir/text
+        python tools/compute-wer.py --char=1 --v=1 \
+            $test_feat_dir/text $test_dir/text > $test_dir/wer
+    } &
+    done
+    wait
+fi

--- a/tools/swig_decoder/README.md
+++ b/tools/swig_decoder/README.md
@@ -1,0 +1,11 @@
+## Installation
+
+We adapted this ctc decoder from [here](https://github.com/PaddlePaddle/DeepSpeech/tree/develop/deepspeech/decoders/swig).
+
+To install the decoder:
+```bash
+apt-get update
+apt-get install swig
+apt-get install python3-dev 
+bash setup.sh
+```

--- a/tools/swig_decoder/ctc_beam_search_decoder.cpp
+++ b/tools/swig_decoder/ctc_beam_search_decoder.cpp
@@ -1,0 +1,233 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <algorithm>
+#include <cmath>
+#include <future>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <utility>
+#include "ThreadPool/ThreadPool.h"
+#include "ctc_beam_search_decoder.h"
+#include "decoder_utils.h"
+#include "fst/fstlib.h"
+#include "path_trie.h"
+
+using FSTMATCH = fst::SortedMatcher<fst::StdVectorFst>;
+std::vector<std::pair<double, std::vector<int>>> ctc_beam_search_decoder(
+    const std::vector<std::vector<double>> &log_probs_seq,
+    const std::vector<std::vector<int>> &log_probs_idx, PathTrie &root,
+    const bool start, size_t beam_size, int blank_id, int space_id,
+    double cutoff_prob, Scorer *ext_scorer) {
+  if (start) {
+    if (ext_scorer != nullptr && !ext_scorer->is_character_based()) {
+      auto fst_dict = static_cast<fst::StdVectorFst *>(ext_scorer->dictionary);
+      fst::StdVectorFst *dict_ptr = fst_dict->Copy(true);
+      root.set_dictionary(dict_ptr);
+      auto matcher = std::make_shared<FSTMATCH>(*dict_ptr, fst::MATCH_INPUT);
+      root.set_matcher(matcher);
+    }
+  }
+  int timesteps = log_probs_seq.size();
+
+  std::vector<PathTrie *> prefixes;
+
+  // update log probs
+  if (root.log_prob_b_prev == -NUM_FLT_INF && start) {
+    root.score = root.log_prob_b_prev = 0.0;
+  }
+  root.iterate_to_vec_only(prefixes);
+  int prev_id = -1;
+  // prefix search over time
+  for (size_t time_step = 0; time_step < timesteps; ++time_step) {
+    float min_cutoff = -NUM_FLT_INF;
+    bool full_beam = false;
+
+    auto &log_prob = log_probs_seq[time_step];
+    auto &log_prob_idx = log_probs_idx[time_step];
+
+    double top_prob = exp(log_prob[0]);
+    auto top_id = log_prob_idx[0];
+    if (top_prob >= cutoff_prob && top_id == blank_id) {
+      if (prev_id == blank_id)
+        continue;  // skip this round
+      else
+        prev_id = top_id;
+    } else {
+      prev_id = -1;
+    }
+    // loop over chars
+    double cur_acc_prob = 0.0;
+    for (size_t index = 0; index < log_prob.size(); index++) {
+      auto c = log_prob_idx[index];
+      float log_prob_c = log_prob[index];
+      cur_acc_prob += exp(log_prob_c);
+      if (cur_acc_prob > cutoff_prob && index >= 1) break;
+      for (size_t i = 0; i < prefixes.size() && i < beam_size; ++i) {
+        auto prefix = prefixes[i];
+        if (full_beam && log_prob_c + prefix->score < min_cutoff) {
+          break;
+        }
+        // blank
+        if (c == blank_id) {
+          prefix->log_prob_b_cur =
+              log_sum_exp(prefix->log_prob_b_cur, log_prob_c + prefix->score);
+          continue;
+        }
+        // repeated character
+        if (c == prefix->character) {
+          prefix->log_prob_nb_cur = log_sum_exp(
+              prefix->log_prob_nb_cur, log_prob_c + prefix->log_prob_nb_prev);
+        }
+        // get new prefix
+        auto prefix_new = prefix->get_path_trie(c);
+        if (prefix_new != nullptr) {
+          float log_p = -NUM_FLT_INF;
+
+          if (c == prefix->character &&
+              prefix->log_prob_b_prev > -NUM_FLT_INF) {
+            log_p = log_prob_c + prefix->log_prob_b_prev;
+          } else if (c != prefix->character) {
+            log_p = log_prob_c + prefix->score;
+          }
+
+          // language model scoring
+          if (ext_scorer != nullptr &&
+              (c == space_id || ext_scorer->is_character_based())) {
+            PathTrie *prefix_to_score = nullptr;
+            // skip scoring the space
+            if (ext_scorer->is_character_based()) {
+              prefix_to_score = prefix_new;
+            } else {
+              prefix_to_score = prefix;
+            }
+            float score = 0.0;
+            std::vector<std::string> ngram;
+            ngram = ext_scorer->make_ngram(prefix_to_score);
+            score = ext_scorer->get_log_cond_prob(ngram) * ext_scorer->alpha;
+            log_p += score;
+            log_p += ext_scorer->beta;
+          }
+
+          prefix_new->log_prob_nb_cur =
+              log_sum_exp(prefix_new->log_prob_nb_cur, log_p);
+        }
+      }  // end of loop over prefix
+    }    // end of loop over vocabulary
+    prefixes.clear();
+    // update log probs
+    root.iterate_to_vec(prefixes);
+    // only preserve top beam_size prefixes
+    if (prefixes.size() >= beam_size) {
+      std::nth_element(prefixes.begin(), prefixes.begin() + beam_size,
+                       prefixes.end(), prefix_compare);
+      for (size_t i = beam_size; i < prefixes.size(); ++i) {
+        prefixes[i]->remove();
+      }
+    }
+  }  // end of loop over time
+  size_t num_prefixes = std::min(prefixes.size(), beam_size);
+  std::sort(prefixes.begin(), prefixes.begin() + num_prefixes, prefix_compare);
+  return get_beam_search_result(prefixes, beam_size);
+}
+
+std::string map_sent(const std::vector<int> &sent,
+                     const std::vector<std::string> &vocabulary, bool greedy,
+                     int blank_id) {
+  std::string output_str;
+
+  if (!greedy) {
+    for (size_t j = 0; j < sent.size(); j++) {
+      output_str += vocabulary[sent[j]];
+    }
+  } else {
+    // greedy search
+    int prev = -1;
+    for (size_t i = 0; i < sent.size(); i++) {
+      int cur = sent[i];
+      if (cur != prev && cur != blank_id) output_str += vocabulary[cur];
+      prev = cur;
+    }
+  }
+  return output_str;
+}
+
+std::vector<std::string> map_batch(
+    const std::vector<std::vector<int>> &batch_sents,
+    const std::vector<std::string> &vocabulary, size_t num_processes,
+    bool greedy, int blank_id) {
+  ThreadPool pool(num_processes);
+  size_t batch_size = batch_sents.size();
+  std::vector<std::future<std::string>> res;
+  for (size_t i = 0; i < batch_size; ++i) {
+    res.emplace_back(pool.enqueue(map_sent, std::ref(batch_sents[i]),
+                                  vocabulary, greedy, blank_id));
+  }
+  // get decoding results
+  std::vector<std::string> batch_results;
+  for (size_t i = 0; i < batch_size; ++i) {
+    batch_results.emplace_back(res[i].get());
+  }
+  return batch_results;
+}
+
+std::vector<std::vector<std::pair<double, std::vector<int>>>>
+ctc_beam_search_decoder_batch(
+    const std::vector<std::vector<std::vector<double>>> &batch_log_probs_seq,
+    const std::vector<std::vector<std::vector<int>>> &batch_log_probs_idx,
+    std::vector<PathTrie *> &batch_root_trie,
+    const std::vector<bool> &batch_start, size_t beam_size,
+    size_t num_processes, int blank_id, int space_id, double cutoff_prob,
+    Scorer *ext_scorer) {
+  // thread pool
+  ThreadPool pool(num_processes);
+  // number of samples
+  size_t batch_size = batch_log_probs_seq.size();
+
+  // enqueue the tasks of decoding
+
+  std::vector<std::future<std::vector<std::pair<double, std::vector<int>>>>>
+      res;
+
+  for (size_t i = 0; i < batch_size; ++i) {
+    res.emplace_back(
+        pool.enqueue(ctc_beam_search_decoder, std::ref(batch_log_probs_seq[i]),
+                     std::ref(batch_log_probs_idx[i]),
+                     std::ref(*batch_root_trie[i]), batch_start[i], beam_size,
+                     blank_id, space_id, cutoff_prob, ext_scorer));
+  }
+
+  // get decoding results
+  std::vector<std::vector<std::pair<double, std::vector<int>>>> batch_results;
+  for (size_t i = 0; i < batch_size; ++i) {
+    batch_results.emplace_back(res[i].get());
+  }
+  return batch_results;
+}

--- a/tools/swig_decoder/ctc_beam_search_decoder.h
+++ b/tools/swig_decoder/ctc_beam_search_decoder.h
@@ -1,0 +1,126 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CTC_BEAM_SEARCH_DECODER_H_
+#define CTC_BEAM_SEARCH_DECODER_H_
+
+#include <string>
+#include <utility>
+#include <vector>
+#include "path_trie.h"
+#include "scorer.h"
+
+/* CTC Beam Search Decoder
+
+ * Parameters:
+ *     log_probs_seq: 2-D vector that each element is a vector of log
+ probabilities
+ *                    for one time step, it is sorted   (topk)
+ *     log_probs_idx: 2-D vector that the index of every element in
+ log_probs_seq
+ *                     topk index
+ *     root: A PathTrie root
+ *     start: whether this the first chunk of this sequence
+ *     beam_size: The width of beam search.
+ *     blank_id: default is 0
+ *     space_id: default is -1
+ *     cutoff_prob: Cutoff probability for pruning.
+ *     ext_scorer: External scorer to evaluate a prefix, which consists of
+ *                 n-gram language model scoring and word insertion term.
+ *                 Default null, decoding the input sample without scorer.
+ * Return:
+ *     A vector that each element is a pair of score  and decoding result,
+ *     in desending order.
+*/
+std::vector<std::pair<double, std::vector<int>>> ctc_beam_search_decoder(
+    const std::vector<std::vector<double>> &log_probs_seq,
+    const std::vector<std::vector<int>> &log_probs_idx, PathTrie &root,
+    const bool start, size_t beam_size, int blank_id = 0, int space_id = -1,
+    double cutoff_prob = 0.999, Scorer *ext_scorer = nullptr);
+
+/* CTC Beam Search Decoder for batch data
+
+ * Parameters:
+ *     batch_log_probs_seq: 3-D vector that each element is a 2-D vector that
+ can be used
+ *                by ctc_beam_search_decoder().
+ *     batch_log_probs_idx: 3-D vector that each element is a 2-D vector that
+ can be used
+ *                by ctc_beam_search_decoder().
+ *     batch_root_trie: a batch of Path trie for each sequence
+ *     batch_start: a batch of boolean value to indicate whether this is the
+ first
+ *                  chunk of each sequence
+ *     beam_size: The width of beam search.
+ *     num_processes: Number of threads for beam search.
+ *     blank_id: default blank_id is 0
+ *     space_id: default space_id is -1, this is for word based scorer
+ *     cutoff_prob: Cutoff probability for pruning.
+ *     ext_scorer: External scorer to evaluate a prefix, which consists of
+ *                 n-gram language model scoring and word insertion term.
+ *                 Default null, decoding the input sample without scorer.
+ * Return:
+ *     A 2-D vector that each element is a vector of beam search decoding
+ *     result for one audio sample.
+*/
+std::vector<std::vector<std::pair<double, std::vector<int>>>>
+ctc_beam_search_decoder_batch(
+    const std::vector<std::vector<std::vector<double>>> &batch_log_probs_seq,
+    const std::vector<std::vector<std::vector<int>>> &batch_log_probs_idx,
+    std::vector<PathTrie *> &batch_root_trie,
+    const std::vector<bool> &batch_start, size_t beam_size,
+    size_t num_processes, int blank_id = 0, int space_id = -1,
+    double cutoff_prob = 0.999, Scorer *ext_scorer = nullptr);
+
+/* Map vector of int to string
+
+ * Parameters:
+ *   sent: a vector of int ids
+ *   vocabulary: vocabulary
+ * Return:
+ *   A decoded string
+*/
+std::string map_sent(const std::vector<int> &sent,
+                     const std::vector<std::string> &vocabulary,
+                     bool greedy = false, int blank_id = 0);
+
+/* Map batch vector of int to string
+
+ * Parameters:
+ *   batch_sents: a batch of vector of int ids
+ *   vocabulary: vocabulary
+ *   num_processes: number of processes to use
+ * Return:
+ *   A vector decoded string
+*/
+std::vector<std::string> map_batch(
+    const std::vector<std::vector<int>> &batch_sents,
+    const std::vector<std::string> &vocabulary, size_t num_processes,
+    bool greedy = false, int blank_id = 0);
+
+#endif  // CTC_BEAM_SEARCH_DECODER_H_

--- a/tools/swig_decoder/decoder_utils.cpp
+++ b/tools/swig_decoder/decoder_utils.cpp
@@ -1,0 +1,183 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "decoder_utils.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+std::vector<std::pair<size_t, float>> get_pruned_log_probs(
+    const std::vector<double> &prob_step, double cutoff_prob,
+    size_t cutoff_top_n) {
+  std::vector<std::pair<int, double>> prob_idx;
+  for (size_t i = 0; i < prob_step.size(); ++i) {
+    prob_idx.push_back(std::pair<int, double>(i, prob_step[i]));
+  }
+  // pruning of vacobulary
+  size_t cutoff_len = prob_step.size();
+  if (cutoff_prob < 1.0 || cutoff_top_n < cutoff_len) {
+    std::sort(prob_idx.begin(), prob_idx.end(),
+              pair_comp_second_rev<int, double>);
+    if (cutoff_prob < 1.0) {
+      double cum_prob = 0.0;
+      cutoff_len = 0;
+      for (size_t i = 0; i < prob_idx.size(); ++i) {
+        cum_prob += prob_idx[i].second;
+        cutoff_len += 1;
+        if (cum_prob >= cutoff_prob || cutoff_len >= cutoff_top_n) break;
+      }
+    }
+    prob_idx = std::vector<std::pair<int, double>>(
+        prob_idx.begin(), prob_idx.begin() + cutoff_len);
+  }
+  std::vector<std::pair<size_t, float>> log_prob_idx;
+  for (size_t i = 0; i < cutoff_len; ++i) {
+    log_prob_idx.push_back(std::pair<int, float>(
+        prob_idx[i].first, log(prob_idx[i].second + NUM_FLT_MIN)));
+  }
+  return log_prob_idx;
+}
+
+std::vector<std::pair<double, std::vector<int>>> get_beam_search_result(
+    const std::vector<PathTrie *> &prefixes, size_t beam_size) {
+  // allow for the post processing
+  std::vector<PathTrie *> space_prefixes;
+  if (space_prefixes.empty()) {
+    for (size_t i = 0; i < beam_size && i < prefixes.size(); ++i) {
+      space_prefixes.push_back(prefixes[i]);
+    }
+  }
+
+  std::sort(space_prefixes.begin(), space_prefixes.end(), prefix_compare);
+  std::vector<std::pair<double, std::vector<int>>> output_vecs;
+  for (size_t i = 0; i < beam_size && i < space_prefixes.size(); ++i) {
+    std::vector<int> output;
+    space_prefixes[i]->get_path_vec(output);
+    // convert index to string
+
+    std::pair<double, std::vector<int>> output_pair(space_prefixes[i]->score,
+                                                    output);
+    output_vecs.emplace_back(output_pair);
+  }
+  return output_vecs;
+}
+
+size_t get_utf8_str_len(const std::string &str) {
+  size_t str_len = 0;
+  for (char c : str) {
+    str_len += ((c & 0xc0) != 0x80);
+  }
+  return str_len;
+}
+
+std::vector<std::string> split_utf8_str(const std::string &str) {
+  std::vector<std::string> result;
+  std::string out_str;
+
+  for (char c : str) {
+    if ((c & 0xc0) != 0x80)  // new UTF-8 character
+    {
+      if (!out_str.empty()) {
+        result.push_back(out_str);
+        out_str.clear();
+      }
+    }
+
+    out_str.append(1, c);
+  }
+  result.push_back(out_str);
+  return result;
+}
+
+std::vector<std::string> split_str(const std::string &s,
+                                   const std::string &delim) {
+  std::vector<std::string> result;
+  std::size_t start = 0, delim_len = delim.size();
+  while (true) {
+    std::size_t end = s.find(delim, start);
+    if (end == std::string::npos) {
+      if (start < s.size()) {
+        result.push_back(s.substr(start));
+      }
+      break;
+    }
+    if (end > start) {
+      result.push_back(s.substr(start, end - start));
+    }
+    start = end + delim_len;
+  }
+  return result;
+}
+
+bool prefix_compare(const PathTrie *x, const PathTrie *y) {
+  if (x->score == y->score) {
+    if (x->character == y->character) {
+      return false;
+    } else {
+      return (x->character < y->character);
+    }
+  } else {
+    return x->score > y->score;
+  }
+}
+
+void add_word_to_fst(const std::vector<int> &word,
+                     fst::StdVectorFst *dictionary) {
+  if (dictionary->NumStates() == 0) {
+    fst::StdVectorFst::StateId start = dictionary->AddState();
+    assert(start == 0);
+    dictionary->SetStart(start);
+  }
+  fst::StdVectorFst::StateId src = dictionary->Start();
+  fst::StdVectorFst::StateId dst;
+  for (auto c : word) {
+    dst = dictionary->AddState();
+    dictionary->AddArc(src, fst::StdArc(c, c, 0, dst));
+    src = dst;
+  }
+  dictionary->SetFinal(dst, fst::StdArc::Weight::One());
+}
+
+bool add_word_to_dictionary(
+    const std::string &word,
+    const std::unordered_map<std::string, int> &char_map, bool add_space,
+    int SPACE_ID, fst::StdVectorFst *dictionary) {
+  auto characters = split_utf8_str(word);
+
+  std::vector<int> int_word;
+
+  for (auto &c : characters) {
+    if (c == " ") {
+      int_word.push_back(SPACE_ID);
+    } else {
+      auto int_c = char_map.find(c);
+      if (int_c != char_map.end()) {
+        int_word.push_back(int_c->second);
+      } else {
+        return false;  // return without adding
+      }
+    }
+  }
+
+  if (add_space) {
+    int_word.push_back(SPACE_ID);
+  }
+
+  add_word_to_fst(int_word, dictionary);
+  return true;  // return with successful adding
+}

--- a/tools/swig_decoder/decoder_utils.h
+++ b/tools/swig_decoder/decoder_utils.h
@@ -1,0 +1,106 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DECODER_UTILS_H_
+#define DECODER_UTILS_H_
+
+#include <utility>
+#include "fst/log.h"
+#include "path_trie.h"
+
+const float NUM_FLT_INF = std::numeric_limits<float>::max();
+const float NUM_FLT_MIN = std::numeric_limits<float>::min();
+
+// inline function for validation check
+inline void check(bool x, const char *expr, const char *file, int line,
+                  const char *err) {
+  if (!x) {
+    std::cout << "[" << file << ":" << line << "] ";
+    LOG(FATAL) << "\"" << expr << "\" check failed. " << err;
+  }
+}
+
+#define VALID_CHECK(x, info) \
+  check(static_cast<bool>(x), #x, __FILE__, __LINE__, info)
+#define VALID_CHECK_EQ(x, y, info) VALID_CHECK((x) == (y), info)
+#define VALID_CHECK_GT(x, y, info) VALID_CHECK((x) > (y), info)
+#define VALID_CHECK_LT(x, y, info) VALID_CHECK((x) < (y), info)
+
+// Function template for comparing two pairs
+template <typename T1, typename T2>
+bool pair_comp_first_rev(const std::pair<T1, T2> &a,
+                         const std::pair<T1, T2> &b) {
+  return a.first > b.first;
+}
+
+// Function template for comparing two pairs
+template <typename T1, typename T2>
+bool pair_comp_second_rev(const std::pair<T1, T2> &a,
+                          const std::pair<T1, T2> &b) {
+  return a.second > b.second;
+}
+
+// Return the sum of two probabilities in log scale
+template <typename T>
+T log_sum_exp(const T &x, const T &y) {
+  static T num_min = -std::numeric_limits<T>::max();
+  if (x <= num_min) return y;
+  if (y <= num_min) return x;
+  T xmax = std::max(x, y);
+  return std::log(std::exp(x - xmax) + std::exp(y - xmax)) + xmax;
+}
+
+// Get pruned probability vector for each time step's beam search
+std::vector<std::pair<size_t, float>> get_pruned_log_probs(
+    const std::vector<double> &prob_step, double cutoff_prob,
+    size_t cutoff_top_n);
+
+// Get beam search result from prefixes in trie tree
+std::vector<std::pair<double, std::string>> get_beam_search_result(
+    const std::vector<PathTrie *> &prefixes,
+    const std::vector<std::string> &vocabulary, size_t beam_size);
+
+std::vector<std::pair<double, std::vector<int>>> get_beam_search_result(
+    const std::vector<PathTrie *> &prefixes, size_t beam_size);
+
+// Functor for prefix comparsion
+bool prefix_compare(const PathTrie *x, const PathTrie *y);
+
+/* Get length of utf8 encoding string
+ * See: http://stackoverflow.com/a/4063229
+ */
+size_t get_utf8_str_len(const std::string &str);
+
+/* Split a string into a list of strings on a given string
+ * delimiter. NB: delimiters on beginning / end of string are
+ * trimmed. Eg, "FooBarFoo" split on "Foo" returns ["Bar"].
+ */
+std::vector<std::string> split_str(const std::string &s,
+                                   const std::string &delim);
+
+/* Splits string into vector of strings representing
+ * UTF-8 characters (not same as chars)
+ */
+std::vector<std::string> split_utf8_str(const std::string &str);
+
+// Add a word in index to the dicionary of fst
+void add_word_to_fst(const std::vector<int> &word,
+                     fst::StdVectorFst *dictionary);
+
+// Add a word in string to dictionary
+bool add_word_to_dictionary(
+    const std::string &word,
+    const std::unordered_map<std::string, int> &char_map, bool add_space,
+    int SPACE_ID, fst::StdVectorFst *dictionary);
+#endif  // DECODER_UTILS_H

--- a/tools/swig_decoder/decoders.i
+++ b/tools/swig_decoder/decoders.i
@@ -1,0 +1,37 @@
+%module swig_decoders
+%{
+#include "scorer.h"
+#include "ctc_beam_search_decoder.h"
+#include "decoder_utils.h"
+#include "path_trie.h"
+%}
+
+%include "std_vector.i"
+%include "std_pair.i"
+%include "std_string.i"
+%include "path_trie.h"
+%import "decoder_utils.h"
+
+namespace std {
+    %template(DoubleVector) std::vector<double>;
+    %template(IntVector) std::vector<int>;
+    %template(StringVector) std::vector<std::string>;
+    %template(VectorOfStructVectorDouble) std::vector<std::vector<double> >;
+    %template(VectorOfStructVectorInt) std::vector<std::vector<int>>;
+    %template(FloatVector) std::vector<float>;
+    %template(Pair) std::pair<float, std::vector<int>>;
+    %template(PairFloatVectorVector)  std::vector<std::pair<float, std::vector<int>>>;
+    %template(PairDoubleVectorVector) std::vector<std::pair<double, std::vector<int>>>;
+    %template(PairDoubleVectorVector2) std::vector<std::vector<std::pair<double, std::vector<int>>>>;
+    %template(DoubleVector3) std::vector<std::vector<std::vector<double>>>;
+    %template(IntVector3) std::vector<std::vector<std::vector<int>>>;
+    %template(TrieVector) std::vector<PathTrie*>;
+    %template(BoolVector) std::vector<bool>;
+}
+%template(IntDoublePairCompSecondRev) pair_comp_second_rev<int, double>;
+%template(StringDoublePairCompSecondRev) pair_comp_second_rev<std::string, double>;
+%template(DoubleStringPairCompFirstRev) pair_comp_first_rev<double, std::string>;
+
+%include "scorer.h"
+%include "path_trie.h"
+%include "ctc_beam_search_decoder.h"

--- a/tools/swig_decoder/path_trie.cpp
+++ b/tools/swig_decoder/path_trie.cpp
@@ -1,0 +1,170 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "path_trie.h"
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "decoder_utils.h"
+
+PathTrie::PathTrie() {
+  log_prob_b_prev = -NUM_FLT_INF;
+  log_prob_nb_prev = -NUM_FLT_INF;
+  log_prob_b_cur = -NUM_FLT_INF;
+  log_prob_nb_cur = -NUM_FLT_INF;
+  score = -NUM_FLT_INF;
+
+  ROOT_ = -1;
+  character = ROOT_;
+  exists_ = true;
+  parent = nullptr;
+
+  dictionary_ = nullptr;
+  dictionary_state_ = 0;
+  has_dictionary_ = false;
+
+  matcher_ = nullptr;
+}
+
+PathTrie::~PathTrie() {
+  for (auto child : children_) {
+    delete child.second;
+  }
+}
+
+PathTrie* PathTrie::get_path_trie(int new_char, bool reset) {
+  auto child = children_.begin();
+  for (child = children_.begin(); child != children_.end(); ++child) {
+    if (child->first == new_char) {
+      break;
+    }
+  }
+  if (child != children_.end()) {
+    if (!child->second->exists_) {
+      child->second->exists_ = true;
+      child->second->log_prob_b_prev = -NUM_FLT_INF;
+      child->second->log_prob_nb_prev = -NUM_FLT_INF;
+      child->second->log_prob_b_cur = -NUM_FLT_INF;
+      child->second->log_prob_nb_cur = -NUM_FLT_INF;
+    }
+    return (child->second);
+  } else {
+    if (has_dictionary_) {
+      matcher_->SetState(dictionary_state_);
+      bool found = matcher_->Find(new_char + 1);
+      if (!found) {
+        // Adding this character causes word outside dictionary
+        auto FSTZERO = fst::TropicalWeight::Zero();
+        auto final_weight = dictionary_->Final(dictionary_state_);
+        bool is_final = (final_weight != FSTZERO);
+        if (is_final && reset) {
+          dictionary_state_ = dictionary_->Start();
+        }
+        return nullptr;
+      } else {
+        PathTrie* new_path = new PathTrie;
+        new_path->character = new_char;
+        new_path->parent = this;
+        new_path->dictionary_ = dictionary_;
+        new_path->dictionary_state_ = matcher_->Value().nextstate;
+        new_path->has_dictionary_ = true;
+        new_path->matcher_ = matcher_;
+        children_.push_back(std::make_pair(new_char, new_path));
+        return new_path;
+      }
+    } else {
+      PathTrie* new_path = new PathTrie;
+      new_path->character = new_char;
+      new_path->parent = this;
+      children_.push_back(std::make_pair(new_char, new_path));
+      return new_path;
+    }
+  }
+}
+
+PathTrie* PathTrie::get_path_vec(std::vector<int>& output) {
+  return get_path_vec(output, ROOT_);
+}
+
+PathTrie* PathTrie::get_path_vec(std::vector<int>& output, int stop,
+                                 size_t max_steps) {
+  if (character == stop || character == ROOT_ || output.size() == max_steps) {
+    std::reverse(output.begin(), output.end());
+    return this;
+  } else {
+    output.push_back(character);
+    return parent->get_path_vec(output, stop, max_steps);
+  }
+}
+
+void PathTrie::iterate_to_vec_only(std::vector<PathTrie*>& output) {
+  if (exists_) {
+    output.push_back(this);
+  }
+  for (auto child : children_) {
+    child.second->iterate_to_vec_only(output);
+  }
+}
+
+void PathTrie::iterate_to_vec(std::vector<PathTrie*>& output) {
+  if (exists_) {
+    log_prob_b_prev = log_prob_b_cur;
+    log_prob_nb_prev = log_prob_nb_cur;
+
+    log_prob_b_cur = -NUM_FLT_INF;
+    log_prob_nb_cur = -NUM_FLT_INF;
+
+    score = log_sum_exp(log_prob_b_prev, log_prob_nb_prev);
+    output.push_back(this);
+  }
+  for (auto child : children_) {
+    child.second->iterate_to_vec(output);
+  }
+}
+
+void PathTrie::remove() {
+  exists_ = false;
+
+  if (children_.size() == 0) {
+    auto child = parent->children_.begin();
+    for (child = parent->children_.begin(); child != parent->children_.end();
+         ++child) {
+      if (child->first == character) {
+        parent->children_.erase(child);
+        break;
+      }
+    }
+
+    if (parent->children_.size() == 0 && !parent->exists_) {
+      parent->remove();
+    }
+
+    delete this;
+  }
+}
+
+void PathTrie::set_dictionary(fst::StdVectorFst* dictionary) {
+  dictionary_ = dictionary;
+  dictionary_state_ = dictionary->Start();
+  has_dictionary_ = true;
+}
+
+using FSTMATCH = fst::SortedMatcher<fst::StdVectorFst>;
+void PathTrie::set_matcher(std::shared_ptr<FSTMATCH> matcher) {
+  matcher_ = matcher;
+}

--- a/tools/swig_decoder/path_trie.h
+++ b/tools/swig_decoder/path_trie.h
@@ -1,0 +1,82 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PATH_TRIE_H
+#define PATH_TRIE_H
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "fst/fstlib.h"
+
+/* Trie tree for prefix storing and manipulating, with a dictionary in
+ * finite-state transducer for spelling correction.
+ */
+class PathTrie {
+ public:
+  PathTrie();
+  ~PathTrie();
+
+  // get new prefix after appending new char
+  PathTrie* get_path_trie(int new_char, bool reset = true);
+
+  // get the prefix in index from root to current node
+  PathTrie* get_path_vec(std::vector<int>& output);
+
+  // get the prefix in index from some stop node to current nodel
+  PathTrie* get_path_vec(std::vector<int>& output, int stop,
+                         size_t max_steps = std::numeric_limits<size_t>::max());
+
+  // update log probs
+  void iterate_to_vec(std::vector<PathTrie*>& output);
+
+  void iterate_to_vec_only(std::vector<PathTrie*>& output);
+
+  // set dictionary for FST
+  void set_dictionary(fst::StdVectorFst* dictionary);
+
+  void set_matcher(std::shared_ptr<fst::SortedMatcher<fst::StdVectorFst>>);
+
+  bool is_empty() { return ROOT_ == character; }
+
+  // remove current path from root
+  void remove();
+
+  float log_prob_b_prev;
+  float log_prob_nb_prev;
+  float log_prob_b_cur;
+  float log_prob_nb_cur;
+  float score;
+  float approx_ctc;
+  int character;
+  PathTrie* parent;
+
+ private:
+  int ROOT_;
+  bool exists_;
+  bool has_dictionary_;
+
+  std::vector<std::pair<int, PathTrie*>> children_;
+
+  // pointer to dictionary of FST
+  fst::StdVectorFst* dictionary_;
+  fst::StdVectorFst::StateId dictionary_state_;
+  // true if finding ars in FST
+  std::shared_ptr<fst::SortedMatcher<fst::StdVectorFst>> matcher_;
+};
+
+#endif  // PATH_TRIE_H

--- a/tools/swig_decoder/scorer.cpp
+++ b/tools/swig_decoder/scorer.cpp
@@ -1,0 +1,242 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "scorer.h"
+
+#include <unistd.h>
+#include <iostream>
+
+#include "lm/config.hh"
+#include "lm/model.hh"
+#include "lm/state.hh"
+#include "util/string_piece.hh"
+#include "util/tokenize_piece.hh"
+
+#include "decoder_utils.h"
+
+using namespace lm::ngram;
+
+Scorer::Scorer(double alpha, double beta, const std::string& lm_path,
+               const std::vector<std::string>& vocab_list) {
+  this->alpha = alpha;
+  this->beta = beta;
+
+  dictionary = nullptr;
+  is_character_based_ = true;
+  language_model_ = nullptr;
+
+  max_order_ = 0;
+  dict_size_ = 0;
+  SPACE_ID_ = -1;
+
+  setup(lm_path, vocab_list);
+}
+
+Scorer::~Scorer() {
+  if (language_model_ != nullptr) {
+    delete static_cast<lm::base::Model*>(language_model_);
+  }
+  if (dictionary != nullptr) {
+    delete static_cast<fst::StdVectorFst*>(dictionary);
+  }
+}
+
+void Scorer::setup(const std::string& lm_path,
+                   const std::vector<std::string>& vocab_list) {
+  // load language model
+  load_lm(lm_path);
+  // set char map for scorer
+  set_char_map(vocab_list);
+  // fill the dictionary for FST
+  if (!is_character_based()) {
+    fill_dictionary(true);
+  }
+}
+
+void Scorer::load_lm(const std::string& lm_path) {
+  const char* filename = lm_path.c_str();
+  VALID_CHECK_EQ(access(filename, F_OK), 0, "Invalid language model path");
+
+  RetriveStrEnumerateVocab enumerate;
+  lm::ngram::Config config;
+  config.enumerate_vocab = &enumerate;
+  language_model_ = lm::ngram::LoadVirtual(filename, config);
+  max_order_ = static_cast<lm::base::Model*>(language_model_)->Order();
+  vocabulary_ = enumerate.vocabulary;
+  for (size_t i = 0; i < vocabulary_.size(); ++i) {
+    if (is_character_based_ && vocabulary_[i] != UNK_TOKEN &&
+        vocabulary_[i] != START_TOKEN && vocabulary_[i] != END_TOKEN &&
+        get_utf8_str_len(enumerate.vocabulary[i]) > 1) {
+      is_character_based_ = false;
+    }
+  }
+}
+
+double Scorer::get_log_cond_prob(const std::vector<std::string>& words) {
+  lm::base::Model* model = static_cast<lm::base::Model*>(language_model_);
+  double cond_prob;
+  lm::ngram::State state, tmp_state, out_state;
+  // avoid to inserting <s> in begin
+  model->NullContextWrite(&state);
+  for (size_t i = 0; i < words.size(); ++i) {
+    lm::WordIndex word_index = model->BaseVocabulary().Index(words[i]);
+    // encounter OOV
+    if (word_index == 0) {
+      return OOV_SCORE;
+    }
+    cond_prob = model->BaseScore(&state, word_index, &out_state);
+    tmp_state = state;
+    state = out_state;
+    out_state = tmp_state;
+  }
+  // return  log10 prob
+  return cond_prob;
+}
+
+double Scorer::get_sent_log_prob(const std::vector<std::string>& words) {
+  std::vector<std::string> sentence;
+  if (words.size() == 0) {
+    for (size_t i = 0; i < max_order_; ++i) {
+      sentence.push_back(START_TOKEN);
+    }
+  } else {
+    for (size_t i = 0; i < max_order_ - 1; ++i) {
+      sentence.push_back(START_TOKEN);
+    }
+    sentence.insert(sentence.end(), words.begin(), words.end());
+  }
+  sentence.push_back(END_TOKEN);
+  return get_log_prob(sentence);
+}
+
+double Scorer::get_log_prob(const std::vector<std::string>& words) {
+  assert(words.size() > max_order_);
+  double score = 0.0;
+  for (size_t i = 0; i < words.size() - max_order_ + 1; ++i) {
+    std::vector<std::string> ngram(words.begin() + i,
+                                   words.begin() + i + max_order_);
+    score += get_log_cond_prob(ngram);
+  }
+  return score;
+}
+
+void Scorer::reset_params(float alpha, float beta) {
+  this->alpha = alpha;
+  this->beta = beta;
+}
+
+std::string Scorer::vec2str(const std::vector<int>& input) {
+  std::string word;
+  for (auto ind : input) {
+    word += char_list_[ind];
+  }
+  return word;
+}
+
+std::vector<std::string> Scorer::split_labels(const std::vector<int>& labels) {
+  if (labels.empty()) return {};
+
+  std::string s = vec2str(labels);
+  std::vector<std::string> words;
+  if (is_character_based_) {
+    words = split_utf8_str(s);
+  } else {
+    words = split_str(s, " ");
+  }
+  return words;
+}
+
+void Scorer::set_char_map(const std::vector<std::string>& char_list) {
+  char_list_ = char_list;
+  char_map_.clear();
+
+  // Set the char map for the FST for spelling correction
+  for (size_t i = 0; i < char_list_.size(); i++) {
+    if (char_list_[i] == " ") {
+      SPACE_ID_ = i;
+    }
+    // The initial state of FST is state 0, hence the index of chars in
+    // the FST should start from 1 to avoid the conflict with the initial
+    // state, otherwise wrong decoding results would be given.
+    char_map_[char_list_[i]] = i + 1;
+  }
+}
+
+std::vector<std::string> Scorer::make_ngram(PathTrie* prefix) {
+  std::vector<std::string> ngram;
+  PathTrie* current_node = prefix;
+  PathTrie* new_node = nullptr;
+
+  for (int order = 0; order < max_order_; order++) {
+    std::vector<int> prefix_vec;
+
+    if (is_character_based_) {
+      new_node = current_node->get_path_vec(prefix_vec, SPACE_ID_, 1);
+      current_node = new_node;
+    } else {
+      new_node = current_node->get_path_vec(prefix_vec, SPACE_ID_);
+      current_node = new_node->parent;  // Skipping spaces
+    }
+
+    // reconstruct word
+    std::string word = vec2str(prefix_vec);
+    ngram.push_back(word);
+
+    if (new_node->character == -1) {
+      // No more spaces, but still need order
+      for (int i = 0; i < max_order_ - order - 1; i++) {
+        ngram.push_back(START_TOKEN);
+      }
+      break;
+    }
+  }
+  std::reverse(ngram.begin(), ngram.end());
+  return ngram;
+}
+
+void Scorer::fill_dictionary(bool add_space) {
+  fst::StdVectorFst dictionary;
+  // For each unigram convert to ints and put in trie
+  int dict_size = 0;
+  for (const auto& word : vocabulary_) {
+    bool added = add_word_to_dictionary(word, char_map_, add_space,
+                                        SPACE_ID_ + 1, &dictionary);
+    dict_size += added ? 1 : 0;
+  }
+
+  dict_size_ = dict_size;
+
+  /* Simplify FST
+
+   * This gets rid of "epsilon" transitions in the FST.
+   * These are transitions that don't require a string input to be taken.
+   * Getting rid of them is necessary to make the FST determinisitc, but
+   * can greatly increase the size of the FST
+   */
+  fst::RmEpsilon(&dictionary);
+  fst::StdVectorFst* new_dict = new fst::StdVectorFst;
+
+  /* This makes the FST deterministic, meaning for any string input there's
+   * only one possible state the FST could be in.  It is assumed our
+   * dictionary is deterministic when using it.
+   * (lest we'd have to check for multiple transitions at each state)
+   */
+  fst::Determinize(dictionary, new_dict);
+
+  /* Finds the simplest equivalent fst. This is unnecessary but decreases
+   * memory usage of the dictionary
+   */
+  fst::Minimize(new_dict);
+  this->dictionary = new_dict;
+}

--- a/tools/swig_decoder/scorer.h
+++ b/tools/swig_decoder/scorer.h
@@ -1,0 +1,124 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SCORER_H_
+#define SCORER_H_
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "lm/enumerate_vocab.hh"
+#include "lm/virtual_interface.hh"
+#include "lm/word_index.hh"
+#include "util/string_piece.hh"
+
+#include "path_trie.h"
+
+const double OOV_SCORE = -1000.0;
+const std::string START_TOKEN = "<s>";
+const std::string UNK_TOKEN = "<unk>";
+const std::string END_TOKEN = "</s>";
+
+// Implement a callback to retrive the dictionary of language model.
+class RetriveStrEnumerateVocab : public lm::EnumerateVocab {
+ public:
+  RetriveStrEnumerateVocab() {}
+
+  void Add(lm::WordIndex index, const StringPiece &str) {
+    vocabulary.push_back(std::string(str.data(), str.length()));
+  }
+
+  std::vector<std::string> vocabulary;
+};
+
+/* External scorer to query score for n-gram or sentence, including language
+ * model scoring and word insertion.
+ *
+ * Example:
+ *     Scorer scorer(alpha, beta, "path_of_language_model");
+ *     scorer.get_log_cond_prob({ "WORD1", "WORD2", "WORD3" });
+ *     scorer.get_sent_log_prob({ "WORD1", "WORD2", "WORD3" });
+ */
+class Scorer {
+ public:
+  Scorer(double alpha, double beta, const std::string &lm_path,
+         const std::vector<std::string> &vocabulary);
+  ~Scorer();
+
+  double get_log_cond_prob(const std::vector<std::string> &words);
+
+  double get_sent_log_prob(const std::vector<std::string> &words);
+
+  // return the max order
+  size_t get_max_order() const { return max_order_; }
+
+  // return the dictionary size of language model
+  size_t get_dict_size() const { return dict_size_; }
+
+  // retrun true if the language model is character based
+  bool is_character_based() const { return is_character_based_; }
+
+  // reset params alpha & beta
+  void reset_params(float alpha, float beta);
+
+  // make ngram for a given prefix
+  std::vector<std::string> make_ngram(PathTrie *prefix);
+
+  // trransform the labels in index to the vector of words (word based lm) or
+  // the vector of characters (character based lm)
+  std::vector<std::string> split_labels(const std::vector<int> &labels);
+
+  // language model weight
+  double alpha;
+  // word insertion weight
+  double beta;
+
+  // pointer to the dictionary of FST
+  void *dictionary;
+
+ protected:
+  // necessary setup: load language model, set char map, fill FST's dictionary
+  void setup(const std::string &lm_path,
+             const std::vector<std::string> &vocab_list);
+
+  // load language model from given path
+  void load_lm(const std::string &lm_path);
+
+  // fill dictionary for FST
+  void fill_dictionary(bool add_space);
+
+  // set char map
+  void set_char_map(const std::vector<std::string> &char_list);
+
+  double get_log_prob(const std::vector<std::string> &words);
+
+  // translate the vector in index to string
+  std::string vec2str(const std::vector<int> &input);
+
+ private:
+  void *language_model_;
+  bool is_character_based_;
+  size_t max_order_;
+  size_t dict_size_;
+
+  int SPACE_ID_;
+  std::vector<std::string> char_list_;
+  std::unordered_map<std::string, int> char_map_;
+
+  std::vector<std::string> vocabulary_;
+};
+
+#endif  // SCORER_H_

--- a/tools/swig_decoder/setup.py
+++ b/tools/swig_decoder/setup.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Script to build and install decoder package."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from setuptools import setup, Extension, distutils
+import glob
+import platform
+import os
+import sys
+import multiprocessing.pool
+import argparse
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument(
+    "--num_processes",
+    default=1,
+    type=int,
+    help="Number of cpu processes to build package. (default: %(default)d)")
+args = parser.parse_known_args()
+
+# reconstruct sys.argv to pass to setup below
+sys.argv = [sys.argv[0]] + args[1]
+
+
+# monkey-patch for parallel compilation
+# See: https://stackoverflow.com/a/13176803
+def parallelCCompile(self,
+                     sources,
+                     output_dir=None,
+                     macros=None,
+                     include_dirs=None,
+                     debug=0,
+                     extra_preargs=None,
+                     extra_postargs=None,
+                     depends=None):
+    # those lines are copied from distutils.ccompiler.CCompiler directly
+    macros, objects, extra_postargs, pp_opts, build = self._setup_compile(
+        output_dir, macros, include_dirs, sources, depends, extra_postargs)
+    cc_args = self._get_cc_args(pp_opts, debug, extra_preargs)
+
+    # parallel code
+    def _single_compile(obj):
+        try:
+            src, ext = build[obj]
+        except KeyError:
+            return
+        self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
+
+    # convert to list, imap is evaluated on-demand
+    thread_pool = multiprocessing.pool.ThreadPool(args[0].num_processes)
+    list(thread_pool.imap(_single_compile, objects))
+    return objects
+
+
+def compile_test(header, library):
+    dummy_path = os.path.join(os.path.dirname(__file__), "dummy")
+    command = "bash -c \"g++ -include " + header \
+        + " -l" + library + " -x c++ - <<<'int main() {}' -o " \
+        + dummy_path + " >/dev/null 2>/dev/null && rm " \
+                + dummy_path + " 2>/dev/null\""
+    return os.system(command) == 0
+
+
+# hack compile to support parallel compiling
+distutils.ccompiler.CCompiler.compile = parallelCCompile
+
+FILES = glob.glob('kenlm/util/*.cc') \
+    + glob.glob('kenlm/lm/*.cc') \
+    + glob.glob('kenlm/util/double-conversion/*.cc')
+
+FILES += glob.glob('openfst-1.6.3/src/lib/*.cc')
+
+FILES = [
+    fn for fn in FILES
+    if not (fn.endswith('main.cc') or fn.endswith('test.cc') or fn.endswith(
+        'unittest.cc'))
+]
+
+LIBS = ['stdc++']
+if platform.system() != 'Darwin':
+    LIBS.append('rt')
+
+ARGS = ['-O3', '-DNDEBUG', '-DKENLM_MAX_ORDER=6', '-std=c++11']
+
+if compile_test('zlib.h', 'z'):
+    ARGS.append('-DHAVE_ZLIB')
+    LIBS.append('z')
+
+if compile_test('bzlib.h', 'bz2'):
+    ARGS.append('-DHAVE_BZLIB')
+    LIBS.append('bz2')
+
+if compile_test('lzma.h', 'lzma'):
+    ARGS.append('-DHAVE_XZLIB')
+    LIBS.append('lzma')
+
+os.system('swig -python -c++ ./decoders.i')
+
+decoders_module = [
+    Extension(
+        name='_swig_decoders',
+        sources=FILES + glob.glob('*.cxx') + glob.glob('*.cpp'),
+        language='c++',
+        include_dirs=[
+            '.',
+            'kenlm',
+            'openfst-1.6.3/src/include',
+            'ThreadPool',
+        ],
+        libraries=LIBS,
+        extra_compile_args=ARGS)
+]
+
+setup(
+    name='swig_decoders',
+    version='1.1',
+    description="""CTC decoders""",
+    ext_modules=decoders_module,
+    py_modules=['swig_decoders'], )

--- a/tools/swig_decoder/setup.sh
+++ b/tools/swig_decoder/setup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+if [ ! -d kenlm ]; then
+    git clone https://github.com/kpu/kenlm.git
+    echo -e "\n"
+fi
+
+if [ ! -d openfst-1.6.3 ]; then
+    echo "Download and extract openfst ..."
+    wget http://www.openfst.org/twiki/pub/FST/FstDownload/openfst-1.6.3.tar.gz
+    tar -xzvf openfst-1.6.3.tar.gz
+    echo -e "\n"
+fi
+
+if [ ! -d ThreadPool ]; then
+    git clone https://github.com/progschj/ThreadPool.git
+    echo -e "\n"
+fi
+
+echo "Install decoders ..."
+python3 setup.py install --num_processes 10

--- a/wenet/bin/export_onnx.py
+++ b/wenet/bin/export_onnx.py
@@ -1,0 +1,297 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import argparse
+import os
+
+import torch
+import yaml
+import logging
+
+from wenet.transformer.asr_model import init_asr_model
+from wenet.utils.checkpoint import load_checkpoint
+from wenet.transformer.ctc import CTC
+from wenet.transformer.decoder import TransformerDecoder
+from wenet.transformer.encoder import BaseEncoder
+from wenet.utils.common import IGNORE_ID
+from wenet.utils.mask import make_pad_mask
+
+import onnxruntime
+
+logger = logging.getLogger(__file__)
+logger.setLevel(logging.INFO)
+
+class Encoder(torch.nn.Module):
+    def __init__(self,
+                 encoder: BaseEncoder,
+                 ctc: CTC,
+                 beam: int):
+        super().__init__()
+        self.encoder = encoder
+        self.ctc = ctc
+        self.beam_size = beam
+
+    def forward(self, speech: torch.Tensor,
+                speech_lengths: torch.Tensor,):
+        """Encoder
+        Args:
+            speech: (Batch, Length, ...)
+            speech_lengths: (Batch, )
+        Returns:
+            encoder_out: B x T x F
+            encoder_mask: B x 1 x T
+            ctc_log_probs: B x T x V
+            encoder_out_lens: B
+        """
+        encoder_out, encoder_mask = self.encoder(speech,
+                                                 speech_lengths, -1, -1)
+        encoder_out_lens = encoder_mask.squeeze(1).sum(1)
+        ctc_log_probs = self.ctc.log_softmax(encoder_out)
+        beam_log_probs, beam_log_probs_idx = torch.topk(
+            ctc_log_probs, self.beam_size, dim=2)
+        return encoder_out, encoder_out_lens, beam_log_probs, beam_log_probs_idx
+
+
+class Decoder(torch.nn.Module):
+    def __init__(self,
+                 decoder: TransformerDecoder,
+                 reverse_weight: float = 0.0,
+                 ctc_weight: float = 0.0,
+                 beam_size: int = 10,
+                 ignore_id: int = IGNORE_ID):
+        super().__init__()
+        self.decoder = decoder
+        self.reverse_weight = reverse_weight
+        self.ctc_weight = ctc_weight
+        self.ignore_id = ignore_id
+        self.beam_size = beam_size
+
+    def forward(self,
+                encoder_out: torch.Tensor,
+                encoder_lens: torch.Tensor,
+                hyps_pad: torch.Tensor,
+                hyps_pad_out: torch.Tensor,
+                hyps_lens: torch.Tensor,
+                r_hyps_pad: torch.Tensor,
+                r_hyps_pad_out: torch.Tensor,
+                ctc_score: torch.Tensor):
+        """Encoder
+        Args:
+            encoder_out: B X T X F
+            encoder_mask: B X 1 x T
+            hyps_pad: B*beam x T2,
+                        hyps with sos and padded by ignore id
+            hyps_pad_out: B*beam x T2,
+                        hyps with eos and padded by ignore_id
+            hyps_lens: B*beam, length for each hyp
+            r_hyps_pad: B*beam x T2,
+                    reversed hyps with sos and padded by ignore id
+            r_hyps_pad_out: B*beam x T2,
+                    reversed hyps with eos and padded by ignore id
+            ctc_score: B*beam
+        """
+        T = encoder_out.shape[1]
+        F = encoder_out.shape[-1]
+        B = encoder_out.shape[0]
+        encoder_out = encoder_out.repeat(1, self.beam_size, 1).view(-1, T, F)
+        encoder_mask = ~make_pad_mask(encoder_lens, T).unsqueeze(1)
+        encoder_mask = encoder_mask.repeat(1, self.beam_size, 1).view(-1, 1, T)
+        decoder_out, r_decoder_out, _ = self.decoder(
+            encoder_out, encoder_mask, hyps_pad, hyps_lens, r_hyps_pad,
+            self.reverse_weight)
+        decoder_out = torch.nn.functional.log_softmax(decoder_out, dim=-1)
+
+        decoder_out_reshape = decoder_out.view(-1, decoder_out.shape[-1])
+        score = -torch.nn.functional.nll_loss(decoder_out_reshape,
+                                              hyps_pad_out.view(-1),
+                                              reduction='none',
+                                              ignore_index=self.ignore_id)
+        if self.reverse_weight > 0:
+            # r_decoder_out will be 0.0, if reverse_weight is 0.0 or decoder is a
+            # conventional transformer decoder.
+            r_decoder_out = torch.nn.functional.log_softmax(
+                r_decoder_out, dim=-1)
+            r_decoder_out_reshape = r_decoder_out.view(
+                -1, r_decoder_out.shape[-1])
+            r_score = -torch.nn.functional.nll_loss(r_decoder_out_reshape,
+                                                    r_hyps_pad_out.view(-1),
+                                                    reduction='none',
+                                                    ignore_index=self.ignore_id)
+            score = score * (1 - self.reverse_weight) + \
+                self.reverse_weight * r_score
+
+        score = torch.reshape(score, hyps_pad.shape)
+        score = torch.sum(score, 1)
+        score = score + self.ctc_weight * ctc_score
+
+        # resize score to B X Beam
+        score = torch.reshape(score, (B, beam_size))
+        best_index = torch.argmax(score, dim=1)  # B
+        return best_index
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='export your script model')
+    parser.add_argument('--config', required=True, help='config file')
+    parser.add_argument('--checkpoint', required=True, help='checkpoint model')
+    parser.add_argument('--beam_size', default=10, type=int, required=False,
+                        help="beam size would be ctc output size")
+    parser.add_argument('--output_onnx_directory',
+                        default="onnx_model",
+                        help='output onnx encoder and decoder directory')
+    args = parser.parse_args()
+
+    torch.manual_seed(0)
+    torch.set_printoptions(precision=10)
+
+    with open(args.config, 'r') as fin:
+        configs = yaml.load(fin, Loader=yaml.FullLoader)
+
+    configs["encoder_conf"]["use_dynamic_chunk"] = False
+    model = init_asr_model(configs)
+    load_checkpoint(model, args.checkpoint)
+    model.eval()
+
+    bz = 32
+    seq_len = 100
+    beam_size = args.beam_size
+    feature_size = configs["collate_conf"]["feature_extraction_conf"]["mel_bins"]
+
+    speech = torch.randn(bz, seq_len, feature_size, dtype=torch.float32)
+    speech_lens = torch.randint(low=10, high=seq_len, size=(bz,), dtype=torch.int32)
+    encoder = Encoder(model.encoder, model.ctc, beam_size)
+    encoder.eval()
+    encoder_onnx_path = os.path.join(args.output_onnx_directory, 'encoder.onnx')
+
+    torch.onnx.export(encoder,
+                      (speech, speech_lens),
+                      encoder_onnx_path,
+                      export_params=True,
+                      opset_version=14,
+                      do_constant_folding=True,
+                      input_names=['speech', 'speech_lengths'],
+                      output_names=['encoder_out', 'encoder_out_lens',
+                                    'beam_log_probs', 'beam_log_probs_idx'],
+                      dynamic_axes={
+                          'speech': [0, 1],
+                          'speech_lengths': [0],
+                          'encoder_out': [0, 1],
+                          'encoder_out_lens': [0],
+                          'beam_log_probs': [0, 1],
+                          'beam_log_probs_idx': [0, 1],
+                      },
+                      verbose=False
+                      )
+
+    def to_numpy(tensor):
+        return tensor.detach().cpu().numpy() if tensor.requires_grad else tensor.cpu().numpy()
+
+    with torch.no_grad():
+        o0, o1, o2, o3 = encoder(speech, speech_lens)
+
+    ort_session = onnxruntime.InferenceSession(encoder_onnx_path)
+    ort_inputs = {ort_session.get_inputs()[0].name: to_numpy(speech),
+                  ort_session.get_inputs()[1].name: to_numpy(speech_lens)}
+    ort_outs = ort_session.run(None, ort_inputs)
+
+    def test(a, b, rtol=1e-3, atol=1e-5, tolerate_small_mismatch=True):
+        try:
+            torch.testing.assert_allclose(a, b, rtol=rtol, atol=atol)
+        except AssertionError as error:
+            if tolerate_small_mismatch:
+                print(error)
+            else:
+                raise
+
+    # check encoder output
+    test(to_numpy(o0), ort_outs[0], rtol=1e-03, atol=1e-05)
+    test(to_numpy(o1), ort_outs[1], rtol=1e-03, atol=1e-05)
+    test(to_numpy(o2), ort_outs[2], rtol=1e-03, atol=1e-05)
+    test(to_numpy(o3), ort_outs[3], rtol=1e-03, atol=1e-05)
+    logger.info("export to onnx encoder succeed!")
+
+    decoder = Decoder(
+        model.decoder,
+        model.reverse_weight,
+        model.ctc_weight,
+        beam_size,
+        IGNORE_ID)
+    decoder.eval()
+    decoder_onnx_path = os.path.join(args.output_onnx_directory, 'decoder.onnx')
+
+    hyps_pad_sos = torch.randint(low=3, high=1000, size=(bz * beam_size, seq_len))
+    hyps_lens_sos = torch.randint(low=3, high=seq_len, size=(bz * beam_size,))
+    hyps_pad_eos = torch.randint(low=3, high=1000, size=(bz * beam_size, seq_len))
+    r_hyps_pad_sos = torch.randint(low=3, high=1000, size=(bz * beam_size, seq_len))
+    r_hyps_pad_eos = torch.randint(low=3, high=1000, size=(bz * beam_size, seq_len))
+
+    output_size = configs["encoder_conf"]["output_size"]
+    encoder_out = torch.randn(bz, seq_len, output_size, dtype=torch.float32)
+    encoder_out_lens = torch.randint(
+        low=3, high=seq_len, size=(
+            bz,), dtype=torch.int64)
+    ctc_score = torch.randn(bz * beam_size, dtype=torch.float32)
+    torch.onnx.export(decoder,
+                      (encoder_out, encoder_out_lens,
+                       hyps_pad_sos, hyps_pad_eos,
+                       hyps_lens_sos, r_hyps_pad_sos,
+                       r_hyps_pad_eos, ctc_score),
+                      decoder_onnx_path,
+                      export_params=True,
+                      opset_version=14,
+                      do_constant_folding=True,
+                      input_names=['encoder_out', 'encoder_out_lens',
+                                   'hyps_pad_sos', 'hyps_pad_eos',
+                                   'hyps_lens_sos', 'r_hyps_pad_sos',
+                                   'r_hyps_pad_eos', 'ctc_score'],
+                      output_names=['best_hyps'],
+                      dynamic_axes={'encoder_out': [0, 1],
+                                    'encoder_out_lens': [0],
+                                    'hyps_pad_sos': [0, 1],
+                                    'hyps_pad_eos': [0, 1],
+                                    'hyps_lens_sos': [0],
+                                    'r_hyps_pad_sos': [0, 1],
+                                    'r_hyps_pad_eos': [0, 1],
+                                    'ctc_score': [0],
+                                    'best_hyps': [0]
+                                    },
+                      verbose=False
+                      )
+    with torch.no_grad():
+        o0 = decoder(encoder_out,
+                     encoder_out_lens,
+                     hyps_pad_sos,
+                     hyps_pad_eos,
+                     hyps_lens_sos,
+                     r_hyps_pad_sos,
+                     r_hyps_pad_eos,
+                     ctc_score)
+
+    ort_session = onnxruntime.InferenceSession(decoder_onnx_path)
+    ort_inputs = {ort_session.get_inputs()[0].name: to_numpy(encoder_out),
+                  ort_session.get_inputs()[1].name: to_numpy(encoder_out_lens),
+                  ort_session.get_inputs()[2].name: to_numpy(hyps_pad_sos),
+                  ort_session.get_inputs()[3].name: to_numpy(hyps_pad_eos),
+                  ort_session.get_inputs()[4].name: to_numpy(hyps_lens_sos),
+                  ort_session.get_inputs()[5].name: to_numpy(r_hyps_pad_sos),
+                  ort_session.get_inputs()[6].name: to_numpy(r_hyps_pad_eos),
+                  ort_session.get_inputs()[7].name: to_numpy(ctc_score)}
+    ort_outs = ort_session.run(None, ort_inputs)
+
+    # check encoder output
+    test(to_numpy(o0), ort_outs[0], rtol=1e-03, atol=1e-05)
+
+    logger.info("export to onnx decoder succeed!")

--- a/wenet/bin/recognize_onnx.py
+++ b/wenet/bin/recognize_onnx.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2020 Mobvoi Inc. (authors: Binbin Zhang, Xiaoyu Chen, Di Wu)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import argparse
+import copy
+import logging
+import multiprocessing
+import os
+import yaml
+import numpy as np
+import onnxruntime
+
+import torch
+from torch.utils.data import DataLoader
+
+from wenet.utils.common import IGNORE_ID
+from wenet.dataset.dataset import AudioDataset, CollateFunc
+from swig_decoders import map_batch, ctc_beam_search_decoder_batch, TrieVector, PathTrie
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='recognize with your model')
+    parser.add_argument('--config', required=True, help='config file')
+    parser.add_argument('--test_data', required=True, help='test data file')
+    parser.add_argument('--gpu',
+                        type=int,
+                        default=-1,
+                        help='gpu id for this rank, -1 for cpu')
+    parser.add_argument(
+        '--encoder_onnx',
+        required=True,
+        help='encoder onnx file')
+    parser.add_argument(
+        '--decoder_onnx',
+        required=True,
+        help='decoder onnx file')
+    parser.add_argument('--dict', required=True, help='dict file')
+    parser.add_argument('--result_file', required=True, help='asr result file')
+    parser.add_argument('--batch_size',
+                        type=int,
+                        default=16,
+                        help='asr result file')
+    parser.add_argument('--mode',
+                        choices=[
+                            'ctc_greedy_search',
+                            'ctc_prefix_beam_search', 'attention_rescoring'
+                        ],
+                        default='attention',
+                        help='decoding mode')
+
+    args = parser.parse_args()
+    print(args)
+    logging.basicConfig(level=logging.DEBUG,
+                        format='%(asctime)s %(levelname)s %(message)s')
+    os.environ['CUDA_VISIBLE_DEVICES'] = str(args.gpu)
+
+    with open(args.config, 'r') as fin:
+        configs = yaml.load(fin, Loader=yaml.FullLoader)
+
+    raw_wav = configs['raw_wav']
+    # Init dataset and data loader
+    # Init dataset and data loader
+    test_collate_conf = copy.deepcopy(configs['collate_conf'])
+    test_collate_conf['spec_aug'] = False
+    test_collate_conf['spec_sub'] = False
+    test_collate_conf['feature_dither'] = False
+    test_collate_conf['speed_perturb'] = False
+    if raw_wav:
+        test_collate_conf['wav_distortion_conf']['wav_distortion_rate'] = 0
+    test_collate_func = CollateFunc(**test_collate_conf, raw_wav=raw_wav)
+    dataset_conf = configs.get('dataset_conf', {})
+    dataset_conf['batch_size'] = args.batch_size
+    dataset_conf['batch_type'] = 'static'
+    dataset_conf['sort'] = False
+    test_dataset = AudioDataset(args.test_data,
+                                **dataset_conf,
+                                raw_wav=raw_wav)
+    test_data_loader = DataLoader(test_dataset,
+                                  collate_fn=test_collate_func,
+                                  shuffle=False,
+                                  batch_size=1,
+                                  num_workers=0)
+
+    # Init asr model from configs
+    encoder_ort_session = onnxruntime.InferenceSession(args.encoder_onnx)
+    decoder_ort_session = None
+    if args.mode == "attention_rescoring":
+        decoder_ort_session = onnxruntime.InferenceSession(args.decoder_onnx)
+
+    # Load dict
+    vocabulary = []
+    char_dict = {}
+    with open(args.dict, 'r') as fin:
+        for line in fin:
+            arr = line.strip().split()
+            assert len(arr) == 2
+            char_dict[int(arr[1])] = arr[0]
+            vocabulary.append(arr[0])
+    eos = sos = len(char_dict) - 1
+    batch_size = args.batch_size
+    num_processes = min(multiprocessing.cpu_count(), batch_size)
+    with torch.no_grad(), open(args.result_file, 'w') as fout:
+        for batch_idx, batch in enumerate(test_data_loader):
+            keys, feats, target, feats_lengths, target_lengths = batch
+            feats = feats
+            feats_lengths = feats_lengths
+            ort_inputs = {
+                encoder_ort_session.get_inputs()[0].name: feats.numpy(),
+                encoder_ort_session.get_inputs()[1].name: feats_lengths.numpy()}
+            ort_outs = encoder_ort_session.run(None, ort_inputs)
+            encoder_out, encoder_out_lens, batch_log_probs, batch_log_probs_idx = ort_outs
+            beam_size = batch_log_probs.shape[-1]
+            hyps, score_hyps = [], []
+            if args.mode == 'ctc_greedy_search':
+                assert batch_log_probs.shape[-1] == 1
+                batch_sents = []
+                for idx, seq in enumerate(batch_log_probs_idx):
+                    batch_sents.append(seq[0:encoder_out_lens[idx]].tolist())
+                hyps = map_batch(
+                    batch_sents,
+                    vocabulary,
+                    num_processes,
+                    greedy=True,
+                    blank_id=0)
+            elif args.mode == 'ctc_prefix_beam_search' or args.mode == "attention_rescoring":
+                batch_log_probs_seq_list = batch_log_probs.tolist()
+                batch_log_probs_idx_list = batch_log_probs_idx.tolist()
+                batch_len_list = encoder_out_lens.tolist()
+                batch_log_probs_seq = []
+                batch_log_probs_ids = []
+                batch_start = []  # only effective in streaming deployment
+                batch_root = TrieVector()
+                root_dict = {}
+                for i in range(len(batch_len_list)):
+                    num_sent = batch_len_list[i]
+                    batch_log_probs_seq.append(
+                        batch_log_probs_seq_list[i][0:num_sent])
+                    batch_log_probs_ids.append(
+                        batch_log_probs_idx_list[i][0:num_sent])
+                    root_dict[i] = PathTrie()
+                    batch_root.append(root_dict[i])
+                    batch_start.append(True)
+                score_hyps = ctc_beam_search_decoder_batch(batch_log_probs_seq,
+                                                           batch_log_probs_ids,
+                                                           batch_root,
+                                                           batch_start,
+                                                           beam_size,
+                                                           num_processes,
+                                                           0, -2, 0.99999)
+
+                if args.mode == 'ctc_prefix_beam_search':
+                    for cand_hyps in score_hyps:
+                        hyps.append(cand_hyps[0][1])
+                    hyps = map_batch(hyps, vocabulary, num_processes, False, 0)
+            if args.mode == 'attention_rescoring':
+                ctc_score, all_hyps = [], []
+                max_len = 0
+                for hyps in score_hyps:
+                    cur_len = len(hyps)
+                    if len(hyps) != beam_size:
+                        hyps += (beam_size - cur_len) * [(-float("INF"), (0,))]
+                    for hyp in hyps:
+                        ctc_score.append(hyp[0])
+                        all_hyps.append(list(hyp[1]))
+                        if len(hyp[1]) + 1 > max_len:
+                            max_len = len(hyp[1]) + 1
+                assert len(ctc_score) == beam_size * batch_size
+                ctc_score = np.array(ctc_score, dtype=np.float32)
+                hyps_pad_sos = np.ones(
+                    (batch_size * beam_size, max_len), dtype=np.int64) * IGNORE_ID
+                hyps_pad_eos = np.ones(
+                    (batch_size * beam_size, max_len), dtype=np.int64) * IGNORE_ID
+                r_hyps_pad_sos = np.ones(
+                    (batch_size * beam_size, max_len), dtype=np.int64) * IGNORE_ID
+                r_hyps_pad_eos = np.ones(
+                    (batch_size * beam_size, max_len), dtype=np.int64) * IGNORE_ID
+                hyps_lens_sos = np.ones(batch_size * beam_size, dtype=np.int64)
+                for idx, cand in enumerate(all_hyps):
+                    hyps_pad_sos[idx][0:len(cand) + 1] = [sos] + cand
+                    hyps_pad_eos[idx][0:len(cand) + 1] = cand + [eos]
+                    r_hyps_pad_sos[idx][0:len(cand) + 1] = [sos] + cand[::-1]
+                    r_hyps_pad_eos[idx][0:len(cand) + 1] = cand[::-1] + [eos]
+                    hyps_lens_sos[idx] = len(cand) + 1
+
+                decoder_ort_inputs = {
+                    decoder_ort_session.get_inputs()[0].name: encoder_out,
+                    decoder_ort_session.get_inputs()[1].name: encoder_out_lens,
+                    decoder_ort_session.get_inputs()[2].name: hyps_pad_sos,
+                    decoder_ort_session.get_inputs()[3].name: hyps_pad_eos,
+                    decoder_ort_session.get_inputs()[4].name: hyps_lens_sos,
+                    decoder_ort_session.get_inputs()[5].name: r_hyps_pad_sos,
+                    decoder_ort_session.get_inputs()[6].name: r_hyps_pad_eos,
+                    decoder_ort_session.get_inputs()[7].name: ctc_score}
+                hyps = []
+                best_index = decoder_ort_session.run(
+                    None, decoder_ort_inputs)[0]
+                for idx, li in enumerate(score_hyps):
+                    hyps.append(li[best_index[idx]][1])
+                hyps = map_batch(hyps, vocabulary, num_processes)
+
+            for i, key in enumerate(keys):
+                content = hyps[i]
+                logging.info('{} {}'.format(key, content))
+                fout.write('{} {}\n'.format(key, content))

--- a/wenet/transformer/decoder.py
+++ b/wenet/transformer/decoder.py
@@ -111,7 +111,7 @@ class TransformerDecoder(torch.nn.Module):
         tgt = ys_in_pad
 
         # tgt_mask: (B, 1, L)
-        tgt_mask = (~make_pad_mask(ys_in_lens).unsqueeze(1)).to(tgt.device)
+        tgt_mask = (~make_pad_mask(ys_in_lens, ys_in_pad.size(1)).unsqueeze(1)).to(tgt.device)
         # m: (1, L, L)
         m = subsequent_mask(tgt_mask.size(-1),
                             device=tgt_mask.device).unsqueeze(0)

--- a/wenet/transformer/embedding.py
+++ b/wenet/transformer/embedding.py
@@ -9,6 +9,7 @@ import math
 from typing import Tuple
 
 import torch
+import torch.nn.functional as F
 
 
 class PositionalEncoding(torch.nn.Module):
@@ -21,6 +22,7 @@ class PositionalEncoding(torch.nn.Module):
     PE(pos, 2i)   = sin(pos/(10000^(2i/dmodel)))
     PE(pos, 2i+1) = cos(pos/(10000^(2i/dmodel)))
     """
+
     def __init__(self,
                  d_model: int,
                  dropout_rate: float,
@@ -41,28 +43,36 @@ class PositionalEncoding(torch.nn.Module):
             -(math.log(10000.0) / self.d_model))
         self.pe[:, 0::2] = torch.sin(position * div_term)
         self.pe[:, 1::2] = torch.cos(position * div_term)
-        self.pe = self.pe.unsqueeze(0)
 
     def forward(self,
                 x: torch.Tensor,
-                offset: int = 0) -> Tuple[torch.Tensor, torch.Tensor]:
+                offset: torch.Tensor = None) -> Tuple[torch.Tensor,
+                                                      torch.Tensor]:
         """Add positional encoding.
 
         Args:
             x (torch.Tensor): Input. Its shape is (batch, time, ...)
-            offset (int): position offset
+            offset (torch.Tensor): position offset (batch)
 
         Returns:
             torch.Tensor: Encoded tensor. Its shape is (batch, time, ...)
             torch.Tensor: for compatibility to RelPositionalEncoding
         """
-        assert offset + x.size(1) < self.max_len
         self.pe = self.pe.to(x.device)
-        pos_emb = self.pe[:, offset:offset + x.size(1)]
+        if offset is None:
+            offset = torch.zeros(x.size(0), dtype=torch.int32).to(x.device)
+        index = offset.unsqueeze(1) + torch.arange(0,
+                                                   x.size(1)).to(offset.device)  # B X T
+        flag = index > 0
+        index = index * flag
+        pos_emb = F.embedding(index, self.pe)  # B X T X d_model
         x = x * self.xscale + pos_emb
         return self.dropout(x), self.dropout(pos_emb)
 
-    def position_encoding(self, offset: int, size: int) -> torch.Tensor:
+    def position_encoding(
+            self,
+            offset: torch.Tensor,
+            size: int) -> torch.Tensor:
         """ For getting encoding in a streaming fashion
 
         Attention!!!!!
@@ -78,8 +88,13 @@ class PositionalEncoding(torch.nn.Module):
         Returns:
             torch.Tensor: Corresponding encoding
         """
-        assert offset + size < self.max_len
-        return self.dropout(self.pe[:, offset:offset + size])
+        self.pe = self.pe.to(offset.device)
+        index = offset.unsqueeze(
+            1) + torch.arange(0, size).to(offset.device)  # B X T
+        flag = index > 0
+        index = index * flag
+        pos_emb = F.embedding(index, self.pe)  # B X T X d_model
+        return self.dropout(pos_emb)
 
 
 class RelPositionalEncoding(PositionalEncoding):
@@ -90,13 +105,15 @@ class RelPositionalEncoding(PositionalEncoding):
         dropout_rate (float): Dropout rate.
         max_len (int): Maximum input length.
     """
+
     def __init__(self, d_model: int, dropout_rate: float, max_len: int = 5000):
         """Initialize class."""
         super().__init__(d_model, dropout_rate, max_len, reverse=True)
 
     def forward(self,
                 x: torch.Tensor,
-                offset: int = 0) -> Tuple[torch.Tensor, torch.Tensor]:
+                offset: torch.Tensor = None) -> Tuple[torch.Tensor,
+                                                      torch.Tensor]:
         """Compute positional encoding.
         Args:
             x (torch.Tensor): Input tensor (batch, time, `*`).
@@ -104,16 +121,23 @@ class RelPositionalEncoding(PositionalEncoding):
             torch.Tensor: Encoded tensor (batch, time, `*`).
             torch.Tensor: Positional embedding tensor (1, time, `*`).
         """
-        assert offset + x.size(1) < self.max_len
+        if offset is None:
+            offset = torch.zeros(x.size(0), dtype=torch.int32).to(x.device)
+
         self.pe = self.pe.to(x.device)
+        index = offset.unsqueeze(1) + torch.arange(0,
+                                                   x.size(1)).to(offset.device)  # B X T
+        flag = index > 0
+        index = index * flag
+        pos_emb = F.embedding(index, self.pe)  # B X T X d_model
         x = x * self.xscale
-        pos_emb = self.pe[:, offset:offset + x.size(1)]
         return self.dropout(x), self.dropout(pos_emb)
 
 
 class NoPositionalEncoding(torch.nn.Module):
     """ No position encoding
     """
+
     def __init__(self, d_model: int, dropout_rate: float):
         super().__init__()
         self.d_model = d_model
@@ -121,11 +145,15 @@ class NoPositionalEncoding(torch.nn.Module):
 
     def forward(self,
                 x: torch.Tensor,
-                offset: int = 0) -> Tuple[torch.Tensor, torch.Tensor]:
+                offset: torch.Tensor = None) -> Tuple[torch.Tensor,
+                                                      torch.Tensor]:
         """ Just return zero vector for interface compatibility
         """
         pos_emb = torch.zeros(1, x.size(1), self.d_model).to(x.device)
         return self.dropout(x), pos_emb
 
-    def position_encoding(self, offset: int, size: int) -> torch.Tensor:
+    def position_encoding(
+            self,
+            offset: torch.Tensor,
+            size: int) -> torch.Tensor:
         return torch.zeros(1, size, self.d_model)

--- a/wenet/transformer/subsampling.py
+++ b/wenet/transformer/subsampling.py
@@ -16,7 +16,7 @@ class BaseSubsampling(torch.nn.Module):
         self.right_context = 0
         self.subsampling_rate = 1
 
-    def position_encoding(self, offset: int, size: int) -> torch.Tensor:
+    def position_encoding(self, offset: torch.Tensor, size: int) -> torch.Tensor:
         return self.pos_enc.position_encoding(offset, size)
 
 
@@ -46,7 +46,7 @@ class LinearNoSubsampling(BaseSubsampling):
             self,
             x: torch.Tensor,
             x_mask: torch.Tensor,
-            offset: int = 0
+            offset: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Input x.
 
@@ -98,7 +98,7 @@ class Conv2dSubsampling4(BaseSubsampling):
             self,
             x: torch.Tensor,
             x_mask: torch.Tensor,
-            offset: int = 0
+            offset: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Subsample x.
 
@@ -151,7 +151,7 @@ class Conv2dSubsampling6(BaseSubsampling):
             self,
             x: torch.Tensor,
             x_mask: torch.Tensor,
-            offset: int = 0
+            offset: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Subsample x.
         Args:
@@ -205,7 +205,7 @@ class Conv2dSubsampling8(BaseSubsampling):
             self,
             x: torch.Tensor,
             x_mask: torch.Tensor,
-            offset: int = 0
+            offset: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Subsample x.
 


### PR DESCRIPTION
Signed-off-by: slyned <slyned@nvidia.com>

1. add offline batch onnx model export for ctc_greedy_search, ctc_prefix_beam_search, attention_rescoring
2. add a ctc prefix beam search adapted from [PaddlePaddle/Deepspeech](https://github.com/PaddlePaddle/DeepSpeech)
3. add onnx run script for testing the three mentioned function

To do:
We need to discuss the interface for encoder and decoder.  I gave an example but feel free to change it.
A perf table on both GPU and CPU is needed.

