### PR TITLE
Revert back to calculating global_cmvn with opus, add sampling option

### DIFF
--- a/examples/wenetspeech/s0/run.sh
+++ b/examples/wenetspeech/s0/run.sh
@@ -30,7 +30,7 @@ test_sets="test_net test_meeting"
 train_config=conf/train_conformer.yaml
 checkpoint=
 cmvn=true
-cmvn_sampling_divisor=10 # 10 means 10% of the training data to train cmvn
+cmvn_sampling_divisor=20 # 20 means 5% of the training data to estimate cmvn
 dir=exp/conformer
 
 decode_checkpoint=


### PR DESCRIPTION
* Reverts wenet-e2e/wenet#736, as the efficiency issue can't be fixed without editting cmvn calculating script
* Adding sampling option for calculating global_cmvn to wenetspeech recipe