### PR TITLE
Waveform caching while calculating global_cmvn

### DIFF
--- a/tools/compute_cmvn_stats.py
+++ b/tools/compute_cmvn_stats.py
@@ -49,7 +49,6 @@ class CollateFunc(object):
             if len(value) == 3:
                 start_frame = int(float(value[1]) * sample_rate)
                 end_frame = int(float(value[2]) * sample_rate)
-                # https://pytorch.org/tutorials/beginner/audio_preprocessing_tutorial.html#tips-on-slicing
                 waveform = waveform[:, start_frame: end_frame]
 
             waveform = waveform * (1 << 15)


### PR DESCRIPTION
* Disable DataLoader's shuffle and enlarge DataLoader's batch_size, to keep segments in the same file being processed by the same worker
* Cache the latest waveform for each worker