### PR TITLE
[src] Add Fp16 grad sync for ddp

### DIFF
--- a/wenet/bin/train.py
+++ b/wenet/bin/train.py
@@ -84,6 +84,10 @@ def get_args():
                         action='store_true',
                         default=False,
                         help='Use automatic mixed precision training')
+    parser.add_argument('--fp16_grad_sync',
+                        action='store_true',
+                        default=False,
+                        help='Use fp16 gradient sync for ddp')
     parser.add_argument('--cmvn', default=None, help='global cmvn file')
     parser.add_argument('--symbol_table',
                         required=True,
@@ -204,6 +208,13 @@ def main():
         model = torch.nn.parallel.DistributedDataParallel(
             model, find_unused_parameters=True)
         device = torch.device("cuda")
+        if args.fp16_grad_sync:
+            from torch.distributed.algorithms.ddp_comm_hooks import (
+                default as comm_hooks,
+            )
+            model.register_comm_hook(
+                state=None,hook=comm_hooks.fp16_compress_hook
+            )
     else:
         use_cuda = args.gpu >= 0 and torch.cuda.is_available()
         device = torch.device('cuda' if use_cuda else 'cpu')

--- a/wenet/bin/train.py
+++ b/wenet/bin/train.py
@@ -213,7 +213,7 @@ def main():
                 default as comm_hooks,
             )
             model.register_comm_hook(
-                state=None,hook=comm_hooks.fp16_compress_hook
+                state=None, hook=comm_hooks.fp16_compress_hook
             )
     else:
         use_cuda = args.gpu >= 0 and torch.cuda.is_available()

--- a/wenet/utils/executor.py
+++ b/wenet/utils/executor.py
@@ -26,7 +26,7 @@ class Executor:
         is_distributed = args.get('is_distributed', True)
         use_amp = args.get('use_amp', False)
         logging.info('using accumulate grad, new batch size is {} times'
-                     'larger than before'.format(accum_grad))
+                     ' larger than before'.format(accum_grad))
         if use_amp:
             assert scaler is not None
         # A context manager to be used in conjunction with an instance of


### PR DESCRIPTION
Aishell test Accuracy with fp16_grad_sync enabled:
ctc greedy: 5.09
ctc prefix: 5.09
attention: 4.99
rescore: 4.69
It could improve training speed from 17 hours/100 epochs to 11 hours/100 epochs, especially for multi-nodes training.
My training environment:
two nodes with 6 gpus per node. eth0 Speed: 10000Mb/s