### PR TITLE
Fix onnx export

### DIFF
--- a/wenet/bin/export_onnx.py
+++ b/wenet/bin/export_onnx.py
@@ -134,7 +134,7 @@ class Decoder(torch.nn.Module):
         score = decoder_out.gather(2, index).squeeze(2)  # B2 X T2
         # mask padded part
         score = score * mask
-        decoder_out = decoder_out.view(B, bz, T2, V) 
+        decoder_out = decoder_out.view(B, bz, T2, V)
         if self.reverse_weight > 0:
             r_decoder_out = torch.nn.functional.log_softmax(r_decoder_out, dim=-1)
             r_decoder_out = r_decoder_out.view(B2, T2, V)
@@ -158,7 +158,7 @@ if __name__ == '__main__':
                         help='global_cmvn file, default path is in config file')
     parser.add_argument('--reverse_weight', default=-1.0, type=float,
                         required=False,
-                        help='reverse weight for bitransformer,' + 
+                        help='reverse weight for bitransformer,' +
                         'default value is in config file')
     parser.add_argument('--ctc_weight', default=-1.0, type=float,
                         required=False,

--- a/wenet/bin/export_onnx.py
+++ b/wenet/bin/export_onnx.py
@@ -321,3 +321,11 @@ if __name__ == '__main__':
     # check encoder output
     test(to_numpy(o0), ort_outs[0], rtol=1e-03, atol=1e-05)
     logger.info("export to onnx decoder succeed!")
+
+    # dump configurations
+    onnx_config = {"beam_size": args.beam_size,
+                   "reverse_weight": args.reverse_weight,
+                   "ctc_weight": args.ctc_weight}
+    config_dir = os.path.join(args.output_onnx_dir, "config.yaml")
+    with open(config_dir, "w") as out:
+        yaml.dump(onnx_config, out)

--- a/wenet/bin/recognize_onnx.py
+++ b/wenet/bin/recognize_onnx.py
@@ -249,7 +249,7 @@ def main():
                     decoder_ort_session.get_inputs()[3].name: hyps_lens_sos,
                     decoder_ort_session.get_inputs()[-1].name: ctc_score}
                 if reverse_weight > 0:
-                    r_hyps_pad_sos_eos_name = decoder_ort_session.get_inputs()[4].name 
+                    r_hyps_pad_sos_eos_name = decoder_ort_session.get_inputs()[4].name
                     decoder_ort_inputs[r_hyps_pad_sos_eos_name] = r_hyps_pad_sos_eos
                 _, _, best_index = decoder_ort_session.run(
                     None, decoder_ort_inputs)

--- a/wenet/bin/recognize_onnx.py
+++ b/wenet/bin/recognize_onnx.py
@@ -251,8 +251,7 @@ def main():
                 if reverse_weight > 0:
                     r_hyps_pad_sos_eos_name = decoder_ort_session.get_inputs()[4].name
                     decoder_ort_inputs[r_hyps_pad_sos_eos_name] = r_hyps_pad_sos_eos
-                _, _, best_index = decoder_ort_session.run(
-                    None, decoder_ort_inputs)
+                best_index = decoder_ort_session.run(None, decoder_ort_inputs)[0]
                 best_sents = []
                 k = 0
                 for idx in best_index:

--- a/wenet/bin/recognize_onnx.py
+++ b/wenet/bin/recognize_onnx.py
@@ -90,15 +90,6 @@ def get_args():
                             'attention_rescoring'],
                         default='attention_rescoring',
                         help='decoding mode')
-    parser.add_argument('--ctc_weight',
-                        type=float,
-                        default=0.0,
-                        help='ctc weight for attention rescoring decode mode')
-    parser.add_argument('--reverse_weight',
-                        type=float,
-                        default=0.0,
-                        help='''right to left weight for attention rescoring
-                                decode mode''')
     parser.add_argument('--bpe_model',
                         default=None,
                         type=str,
@@ -124,9 +115,9 @@ def main():
     if len(args.override_config) > 0:
         configs = override_config(configs, args.override_config)
 
+    reverse_weight = configs["model_conf"].get("reverse_weight", 0.0)
     symbol_table = read_symbol_table(args.dict)
     test_conf = copy.deepcopy(configs['dataset_conf'])
-
     test_conf['filter_conf']['max_length'] = 102400
     test_conf['filter_conf']['min_length'] = 0
     test_conf['filter_conf']['token_max_length'] = 102400
@@ -229,56 +220,43 @@ def main():
                     cur_len = len(hyps)
                     if len(hyps) < beam_size:
                         hyps += (beam_size - cur_len) * [(-float("INF"), (0,))]
+                    cur_ctc_score = []
                     for hyp in hyps:
-                        ctc_score.append(hyp[0])
+                        cur_ctc_score.append(hyp[0])
                         all_hyps.append(list(hyp[1]))
-                        if len(hyp[1]) + 1 > max_len:
-                            max_len = len(hyp[1]) + 1
-                assert len(ctc_score) == beam_size * batch_size
-                hyps_pad_sos = np.ones(
-                    (batch_size, beam_size, max_len), dtype=np.int64) * IGNORE_ID
-                r_hyps_pad_sos = np.ones(
-                    (batch_size, beam_size, max_len), dtype=np.int64) * IGNORE_ID
+                        if len(hyp[1]) > max_len:
+                            max_len = len(hyp[1])
+                    ctc_score.append(cur_ctc_score)
+                ctc_score = np.array(ctc_score, dtype=np.float32)
+                hyps_pad_sos_eos = np.ones(
+                    (batch_size, beam_size, max_len + 2), dtype=np.int64) * IGNORE_ID
+                r_hyps_pad_sos_eos = np.ones(
+                    (batch_size, beam_size, max_len + 2), dtype=np.int64) * IGNORE_ID
                 hyps_lens_sos = np.ones((batch_size, beam_size), dtype=np.int32)
                 k = 0
                 for i in range(batch_size):
                     for j in range(beam_size):
                         cand = all_hyps[k]
-                        hyps_pad_sos[i][j][0:len(cand) + 1] = [sos] + cand
-                        r_hyps_pad_sos[i][j][0:len(cand) + 1] = [sos] + cand[::-1]
+                        hyps_pad_sos_eos[i][j][0:len(cand) + 2] = [sos] + cand + [eos]
+                        r_hyps_pad_sos_eos[i][j][0:len(cand) + 2] = [sos] + cand[::-1] + [eos]
                         hyps_lens_sos[i][j] = len(cand) + 1
                         k += 1
                 decoder_ort_inputs = {
                     decoder_ort_session.get_inputs()[0].name: encoder_out,
                     decoder_ort_session.get_inputs()[1].name: encoder_out_lens,
-                    decoder_ort_session.get_inputs()[2].name: hyps_pad_sos,
+                    decoder_ort_session.get_inputs()[2].name: hyps_pad_sos_eos,
                     decoder_ort_session.get_inputs()[3].name: hyps_lens_sos,
-                    decoder_ort_session.get_inputs()[4].name: r_hyps_pad_sos}
-                decoder_out, r_decoder_out = decoder_ort_session.run(
+                    decoder_ort_session.get_inputs()[-1].name: ctc_score}
+                if reverse_weight > 0:
+                    decoder_ort_inputs[decoder_ort_session.get_inputs()[4].name] = r_hyps_pad_sos_eos
+                _, _, best_index = decoder_ort_session.run(
                     None, decoder_ort_inputs)
                 best_sents = []
                 k = 0
-                for d_o, r_d_o in zip(decoder_out, r_decoder_out):
-                    # d_0 & r_d_o: beam x T x V
-                    cur_best_sent = []
-                    cur_best_score = -float("inf")
-                    for sent_d_o, sent_r_d_o in zip(d_o, r_d_o):
-                        cand = all_hyps[k] + [eos]
-                        r_cand = all_hyps[k][::-1] + [eos]
-                        score, r_score = 0, 0
-                        for i in range(len(cand)):
-                            index, r_index = cand[i], r_cand[i]
-                            score += sent_d_o[i][index]
-                            r_score += sent_r_d_o[i][r_index]
-                        if args.reverse_weight > 0:
-                            score = score * (1 - args.reverse_weight) + \
-                                args.reverse_weight * r_score
-                        score = score + args.ctc_weight * ctc_score[k]
-                        if score > cur_best_score:
-                            cur_best_sent = all_hyps[k]
-                            cur_best_score = score
-                        k += 1
+                for idx in best_index:
+                    cur_best_sent = all_hyps[k: k + beam_size][idx]
                     best_sents.append(cur_best_sent)
+                    k += beam_size
                 hyps = map_batch(best_sents, vocabulary, num_processes)
 
             for i, key in enumerate(keys):

--- a/wenet/bin/recognize_onnx.py
+++ b/wenet/bin/recognize_onnx.py
@@ -237,8 +237,9 @@ def main():
                 for i in range(batch_size):
                     for j in range(beam_size):
                         cand = all_hyps[k]
-                        hyps_pad_sos_eos[i][j][0:len(cand) + 2] = [sos] + cand + [eos]
-                        r_hyps_pad_sos_eos[i][j][0:len(cand) + 2] = [sos] + cand[::-1] + [eos]
+                        l = len(cand) + 2
+                        hyps_pad_sos_eos[i][j][0:l] = [sos] + cand + [eos]
+                        r_hyps_pad_sos_eos[i][j][0:l] = [sos] + cand[::-1] + [eos]
                         hyps_lens_sos[i][j] = len(cand) + 1
                         k += 1
                 decoder_ort_inputs = {
@@ -248,7 +249,8 @@ def main():
                     decoder_ort_session.get_inputs()[3].name: hyps_lens_sos,
                     decoder_ort_session.get_inputs()[-1].name: ctc_score}
                 if reverse_weight > 0:
-                    decoder_ort_inputs[decoder_ort_session.get_inputs()[4].name] = r_hyps_pad_sos_eos
+                    r_hyps_pad_sos_eos_name = decoder_ort_session.get_inputs()[4].name 
+                    decoder_ort_inputs[r_hyps_pad_sos_eos_name] = r_hyps_pad_sos_eos
                 _, _, best_index = decoder_ort_session.run(
                     None, decoder_ort_inputs)
                 best_sents = []


### PR DESCRIPTION
1. Fix model with only left to right decoder.
2. Add scoring function to rescore decoder.
3. Add cmvn_file option to export_onnx.py so that users don't need edit cmvn path in train.yaml.
3. Tested pretrained models in wenetspeech (2 models) and aishell2 (4 models).
4. The accuracy of pretrained models in wenetspeech seems better than the official published ones. (~0.06 cer better)
5. Found 'constant-folding' warning will only appear in models with 'causal:True'.
6. Found the dataset configs in aishell2 last three pretrained models (u2_transformer, unified_conformer, unified_transformer) are old ones. 
7. Found no cmvn file in 20211025_conformer_bidecoder_exp.tar.gz