### PR TITLE
fix recognize's batch type error

### DIFF
--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -133,6 +133,7 @@ def main():
     test_conf['shuffle'] = False
     test_conf['sort'] = False
     test_conf['fbank_conf']['dither'] = 0.0
+    test_conf['batch_conf']['batch_type'] = "static"
     test_conf['batch_conf']['batch_size'] = args.batch_size
 
     test_dataset = Dataset(args.data_type,


### PR DESCRIPTION
When training with dynamic batch size, batch type at decoding will also be set to "dynamic". This may cause assertion error because decoding batch size must be 1.