### PR TITLE
Add an option to decoder_main for outputting search candidates

### DIFF
--- a/runtime/core/bin/decoder_main.cc
+++ b/runtime/core/bin/decoder_main.cc
@@ -16,7 +16,7 @@
 #include "utils/utils.h"
 
 DEFINE_bool(simulate_streaming, false, "simulate streaming input");
-DEFINE_bool(output_candidates, false, "output CTC candidates");
+DEFINE_bool(output_nbest, false, "output n-best of decode result");
 DEFINE_string(wav_path, "", "single wave path");
 DEFINE_string(wav_scp, "", "input wav scp");
 DEFINE_string(result, "", "result output file");
@@ -108,7 +108,7 @@ int main(int argc, char *argv[]) {
     LOG(INFO) << "Decoded " << wave_dur << "ms audio taken " << decode_time
               << "ms.";
 
-    if (!FLAGS_output_candidates) {
+    if (!FLAGS_output_nbest) {
       buffer << wav.first << " " << final_result << std::endl;
     } else {
       buffer << "wav " << wav.first << std::endl;


### PR DESCRIPTION
* Added option `--output_candidates` to `decoder_main`, which enables printing of all candidates together with their score
e.g.
    > ﻿wav S0001_100016
candidate -3.81529 算了跟你说不清楚你说的这些我都懂当我问的问题你不懂
candidate -3.93011 算了跟你说不清楚你说的这些我都懂但我问的问题你不懂
candidate -4.95558 算啦跟你说不清楚你说的这些我都懂当我问的问题你不懂
candidate -5.0631 算啦跟你说不清楚你说的这些我都懂但我问的问题你不懂
candidate -7.29293 算了跟你说不清楚你说的这些我都懂单我问的问题你不懂
candidate -14.0336 算了跟你说不清楚你说的这些我都懂当我问的问题你不董
candidate -14.7056 算了跟你说不清楚你说的这些我都懂当我问的问题你不等
candidate -16.5955 算了啦跟你说不清楚你说的这些我都懂当我问的问题你不懂
candidate -17.232 算了跟你说不清楚你说的这些我都懂当我问的问题你不
candidate -18.1941 算了跟你说不清楚你说的这些我都懂当我问的问题你不不懂