### PR TITLE
OOM Issue when using dynamic_batching + UIO, and a temporary fix

### DIFF
--- a/wenet/dataset/processor.py
+++ b/wenet/dataset/processor.py
@@ -467,17 +467,20 @@ def dynamic_batch(data, max_frames_in_batch=12000):
         Returns:
             Iterable[List[{key, feat, label}]]
     """
-    total_frames_in_batch = 0
     buf = []
+    longest_frames = 0
     for sample in data:
-        buf.append(sample)
         assert 'feat' in sample
         assert isinstance(sample['feat'], torch.Tensor)
-        total_frames_in_batch += sample['feat'].size(0)
-        if total_frames_in_batch > max_frames_in_batch:
+        new_sample_frames = sample['feat'].size(0)
+        longest_frames = max(longest_frames, new_sample_frames)
+        frames_after_padding = longest_frames * (len(buf) + 1)
+        if frames_after_padding > max_frames_in_batch:
             yield buf
-            buf = []
-            total_frames_in_batch = 0
+            buf = [sample]
+            longest_frames = new_sample_frames
+        else:
+            buf.append(sample)
     if len(buf) > 0:
         yield buf
 


### PR DESCRIPTION
# Issue  
OOM happened when I'm training model using `dynamic_batching` + UIO, even with very small `max_frames_in_batch=4096`, compared with the much larger `max_frames_in_batch=16384` I used before on the same GPU.  
Observed a sudden spiking of GPU Mem usage after a few batches, via monitors like `nvidia-smi` and `nvtop`

# My Debugging Effort  
Adding `print("idle CUDA mem: %.3f, input_shape: %s %s" % (torch.cuda.memory_allocated() / torch.cuda.max_memory_allocated(), feats.shape, target.shape))` to monitor CUDA memory usage and input shape, right after `loss.backward()`. 
Then I got some outputs like this (`max_frames_in_batch=4096`):  

idle CUDA mem: 0.406, input_shape: torch.Size([7, 621, 80]) torch.Size([7, 16])  
idle CUDA mem: 0.371, input_shape: torch.Size([23, 193, 80]) torch.Size([23, 9])  
idle CUDA mem: 0.406, input_shape: torch.Size([6, 754, 80]) torch.Size([6, 35])  
idle CUDA mem: 0.371, input_shape: torch.Size([7, 632, 80]) torch.Size([7, 22])  
idle CUDA mem: 0.406, input_shape: torch.Size([8, 552, 80]) torch.Size([8, 22])  
idle CUDA mem: 0.371, input_shape: torch.Size([5, 884, 80]) torch.Size([5, 37])  
**idle CUDA mem: 0.138, input_shape: torch.Size([20, 1052, 80]) torch.Size([20, 22])**

# My Preliminary Solution
The GPU Mem usage ramps up from time to time then finally hit the limit. Seems the GPU Mem usage increasing is caused by an unreasonable shape of input. 

So I made a simple fix towards this issue via limiting the "size after padding". But I think it's an issue caused by the sorting logic and there should be a better fix.

Here's the output after the fix (`max_frames_in_batch=16384`):
idle CUDA mem: 0.146, input_shape: torch.Size([31, 521, 80]) torch.Size([31, 22])  
idle CUDA mem: 0.163, input_shape: torch.Size([19, 827, 80]) torch.Size([19, 24])  
idle CUDA mem: 0.163, input_shape: torch.Size([43, 377, 80]) torch.Size([43, 20])  
idle CUDA mem: 0.146, input_shape: torch.Size([12, 1290, 80]) torch.Size([12, 78])  
idle CUDA mem: 0.146, input_shape: torch.Size([19, 825, 80]) torch.Size([19, 31])  
idle CUDA mem: 0.163, input_shape: torch.Size([28, 567, 80]) torch.Size([28, 37])  
idle CUDA mem: 0.146, input_shape: torch.Size([56, 290, 80]) torch.Size([56, 11])  
idle CUDA mem: 0.163, input_shape: torch.Size([18, 873, 80]) torch.Size([18, 37])  