### PR TITLE
add wenetspeech u2++ model perf

### DIFF
--- a/examples/wenetspeech/s0/README.md
+++ b/examples/wenetspeech/s0/README.md
@@ -25,3 +25,19 @@
 |  ctc_greedy_search  | 8.98 |    9.55   |     16.48     |
 |      attention      | 9.42 |   10.57   |     18.05     |
 | attention_rescoring | 8.85 |    9.25   |     16.18     |
+
+## U2++ conformer
+
+* Feature info: using fbank feature, with dither 1.0, with cmvn
+* Training info: lr 0.001, batch size 48, 8 gpus on A100, acc_grad 16, 50 epochs
+* Decoding info: ctc_weight 0.5, reverse_weight 0.3, average_num 10
+* model link: <TO ADD>
+
+| Decoding mode - Chunk size    | Dev  | Test\_Net | Test\_Meeting |
+|:-----------------------------:|:----:|:---------:|:-------------:|
+| ctc greedy search - full      | 8.85 | 9.78      | 17.77         |
+| ctc greedy search - 16        | 9.32 | 11.02     | 18.79         |
+| ctc prefix beam search - full | 8.80 | 9.73      | 17.57         |
+| ctc prefix beam search - 16   | 9.25 | 10.96     | 18.62         |
+| attention rescoring - full    | 8.60 | 9.26      | 17.34         |
+| attention rescoring - 16      | 8.87 | 10.22     | 18.11         |


### PR DESCRIPTION
Signed-off-by: slyned <slyned@nvidia.com>

Add other models' perf as notes
U2 ++  conformer 26 epochs:

| Decoding mode - Chunk size    | Dev  | Test_Net | Test_Meeting |
|-------------------------------|------|----------|--------------|
| ctc greedy search - full      | 9.16 | 10.38    | 17.77        |
| ctc greedy search - 16        | 9.54 | 11.66    | 18.70        |
| ctc prefix beam search - full | 9.09 | 10.33    | 17.59        |
| ctc prefix beam search - 16   | 9.48 | 11.60    | 18.57        |
| attention rescoring - full    | 8.84 | 9.79     | 17.29        |
| attention rescoring - 16      | 9.08 | 10.83    | 18.06        |

ctc_weight: 0.5  reverse_weight: 0.3

Unified conformer(single decoder), 26 epochs:
| Decoding mode - Chunk size    | Dev   | Test_Net | Test_Meeting |
|-------------------------------|-------|----------|--------------|
| ctc greedy search - full      | 9.4   | 10.46    | 18.81        |
| ctc greedy search - 16        | 10.03 | 11.79    | 20.11        |
| ctc prefix beam search - full | 9.33  | 10.42    | 18.61        |
| ctc prefix beam search - 16   | 9.94  | 11.76    | 19.94        |
| attention rescoring - full    | 9.12  | 9.82     | 18.25        |
| attention rescoring - 16      | 9.45  | 10.95    | 19.39        |

ctc_weight: 0.5