### PR TITLE
Handle the context that has not yet the end boundary does not set to start state with negative score

### DIFF
--- a/runtime/core/decoder/ctc_prefix_beam_search.cc
+++ b/runtime/core/decoder/ctc_prefix_beam_search.cc
@@ -186,4 +186,46 @@ void CtcPrefixBeamSearch::Search(const torch::Tensor& logp) {
   }
 }
 
+void CtcPrefixBeamSearch::FinalizeSearch()
+{ 
+  //TODO(luchuanze)
+  UpdateFinalContext();
+}
+
+void CtcPrefixBeamSearch::UpdateFinalContext() {
+  if (context_graph_ == nullptr) return;
+
+  CHECK_EQ(hypotheses_.size(), cur_hyps_.size());
+  CHECK_EQ(hypotheses_.size(), likelihood_.size());
+  // TODO(luchuanze)
+  // The context that has not yet the end boudary does not set to start state
+  // with negative score, so using a word id -1 to udpate the hyps itself at the
+  // end of the search.
+  for (const auto& prefix : hypotheses_) {
+    PrefixScore& prefix_score = cur_hyps_[prefix];
+    prefix_score.UpdateContext(context_graph_, prefix_score, -1, prefix.size());
+  }
+
+  //Resort hyps
+  std::vector<std::pair<std::vector<int>, PrefixScore>> arr(cur_hyps_.begin(),
+                                                              cur_hyps_.end());
+  std::sort(arr.begin(), arr.end(), PrefixScoreCompare);
+
+  //Update cur_hyps_ and get new result
+  cur_hyps_.clear();
+  outputs_.clear();
+  hypotheses_.clear();
+  likelihood_.clear();
+  viterbi_likelihood_.clear();
+  times_.clear();
+  for (auto& item : arr) {
+    cur_hyps_[item.first] = item.second;
+    UpdateOutputs(item);
+    hypotheses_.emplace_back(std::move(item.first));
+    likelihood_.emplace_back(item.second.total_score());
+    viterbi_likelihood_.emplace_back(item.second.viterbi_score());
+    times_.emplace_back(item.second.times());
+  }
+}
+
 }  // namespace wenet

--- a/runtime/core/decoder/ctc_prefix_beam_search.cc
+++ b/runtime/core/decoder/ctc_prefix_beam_search.cc
@@ -194,7 +194,6 @@ void CtcPrefixBeamSearch::UpdateFinalContext() {
   if (context_graph_ == nullptr) return;
   CHECK_EQ(hypotheses_.size(), cur_hyps_.size());
   CHECK_EQ(hypotheses_.size(), likelihood_.size());
-  
   // The context that has not yet the end boudary does not set to start state
   // with negative score, so using a word id -1 to udpate the hyps itself at the
   // end of the search.

--- a/runtime/core/decoder/ctc_prefix_beam_search.cc
+++ b/runtime/core/decoder/ctc_prefix_beam_search.cc
@@ -186,18 +186,15 @@ void CtcPrefixBeamSearch::Search(const torch::Tensor& logp) {
   }
 }
 
-void CtcPrefixBeamSearch::FinalizeSearch()
-{ 
-  //TODO(luchuanze)
+void CtcPrefixBeamSearch::FinalizeSearch(){ 
   UpdateFinalContext();
 }
 
 void CtcPrefixBeamSearch::UpdateFinalContext() {
   if (context_graph_ == nullptr) return;
-
   CHECK_EQ(hypotheses_.size(), cur_hyps_.size());
   CHECK_EQ(hypotheses_.size(), likelihood_.size());
-  // TODO(luchuanze)
+  
   // The context that has not yet the end boudary does not set to start state
   // with negative score, so using a word id -1 to udpate the hyps itself at the
   // end of the search.
@@ -206,12 +203,12 @@ void CtcPrefixBeamSearch::UpdateFinalContext() {
     prefix_score.UpdateContext(context_graph_, prefix_score, -1, prefix.size());
   }
 
-  //Resort hyps
+  // Resort hyps
   std::vector<std::pair<std::vector<int>, PrefixScore>> arr(cur_hyps_.begin(),
                                                               cur_hyps_.end());
   std::sort(arr.begin(), arr.end(), PrefixScoreCompare);
 
-  //Update cur_hyps_ and get new result
+  // Update cur_hyps_ and get new result
   cur_hyps_.clear();
   outputs_.clear();
   hypotheses_.clear();

--- a/runtime/core/decoder/ctc_prefix_beam_search.cc
+++ b/runtime/core/decoder/ctc_prefix_beam_search.cc
@@ -186,7 +186,7 @@ void CtcPrefixBeamSearch::Search(const torch::Tensor& logp) {
   }
 }
 
-void CtcPrefixBeamSearch::FinalizeSearch() { 
+void CtcPrefixBeamSearch::FinalizeSearch() {
   UpdateFinalContext();
 }
 

--- a/runtime/core/decoder/ctc_prefix_beam_search.cc
+++ b/runtime/core/decoder/ctc_prefix_beam_search.cc
@@ -186,7 +186,7 @@ void CtcPrefixBeamSearch::Search(const torch::Tensor& logp) {
   }
 }
 
-void CtcPrefixBeamSearch::FinalizeSearch(){ 
+void CtcPrefixBeamSearch::FinalizeSearch() { 
   UpdateFinalContext();
 }
 

--- a/runtime/core/decoder/ctc_prefix_beam_search.h
+++ b/runtime/core/decoder/ctc_prefix_beam_search.h
@@ -94,10 +94,10 @@ class CtcPrefixBeamSearch : public SearchInterface {
 
   void Search(const torch::Tensor& logp) override;
   void Reset() override;
-  // CtcPrefixBeamSearch do nothing at FinalizeSearch
-  void FinalizeSearch() override {}
+  void FinalizeSearch() override;
   SearchType Type() const override { return SearchType::kPrefixBeamSearch; }
   void UpdateOutputs(const std::pair<std::vector<int>, PrefixScore>& prefix);
+  void UpdateFinalContext();
 
   const std::vector<float>& viterbi_likelihood() const {
     return viterbi_likelihood_;


### PR DESCRIPTION
Handle the context that has not yet the end boundary does not set to start state with negative score at the end of ctc prefix search at the end of ctc prefix search.
See the issue #864.