### PR TITLE
[examples] wenetspeech uses segments to calculate global_cmvn

### DIFF
--- a/examples/wenetspeech/s0/run.sh
+++ b/examples/wenetspeech/s0/run.sh
@@ -81,11 +81,11 @@ if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
     python tools/segment.py \
       --segments data/$train_set/segments \
       --input data/$train_set/wav.scp \
-      --output data/$train_set/wav.seg.scp
+      --output data/$train_set/wav.segment.scp
     python3 tools/compute_cmvn_stats.py \
     --num_workers 16 \
     --train_config $train_config \
-    --in_scp data/$train_set/wav.seg.scp \
+    --in_scp data/$train_set/wav.segment.scp \
     --out_cmvn data/$train_set/global_cmvn \
     || exit 1;
   fi


### PR DESCRIPTION
* Store segmented training .scp to `wav.segment.scp`
* Remove the warning comment