### PR TITLE
change layer norm to use default eps

### DIFF
--- a/wenet/transformer/decoder.py
+++ b/wenet/transformer/decoder.py
@@ -63,7 +63,7 @@ class TransformerDecoder(torch.nn.Module):
             raise ValueError(f"only 'embed' is supported: {input_layer}")
 
         self.normalize_before = normalize_before
-        self.after_norm = torch.nn.LayerNorm(attention_dim, eps=1e-12)
+        self.after_norm = torch.nn.LayerNorm(attention_dim, eps=1e-5)
         self.use_output_layer = use_output_layer
         self.output_layer = torch.nn.Linear(attention_dim, vocab_size)
         self.num_blocks = num_blocks

--- a/wenet/transformer/decoder_layer.py
+++ b/wenet/transformer/decoder_layer.py
@@ -46,9 +46,9 @@ class DecoderLayer(nn.Module):
         self.self_attn = self_attn
         self.src_attn = src_attn
         self.feed_forward = feed_forward
-        self.norm1 = nn.LayerNorm(size, eps=1e-12)
-        self.norm2 = nn.LayerNorm(size, eps=1e-12)
-        self.norm3 = nn.LayerNorm(size, eps=1e-12)
+        self.norm1 = nn.LayerNorm(size, eps=1e-5)
+        self.norm2 = nn.LayerNorm(size, eps=1e-5)
+        self.norm3 = nn.LayerNorm(size, eps=1e-5)
         self.dropout = nn.Dropout(dropout_rate)
         self.normalize_before = normalize_before
         self.concat_after = concat_after

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -112,7 +112,7 @@ class BaseEncoder(torch.nn.Module):
         )
 
         self.normalize_before = normalize_before
-        self.after_norm = torch.nn.LayerNorm(output_size, eps=1e-12)
+        self.after_norm = torch.nn.LayerNorm(output_size, eps=1e-5)
         self.static_chunk_size = static_chunk_size
         self.use_dynamic_chunk = use_dynamic_chunk
         self.use_dynamic_left_chunk = use_dynamic_left_chunk

--- a/wenet/transformer/encoder_layer.py
+++ b/wenet/transformer/encoder_layer.py
@@ -44,8 +44,8 @@ class TransformerEncoderLayer(nn.Module):
         super().__init__()
         self.self_attn = self_attn
         self.feed_forward = feed_forward
-        self.norm1 = nn.LayerNorm(size, eps=1e-12)
-        self.norm2 = nn.LayerNorm(size, eps=1e-12)
+        self.norm1 = nn.LayerNorm(size, eps=1e-5)
+        self.norm2 = nn.LayerNorm(size, eps=1e-5)
         self.dropout = nn.Dropout(dropout_rate)
         self.size = size
         self.normalize_before = normalize_before
@@ -158,18 +158,18 @@ class ConformerEncoderLayer(nn.Module):
         self.feed_forward = feed_forward
         self.feed_forward_macaron = feed_forward_macaron
         self.conv_module = conv_module
-        self.norm_ff = nn.LayerNorm(size, eps=1e-12)  # for the FNN module
-        self.norm_mha = nn.LayerNorm(size, eps=1e-12)  # for the MHA module
+        self.norm_ff = nn.LayerNorm(size, eps=1e-5)  # for the FNN module
+        self.norm_mha = nn.LayerNorm(size, eps=1e-5)  # for the MHA module
         if feed_forward_macaron is not None:
-            self.norm_ff_macaron = nn.LayerNorm(size, eps=1e-12)
+            self.norm_ff_macaron = nn.LayerNorm(size, eps=1e-5)
             self.ff_scale = 0.5
         else:
             self.ff_scale = 1.0
         if self.conv_module is not None:
             self.norm_conv = nn.LayerNorm(size,
-                                          eps=1e-12)  # for the CNN module
+                                          eps=1e-5)  # for the CNN module
             self.norm_final = nn.LayerNorm(
-                size, eps=1e-12)  # for the final output of the block
+                size, eps=1e-5)  # for the final output of the block
         self.dropout = nn.Dropout(dropout_rate)
         self.size = size
         self.normalize_before = normalize_before

--- a/wenet/transformer/subsampling.py
+++ b/wenet/transformer/subsampling.py
@@ -35,7 +35,7 @@ class LinearNoSubsampling(BaseSubsampling):
         super().__init__()
         self.out = torch.nn.Sequential(
             torch.nn.Linear(idim, odim),
-            torch.nn.LayerNorm(odim, eps=1e-12),
+            torch.nn.LayerNorm(odim, eps=1e-5),
             torch.nn.Dropout(dropout_rate),
         )
         self.pos_enc = pos_enc_class


### PR DESCRIPTION
Signed-off-by: slyned <slyned@nvidia.com>

NAN will occur when using model.half() to do inference.
The issue is reported here: https://github.com/pytorch/pytorch/issues/41527

1. Changed all eps=1e-12 to 1e-5 a default value for [torch.nn.functional.layer_norm](https://pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html). 

