### PR TITLE
[runtime] add onnxruntime export and inference

### DIFF
--- a/runtime/core/bin/decoder_main_onnx.cc
+++ b/runtime/core/bin/decoder_main_onnx.cc
@@ -1,0 +1,139 @@
+// Copyright 2020 Mobvoi Inc. All Rights Reserved.
+// Author: binbinzhang@mobvoi.com (Binbin Zhang)
+//         di.wu@mobvoi.com (Di Wu)
+// Copyright 2021 Huya Inc. All Rights Reserved.
+// Author: lizexuan@huya.com (Zexuan Li)
+
+#include <iomanip>
+#include <utility>
+
+#include "torch/script.h"
+
+#include "decoder/params.h"
+#include "frontend/wav.h"
+#include "utils/flags.h"
+#include "utils/log.h"
+#include "utils/string.h"
+#include "utils/timer.h"
+#include "utils/utils.h"
+
+DEFINE_bool(simulate_streaming, false, "simulate streaming input");
+DEFINE_bool(output_nbest, false, "output n-best of decode result");
+DEFINE_string(wav_path, "", "single wave path");
+DEFINE_string(wav_scp, "", "input wav scp");
+DEFINE_string(result, "", "result output file");
+
+int main(int argc, char *argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, false);
+  google::InitGoogleLogging(argv[0]);
+
+  auto decode_config = wenet::InitDecodeOptionsFromFlags();
+  auto feature_config = wenet::InitFeaturePipelineConfigFromFlags();
+  auto decode_resource = wenet::InitDecodeResourceFromFlags();
+
+  if (FLAGS_wav_path.empty() && FLAGS_wav_scp.empty()) {
+    LOG(FATAL) << "Please provide the wave path or the wav scp.";
+  }
+  std::vector<std::pair<std::string, std::string>> waves;
+  if (!FLAGS_wav_path.empty()) {
+    waves.emplace_back(make_pair("test", FLAGS_wav_path));
+  } else {
+    std::ifstream wav_scp(FLAGS_wav_scp);
+    std::string line;
+    while (getline(wav_scp, line)) {
+      std::vector<std::string> strs;
+      wenet::SplitString(line, &strs);
+      CHECK_GE(strs.size(), 2);
+      waves.emplace_back(make_pair(strs[0], strs[1]));
+    }
+  }
+
+  std::ofstream result;
+  if (!FLAGS_result.empty()) {
+    result.open(FLAGS_result, std::ios::out);
+  }
+  std::ostream &buffer = FLAGS_result.empty() ? std::cout : result;
+
+  int total_waves_dur = 0;
+  int total_decode_time = 0;
+  for (auto &wav : waves) {
+    wenet::WavReader wav_reader(wav.second);
+    CHECK_EQ(wav_reader.sample_rate(), FLAGS_sample_rate);
+
+    auto feature_pipeline =
+        std::make_shared<wenet::FeaturePipeline>(*feature_config);
+    feature_pipeline->AcceptWaveform(std::vector<float>(
+        wav_reader.data(), wav_reader.data() + wav_reader.num_sample()));
+    feature_pipeline->set_input_finished();
+    LOG(INFO) << "num frames " << feature_pipeline->num_frames();
+
+    wenet::OnnxAsrDecoder decoder(feature_pipeline, decode_resource,
+                                   *decode_config);
+
+    int wave_dur =
+        static_cast<int>(static_cast<float>(wav_reader.num_sample()) /
+                         wav_reader.sample_rate() * 1000);
+    int decode_time = 0;
+    std::string final_result;
+    while (true) {
+      wenet::Timer timer;
+      wenet::DecodeState state = decoder.Decode();
+      if (state == wenet::DecodeState::kEndFeats) {
+        decoder.Rescoring();
+      }
+      int chunk_decode_time = timer.Elapsed();
+      decode_time += chunk_decode_time;
+      if (decoder.DecodedSomething()) {
+        LOG(INFO) << "Partial result: " << decoder.result()[0].sentence;
+      }
+
+      if (state == wenet::DecodeState::kEndpoint) {
+        decoder.Rescoring();
+        final_result.append(decoder.result()[0].sentence);
+        decoder.ResetContinuousDecoding();
+      }
+
+      if (state == wenet::DecodeState::kEndFeats) {
+        break;
+      } else if (FLAGS_chunk_size > 0 && FLAGS_simulate_streaming) {
+        float frame_shift_in_ms =
+            static_cast<float>(feature_config->frame_shift) /
+            wav_reader.sample_rate() * 1000;
+        auto wait_time =
+            decoder.num_frames_in_current_chunk() * frame_shift_in_ms -
+            chunk_decode_time;
+        if (wait_time > 0) {
+          LOG(INFO) << "Simulate streaming, waiting for " << wait_time << "ms";
+          std::this_thread::sleep_for(
+              std::chrono::milliseconds(static_cast<int>(wait_time)));
+        }
+      }
+    }
+    if (decoder.DecodedSomething()) {
+      final_result.append(decoder.result()[0].sentence);
+    }
+    LOG(INFO) << wav.first << " Final result: " << final_result << std::endl;
+    LOG(INFO) << "Decoded " << wave_dur << "ms audio taken " << decode_time
+              << "ms.";
+
+    if (!FLAGS_output_nbest) {
+      buffer << wav.first << " " << final_result << std::endl;
+    } else {
+      buffer << "wav " << wav.first << std::endl;
+      auto &results = decoder.result();
+      for (auto &r : results) {
+        if (r.sentence.empty())
+          continue;
+        buffer << "candidate " << r.score << " " << r.sentence << std::endl;
+      }
+    }
+
+    total_waves_dur += wave_dur;
+    total_decode_time += decode_time;
+  }
+  LOG(INFO) << "Total: decoded " << total_waves_dur << "ms audio taken "
+            << total_decode_time << "ms.";
+  LOG(INFO) << "RTF: " << std::setprecision(4)
+            << static_cast<float>(total_decode_time) / total_waves_dur;
+  return 0;
+}

--- a/runtime/core/decoder/onnx_asr_decoder.cc
+++ b/runtime/core/decoder/onnx_asr_decoder.cc
@@ -1,0 +1,437 @@
+// Copyright 2020 Mobvoi Inc. All Rights Reserved.
+// Author: binbinzhang@mobvoi.com (Binbin Zhang)
+//         di.wu@mobvoi.com (Di Wu)
+// Copyright 2021 Huya Inc. All Rights Reserved.
+// Author: lizexuan@huya.com (Zexuan Li)
+
+#include "decoder/onnx_asr_decoder.h"
+
+#include <ctype.h>
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+#include "decoder/ctc_endpoint.h"
+#include "utils/timer.h"
+
+namespace wenet {
+
+OnnxAsrDecoder::OnnxAsrDecoder(
+    std::shared_ptr<FeaturePipeline> feature_pipeline,
+    std::shared_ptr<DecodeResource> resource, const DecodeOptions& opts)
+    : feature_pipeline_(std::move(feature_pipeline)),
+      model_(resource->onnx_model),
+      post_processor_(resource->post_processor),
+      symbol_table_(resource->symbol_table),
+      fst_(resource->fst),
+      unit_table_(resource->unit_table),
+      opts_(opts),
+      ctc_endpointer_(new CtcEndpoint(opts.ctc_endpoint_config)) {
+  if (opts_.reverse_weight > 0) {
+    // Check if model has a right to left decoder
+    CHECK(model_->is_bidirectional_decoder());
+  }
+  if (nullptr == fst_) {
+    searcher_.reset(new CtcPrefixBeamSearch(opts.ctc_prefix_search_opts,
+                                            resource->context_graph));
+  } else {
+    searcher_.reset(new CtcWfstBeamSearch(*fst_, opts.ctc_wfst_search_opts,
+                                          resource->context_graph));
+  }
+  ctc_endpointer_->frame_shift_in_ms(frame_shift_in_ms());
+  OnnxReset();
+}
+
+void OnnxAsrDecoder::Reset() {
+  start_ = false;
+  result_.clear();
+  offset_ = 1;
+  num_frames_ = 0;
+  global_frame_offset_ = 0;
+  num_frames_in_current_chunk_ = 0;
+  OnnxReset();
+  cached_feature_.clear();
+  searcher_->Reset();
+  feature_pipeline_->Reset();
+  ctc_endpointer_->Reset();
+}
+
+void OnnxAsrDecoder::ResetContinuousDecoding() {
+  global_frame_offset_ = num_frames_;
+  start_ = false;
+  result_.clear();
+  offset_ = 0;
+  num_frames_in_current_chunk_ = 0;
+  OnnxReset();
+  cached_feature_.clear();
+  searcher_->Reset();
+  ctc_endpointer_->Reset();
+}
+
+void OnnxAsrDecoder::OnnxReset() {
+  int encoder_output_size = model_->encoder_output_size();
+  int num_blocks = model_->num_blocks();
+  int cnn_module_kernel = model_->cnn_module_kernel();
+
+  subsampling_cache_.resize(encoder_output_size);
+  const int64_t subsampling_cache_shape[] = {1, 1, encoder_output_size};
+
+  elayers_output_cache_.resize(encoder_output_size * num_blocks);
+  const int64_t elayers_output_cache_shape[] = {num_blocks, 1, 1,
+                                                encoder_output_size};
+
+  conformer_cnn_cache_.resize(num_blocks * encoder_output_size *
+                              cnn_module_kernel);
+  const int64_t conformer_cnn_cache_shape[] = {
+      num_blocks, 1, encoder_output_size, cnn_module_kernel};
+
+  subsampling_cache_ort_ = Ort::Value::CreateTensor<float>(
+      memory_info_, subsampling_cache_.data(), subsampling_cache_.size(),
+      subsampling_cache_shape, 3);
+  elayers_output_cache_ort_ = Ort::Value::CreateTensor<float>(
+      memory_info_, elayers_output_cache_.data(), elayers_output_cache_.size(),
+      elayers_output_cache_shape, 4);
+  conformer_cnn_cache_ort_ = Ort::Value::CreateTensor<float>(
+      memory_info_, conformer_cnn_cache_.data(), conformer_cnn_cache_.size(),
+      conformer_cnn_cache_shape, 4);
+
+  encoder_outs_ort_.clear();
+}
+
+DecodeState OnnxAsrDecoder::Decode() { return this->AdvanceDecoding(); }
+
+void OnnxAsrDecoder::Rescoring() {
+  // Do attention rescoring
+  Timer timer;
+  AttentionRescoring();
+  LOG(INFO) << "Rescoring cost latency: " << timer.Elapsed() << "ms.";
+}
+
+DecodeState OnnxAsrDecoder::AdvanceDecoding() {
+  DecodeState state = DecodeState::kEndBatch;
+  const int subsampling_rate = model_->subsampling_rate();
+  const int right_context = model_->right_context();
+  const int cached_feature_size = 1 + right_context - subsampling_rate;
+  const int feature_dim = feature_pipeline_->feature_dim();
+  int num_requried_frames = 0;
+  // If opts_.chunk_size > 0, streaming case, read feature chunk by chunk
+  // otherwise, none streaming case, read all feature at once
+  if (opts_.chunk_size > 0) {
+    if (!start_) {                      // First batch
+      int context = right_context + 1;  // Add current frame
+      num_requried_frames = (opts_.chunk_size - 1) * subsampling_rate + context;
+    } else {
+      num_requried_frames = opts_.chunk_size * subsampling_rate;
+    }
+  } else {
+    num_requried_frames = std::numeric_limits<int>::max();
+  }
+  std::vector<std::vector<float>> chunk_feats;
+  // If not okay, that means we reach the end of the input
+  if (!feature_pipeline_->Read(num_requried_frames, &chunk_feats)) {
+    state = DecodeState::kEndFeats;
+  }
+
+  num_frames_in_current_chunk_ = chunk_feats.size();
+  num_frames_ += chunk_feats.size();
+  LOG(INFO) << "Required " << num_requried_frames << " get "
+            << chunk_feats.size();
+  int num_frames = cached_feature_.size() + chunk_feats.size();
+  // The total frames should be big enough to get just one output
+  if (num_frames >= right_context + 1) {
+    std::vector<float> model_input;
+    for (size_t i = 0; i < cached_feature_.size(); ++i) {
+      for (int j = 0; j < feature_dim; j++) {
+        model_input.emplace_back(cached_feature_[i][j]);
+      }
+    }
+    for (size_t i = 0; i < chunk_feats.size(); ++i) {
+      for (int j = 0; j < feature_dim; j++) {
+        model_input.emplace_back(chunk_feats[i][j]);
+      }
+    }
+
+    Timer timer;
+    std::vector<int64_t> offset{offset_};
+    const int64_t offset_shape[1] = {1};
+    int requried_cache_size = opts_.chunk_size * opts_.num_left_chunks;
+    std::vector<int64_t> requried_cache_size_vec{requried_cache_size};
+    const int64_t requried_cache_size_shape[1] = {1};
+
+    const int64_t input_shape[3] = {1, num_frames, feature_dim};
+
+    Ort::Value input_tensor = Ort::Value::CreateTensor<float>(
+        memory_info_, model_input.data(), model_input.size(), input_shape, 3);
+    Ort::Value offset_tensor = Ort::Value::CreateTensor<int64_t>(
+        memory_info_, offset.data(), 1, offset_shape, 1);
+    Ort::Value requried_cache_size_tensor = Ort::Value::CreateTensor<int64_t>(
+        memory_info_, requried_cache_size_vec.data(), 1,
+        requried_cache_size_shape, 1);
+    std::vector<Ort::Value> tensors;
+    tensors.emplace_back(std::move(input_tensor));
+    tensors.emplace_back(std::move(offset_tensor));
+    tensors.emplace_back(std::move(requried_cache_size_tensor));
+    tensors.emplace_back(std::move(subsampling_cache_ort_));
+    tensors.emplace_back(std::move(elayers_output_cache_ort_));
+    tensors.emplace_back(std::move(conformer_cnn_cache_ort_));
+
+    std::vector<Ort::Value> ort_outputs =
+        model_->encoder_session()->Run(Ort::RunOptions{nullptr}, input_names_,
+                                       tensors.data(), 6, output_names_, 4);
+
+    offset_ += ort_outputs[0].GetTensorTypeAndShapeInfo().GetShape()[1];
+    subsampling_cache_ort_ = std::move(ort_outputs[1]);
+    elayers_output_cache_ort_ = std::move(ort_outputs[2]);
+    conformer_cnn_cache_ort_ = std::move(ort_outputs[3]);
+
+    std::vector<Ort::Value> ctc_tensors;
+    ctc_tensors.emplace_back(std::move(ort_outputs[0]));
+
+    std::vector<Ort::Value> ctc_ort_outputs =
+        model_->ctc_session()->Run(Ort::RunOptions{nullptr}, ctc_input_names_,
+                                   ctc_tensors.data(), 1, ctc_output_names_, 1);
+    encoder_outs_ort_.push_back(std::move(ctc_tensors[0]));
+
+    float* logp_data = ctc_ort_outputs[0].GetTensorMutableData<float>();
+    auto type_info = ctc_ort_outputs[0].GetTensorTypeAndShapeInfo();
+
+    int num_subsampling_frame = type_info.GetShape()[1];
+    int num_probability = type_info.GetShape()[2];
+
+    std::vector<std::vector<float>> ctc_log_probs_vec;
+
+    for (size_t t = 0; t < num_subsampling_frame; ++t) {
+      std::vector<float> logp_t(
+          logp_data + t * num_probability,
+          logp_data + t * num_probability + num_probability);
+      ctc_log_probs_vec.emplace_back(logp_t);
+    }
+
+    torch::Tensor ctc_log_probs =
+        torch::zeros({num_subsampling_frame, num_probability}, torch::kFloat);
+
+    for (size_t t = 0; t < num_subsampling_frame; ++t) {
+      torch::Tensor row = torch::from_blob(ctc_log_probs_vec[t].data(),
+                                           {num_probability}, torch::kFloat);
+      ctc_log_probs[t] = std::move(row);
+    }
+
+    int forward_time = timer.Elapsed();
+    timer.Reset();
+    searcher_->Search(ctc_log_probs);
+    int search_time = timer.Elapsed();
+    VLOG(3) << "forward takes " << forward_time << " ms, search takes "
+            << search_time << " ms";
+    UpdateResult();
+
+    if (ctc_endpointer_->IsEndpoint(ctc_log_probs, DecodedSomething())) {
+      LOG(INFO) << "Endpoint is detected at " << num_frames_;
+      state = DecodeState::kEndpoint;
+    }
+
+    // 3. Cache feature for next chunk
+    if (state == DecodeState::kEndBatch) {
+      // TODO(Binbin Zhang): Only deal the case when
+      // chunk_feats.size() > cached_feature_size_ here, and it's consistent
+      // with our current model, refine it later if we have new model or
+      // new requirements
+      CHECK(chunk_feats.size() >= cached_feature_size);
+      cached_feature_.resize(cached_feature_size);
+      for (int i = 0; i < cached_feature_size; ++i) {
+        cached_feature_[i] = std::move(
+            chunk_feats[chunk_feats.size() - cached_feature_size + i]);
+      }
+    }
+  }
+
+  start_ = true;
+  return state;
+}
+
+void OnnxAsrDecoder::UpdateResult(bool finish) {
+  const auto& hypotheses = searcher_->Outputs();
+  const auto& inputs = searcher_->Inputs();
+  const auto& likelihood = searcher_->Likelihood();
+  const auto& times = searcher_->Times();
+  result_.clear();
+
+  CHECK_EQ(hypotheses.size(), likelihood.size());
+  for (size_t i = 0; i < hypotheses.size(); i++) {
+    const std::vector<int>& hypothesis = hypotheses[i];
+
+    DecodeResult path;
+    path.score = likelihood[i];
+    int offset = global_frame_offset_ * feature_frame_shift_in_ms();
+    for (size_t j = 0; j < hypothesis.size(); j++) {
+      std::string word = symbol_table_->Find(hypothesis[j]);
+      // A detailed explanation of this if-else branch can be found in
+      // https://github.com/wenet-e2e/wenet/issues/583#issuecomment-907994058
+      if (searcher_->Type() == kWfstBeamSearch) {
+        path.sentence += (' ' + word);
+      } else {
+        path.sentence += (word);
+      }
+    }
+
+    // TimeStamp is only supported in final result
+    // TimeStamp of the output of CtcWfstBeamSearch may be inaccurate due to
+    // various FST operations when building the decoding graph. So here we use
+    // time stamp of the input(e2e model unit), which is more accurate, and it
+    // requires the symbol table of the e2e model used in training.
+    if (unit_table_ != nullptr && finish) {
+      const std::vector<int>& input = inputs[i];
+      const std::vector<int>& time_stamp = times[i];
+      CHECK_EQ(input.size(), time_stamp.size());
+      for (size_t j = 0; j < input.size(); j++) {
+        std::string word = unit_table_->Find(input[j]);
+        int start = j > 0 ? ((time_stamp[j - 1] + time_stamp[j]) / 2 *
+                             frame_shift_in_ms())
+                          : 0;
+        int end = j < input.size() - 1 ? ((time_stamp[j] + time_stamp[j + 1]) /
+                                          2 * frame_shift_in_ms())
+                                       : offset_ * frame_shift_in_ms();
+        WordPiece word_piece(word, offset + start, offset + end);
+        path.word_pieces.emplace_back(word_piece);
+      }
+    }
+    path.sentence = post_processor_->Process(path.sentence, finish);
+    result_.emplace_back(path);
+  }
+
+  if (DecodedSomething()) {
+    VLOG(1) << "Partial CTC result " << result_[0].sentence;
+  }
+}
+
+float OnnxAsrDecoder::AttentionDecoderScore(const float* prob,
+                                            const std::vector<int>& hyp,
+                                            int eos, int decode_out_len) {
+  float score = 0.0f;
+  for (size_t j = 0; j < hyp.size(); ++j) {
+    score += *(prob + j * decode_out_len + hyp[j]);
+  }
+  score += *(prob + hyp.size() * decode_out_len + eos);
+  return score;
+}
+
+void OnnxAsrDecoder::AttentionRescoring() {
+  searcher_->FinalizeSearch();
+  UpdateResult(true);
+  // No need to do rescoring
+  if (0.0 == opts_.rescoring_weight) {
+    return;
+  }
+
+  // No encoder output
+  if (encoder_outs_ort_.size() == 0) {
+    return;
+  }
+
+  int sos = model_->sos();
+  int eos = model_->eos();
+
+  const auto& hypotheses = searcher_->Inputs();
+
+  int num_hyps = hypotheses.size();
+  if (num_hyps <= 0) {
+    return;
+  }
+
+  std::vector<int64_t> hyps_lens;
+  int max_hyps_len = 0;
+  for (size_t i = 0; i < num_hyps; ++i) {
+    int length = hypotheses[i].size() + 1;
+    max_hyps_len = std::max(length, max_hyps_len);
+    hyps_lens.emplace_back(static_cast<int64_t>(length));
+  }
+
+  std::vector<float> rescore_input;
+  int encoder_len = 0;
+  for (int i = 0; i < encoder_outs_ort_.size(); i++) {
+    float* encoder_outs_data =
+        encoder_outs_ort_[i].GetTensorMutableData<float>();
+    auto type_info = encoder_outs_ort_[i].GetTensorTypeAndShapeInfo();
+    for (int j = 0; j < type_info.GetElementCount(); j++) {
+      rescore_input.emplace_back(encoder_outs_data[j]);
+    }
+    encoder_len += type_info.GetShape()[1];
+  }
+
+  int encoder_output_size = model_->encoder_output_size();
+  const int64_t decode_input_shape[] = {1, encoder_len, encoder_output_size};
+
+  std::vector<int64_t> hyps_pad;
+
+  for (size_t i = 0; i < num_hyps; ++i) {
+    const std::vector<int>& hyp = hypotheses[i];
+    hyps_pad.emplace_back(sos);
+    size_t j = 0;
+    for (; j < hyp.size(); ++j) {
+      hyps_pad.emplace_back(hyp[j]);
+    }
+    if (j == max_hyps_len - 1) {
+      continue;
+    }
+    for (; j < max_hyps_len - 1; ++j) {
+      hyps_pad.emplace_back(0);
+    }
+  }
+
+  const int64_t hyps_pad_shape[] = {num_hyps, max_hyps_len};
+
+  const int64_t hyps_lens_shape[] = {num_hyps};
+
+  Ort::Value decode_input_tensor_ = Ort::Value::CreateTensor<float>(
+      memory_info_, rescore_input.data(), rescore_input.size(),
+      decode_input_shape, 3);
+  Ort::Value hyps_pad_tensor_ = Ort::Value::CreateTensor<int64_t>(
+      memory_info_, hyps_pad.data(), hyps_pad.size(), hyps_pad_shape, 2);
+  Ort::Value hyps_lens_tensor_ = Ort::Value::CreateTensor<int64_t>(
+      memory_info_, hyps_lens.data(), hyps_lens.size(), hyps_lens_shape, 1);
+
+  std::vector<Ort::Value> rescore_tensors;
+
+  rescore_tensors.emplace_back(std::move(hyps_pad_tensor_));
+  rescore_tensors.emplace_back(std::move(hyps_lens_tensor_));
+  rescore_tensors.emplace_back(std::move(decode_input_tensor_));
+
+  std::vector<Ort::Value> rescore_outputs = model_->rescore_session()->Run(
+      Ort::RunOptions{nullptr}, decode_input_names_, rescore_tensors.data(),
+      rescore_tensors.size(), decode_output_names_, 2);
+
+  float* decoder_outs_data = rescore_outputs[0].GetTensorMutableData<float>();
+  float* r_decoder_outs_data = rescore_outputs[1].GetTensorMutableData<float>();
+
+  auto type_info = rescore_outputs[0].GetTensorTypeAndShapeInfo();
+  int decode_out_len = type_info.GetShape()[2];
+
+  for (size_t i = 0; i < num_hyps; ++i) {
+    const std::vector<int>& hyp = hypotheses[i];
+    float score = 0.0f;
+    // left to right decoder score
+    score = AttentionDecoderScore(
+        decoder_outs_data + max_hyps_len * decode_out_len * i, hyp, eos,
+        decode_out_len);
+    // Optional: Used for right to left score
+    float r_score = 0.0f;
+    if (opts_.reverse_weight > 0) {
+      std::vector<int> r_hyp(hyp.size());
+      std::reverse_copy(hyp.begin(), hyp.end(), r_hyp.begin());
+      // right to left decoder score
+      r_score = AttentionDecoderScore(
+          r_decoder_outs_data + max_hyps_len * decode_out_len * i, r_hyp, eos,
+          decode_out_len);
+    }
+    // combined reverse attention score
+    score =
+        (score * (1 - opts_.reverse_weight)) + (r_score * opts_.reverse_weight);
+    // combined ctc score
+    result_[i].score =
+        opts_.rescoring_weight * score + opts_.ctc_weight * result_[i].score;
+  }
+
+  std::sort(result_.begin(), result_.end(), DecodeResult::CompareFunc);
+}
+
+}  // namespace wenet

--- a/runtime/core/decoder/onnx_asr_decoder.cc
+++ b/runtime/core/decoder/onnx_asr_decoder.cc
@@ -4,14 +4,14 @@
 // Copyright 2021 Huya Inc. All Rights Reserved.
 // Author: lizexuan@huya.com (Zexuan Li)
 
-#include "decoder/onnx_asr_decoder.h"
-
 #include <ctype.h>
-
+#include <memory>
 #include <algorithm>
 #include <limits>
 #include <utility>
-
+#include <string>
+#include <vector>
+#include "decoder/onnx_asr_decoder.h"
 #include "decoder/ctc_endpoint.h"
 #include "utils/timer.h"
 

--- a/runtime/core/decoder/onnx_asr_decoder.h
+++ b/runtime/core/decoder/onnx_asr_decoder.h
@@ -1,0 +1,103 @@
+// Copyright 2020 Mobvoi Inc. All Rights Reserved.
+// Author: binbinzhang@mobvoi.com (Binbin Zhang)
+//         di.wu@mobvoi.com (Di Wu)
+// Copyright 2021 Huya Inc. All Rights Reserved.
+// Author: lizexuan@huya.com (Zexuan Li)
+
+#ifndef DECODER_ONNX_ASR_DECODER_H_
+#define DECODER_ONNX_ASR_DECODER_H_
+
+#include "decoder/torch_asr_decoder.h"
+
+namespace wenet {
+
+// Onnx ASR decoder
+class OnnxAsrDecoder {
+ public:
+  OnnxAsrDecoder(std::shared_ptr<FeaturePipeline> feature_pipeline,
+                 std::shared_ptr<DecodeResource> resource,
+                 const DecodeOptions& opts);
+
+  DecodeState Decode();
+  void Rescoring();
+  void Reset();
+  void ResetContinuousDecoding();
+  bool DecodedSomething() const {
+    return !result_.empty() && !result_[0].sentence.empty();
+  }
+
+  // This method is used for time benchmark
+  int num_frames_in_current_chunk() const {
+    return num_frames_in_current_chunk_;
+  }
+  int frame_shift_in_ms() const {
+    return model_->subsampling_rate() *
+           feature_pipeline_->config().frame_shift * 1000 /
+           feature_pipeline_->config().sample_rate;
+  }
+  int feature_frame_shift_in_ms() const {
+    return feature_pipeline_->config().frame_shift * 1000 /
+           feature_pipeline_->config().sample_rate;
+  }
+  const std::vector<DecodeResult>& result() const { return result_; }
+
+ private:
+  // Return true if we reach the end of the feature pipeline
+  DecodeState AdvanceDecoding();
+  void AttentionRescoring();
+  void OnnxReset();
+  float AttentionDecoderScore(const float* prob, const std::vector<int>& hyp,
+                              int eos, int decode_out_len);
+  void UpdateResult(bool finish = false);
+
+  std::shared_ptr<FeaturePipeline> feature_pipeline_;
+  std::shared_ptr<OnnxAsrModel> model_;
+  std::shared_ptr<PostProcessor> post_processor_;
+
+  std::shared_ptr<fst::Fst<fst::StdArc>> fst_ = nullptr;
+  // output symbol table
+  std::shared_ptr<fst::SymbolTable> symbol_table_;
+  // e2e unit symbol table
+  std::shared_ptr<fst::SymbolTable> unit_table_ = nullptr;
+  const DecodeOptions& opts_;
+  // cache feature
+  std::vector<std::vector<float>> cached_feature_;
+  bool start_ = false;
+
+  Ort::MemoryInfo memory_info_ =
+      Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+  const char* input_names_[6] = {"input", "offset", "required_cache_size",
+                                 "i1",    "i2",     "i3"};
+  const char* output_names_[4] = {"output", "o1", "o2", "o3"};
+  const char* decode_input_names_[3] = {"hyps_pad", "hyps_lens", "encoder_out"};
+  const char* decode_output_names_[2] = {"o1", "o2"};
+
+  const char* ctc_input_names_[1] = {"input"};
+  const char* ctc_output_names_[1] = {"output"};
+
+  Ort::Value subsampling_cache_ort_{nullptr};
+  Ort::Value elayers_output_cache_ort_{nullptr};
+  Ort::Value conformer_cnn_cache_ort_{nullptr};
+  std::vector<Ort::Value> encoder_outs_ort_;
+  std::vector<float> subsampling_cache_;
+  std::vector<float> elayers_output_cache_;
+  std::vector<float> conformer_cnn_cache_;
+
+  int offset_ = 1;  // offset
+  // For continuous decoding
+  int num_frames_ = 0;
+  int global_frame_offset_ = 0;
+
+  std::unique_ptr<SearchInterface> searcher_;
+  std::unique_ptr<CtcEndpoint> ctc_endpointer_;
+
+  int num_frames_in_current_chunk_ = 0;
+  std::vector<DecodeResult> result_;
+
+ public:
+  WENET_DISALLOW_COPY_AND_ASSIGN(OnnxAsrDecoder);
+};
+
+}  // namespace wenet
+
+#endif  // DECODER_TORCH_ASR_DECODER_H_

--- a/runtime/core/decoder/onnx_asr_decoder.h
+++ b/runtime/core/decoder/onnx_asr_decoder.h
@@ -7,6 +7,8 @@
 #ifndef DECODER_ONNX_ASR_DECODER_H_
 #define DECODER_ONNX_ASR_DECODER_H_
 
+#include <memory>
+#include <vector>
 #include "decoder/torch_asr_decoder.h"
 
 namespace wenet {
@@ -100,4 +102,4 @@ class OnnxAsrDecoder {
 
 }  // namespace wenet
 
-#endif  // DECODER_TORCH_ASR_DECODER_H_
+#endif  // DECODER_ONNX_ASR_DECODER_H_

--- a/runtime/core/decoder/onnx_asr_model.cc
+++ b/runtime/core/decoder/onnx_asr_model.cc
@@ -14,7 +14,6 @@ void OnnxAsrModel::Read(const std::string &model_dir) {
   std::string onnx_conf_path = model_dir + "/onnx.conf";
 
   try {
-    
     Ort::SessionOptions session_options;
     session_options.SetIntraOpNumThreads(1);
     session_options.SetInterOpNumThreads(1);

--- a/runtime/core/decoder/onnx_asr_model.cc
+++ b/runtime/core/decoder/onnx_asr_model.cc
@@ -4,6 +4,8 @@
 #include "decoder/onnx_asr_model.h"
 
 #include <utility>
+#include <memory>
+#include <string>
 
 namespace wenet {
 
@@ -18,15 +20,18 @@ void OnnxAsrModel::Read(const std::string &model_dir) {
     session_options.SetIntraOpNumThreads(1);
     session_options.SetInterOpNumThreads(1);
 
-    Ort::Session encoder_session{env_, encoder_onnx_path.data(), session_options};
-    encoder_session_ = std::make_shared<Ort::Session>(std::move(encoder_session));
+    Ort::Session encoder_session{env_, encoder_onnx_path.data(),
+                                 session_options};
+    encoder_session_ = std::make_shared<Ort::Session>(
+                            std::move(encoder_session));
 
-    Ort::Session rescore_session{env_, rescore_onnx_path.data(), session_options};
-    rescore_session_ = std::make_shared<Ort::Session>(std::move(rescore_session));
+    Ort::Session rescore_session{env_, rescore_onnx_path.data(),
+                                 session_options};
+    rescore_session_ = std::make_shared<Ort::Session>(
+                            std::move(rescore_session));
 
     Ort::Session ctc_session{env_, ctc_onnx_path.data(), session_options};
     ctc_session_ = std::make_shared<Ort::Session>(std::move(ctc_session));
-
   } catch (std::exception const &e) {
     printf("%s", e.what());
     exit(0);
@@ -68,7 +73,6 @@ void OnnxAsrModel::Read(const std::string &model_dir) {
   is_bidirectional_decoder_ = std::stoi(data);
 
   infile.close();
-
 }
 
 }  // namespace wenet

--- a/runtime/core/decoder/onnx_asr_model.cc
+++ b/runtime/core/decoder/onnx_asr_model.cc
@@ -1,0 +1,75 @@
+// Copyright 2021 Huya Inc. All Rights Reserved.
+// Author: lizexuan@huya.com (Zexuan Li)
+
+#include "decoder/onnx_asr_model.h"
+
+#include <utility>
+
+namespace wenet {
+
+void OnnxAsrModel::Read(const std::string &model_dir) {
+  std::string encoder_onnx_path = model_dir + "/encoder.onnx";
+  std::string rescore_onnx_path = model_dir + "/rescore.onnx";
+  std::string ctc_onnx_path = model_dir + "/ctc.onnx";
+  std::string onnx_conf_path = model_dir + "/onnx.conf";
+
+  try {
+    
+    Ort::SessionOptions session_options;
+    session_options.SetIntraOpNumThreads(1);
+    session_options.SetInterOpNumThreads(1);
+
+    Ort::Session encoder_session{env_, encoder_onnx_path.data(), session_options};
+    encoder_session_ = std::make_shared<Ort::Session>(std::move(encoder_session));
+
+    Ort::Session rescore_session{env_, rescore_onnx_path.data(), session_options};
+    rescore_session_ = std::make_shared<Ort::Session>(std::move(rescore_session));
+
+    Ort::Session ctc_session{env_, ctc_onnx_path.data(), session_options};
+    ctc_session_ = std::make_shared<Ort::Session>(std::move(ctc_session));
+
+  } catch (std::exception const &e) {
+    printf("%s", e.what());
+    exit(0);
+  }
+
+  std::ifstream infile;
+
+  infile.open(onnx_conf_path);
+
+  if (!infile) {
+    printf("error when open %s\n", onnx_conf_path.data());
+    exit(0);
+  }
+
+  std::string data;
+
+  infile >> data;
+  encoder_output_size_ = std::stoi(data);
+
+  infile >> data;
+  num_blocks_ = std::stoi(data);
+
+  infile >> data;
+  cnn_module_kernel_ = std::stoi(data);
+
+  infile >> data;
+  subsampling_rate_ = std::stoi(data);
+
+  infile >> data;
+  right_context_ = std::stoi(data);
+
+  infile >> data;
+  sos_ = std::stoi(data);
+
+  infile >> data;
+  eos_ = std::stoi(data);
+
+  infile >> data;
+  is_bidirectional_decoder_ = std::stoi(data);
+
+  infile.close();
+
+}
+
+}  // namespace wenet

--- a/runtime/core/decoder/onnx_asr_model.h
+++ b/runtime/core/decoder/onnx_asr_model.h
@@ -5,8 +5,10 @@
 #define DECODER_ONNX_ASR_MODEL_H_
 
 #include <fstream>
-#include "onnxruntime_cxx_api.h"
 #include <algorithm>
+#include <string>
+#include <memory>
+#include "./onnxruntime_cxx_api.h"
 #include "utils/utils.h"
 
 namespace wenet {
@@ -23,9 +25,15 @@ class OnnxAsrModel {
   int num_blocks() const { return num_blocks_; }
   int cnn_module_kernel() const { return cnn_module_kernel_; }
   bool is_bidirectional_decoder() const { return is_bidirectional_decoder_; }
-  std::shared_ptr<Ort::Session> encoder_session() const { return encoder_session_; }
-  std::shared_ptr<Ort::Session> rescore_session() const { return rescore_session_; }
-  std::shared_ptr<Ort::Session> ctc_session() const { return ctc_session_; }
+  std::shared_ptr<Ort::Session> encoder_session() const {
+    return encoder_session_;
+  }
+  std::shared_ptr<Ort::Session> rescore_session() const {
+    return rescore_session_;
+  }
+  std::shared_ptr<Ort::Session> ctc_session() const {
+    return ctc_session_;
+  }
 
  private:
   Ort::Env env_;

--- a/runtime/core/decoder/onnx_asr_model.h
+++ b/runtime/core/decoder/onnx_asr_model.h
@@ -1,0 +1,50 @@
+// Copyright 2021 Huya Inc. All Rights Reserved.
+// Author: lizexuan@huya.com (Zexuan Li)
+
+#ifndef DECODER_ONNX_ASR_MODEL_H_
+#define DECODER_ONNX_ASR_MODEL_H_
+
+#include <fstream>
+#include "onnxruntime_cxx_api.h"
+#include <algorithm>
+#include "utils/utils.h"
+
+namespace wenet {
+
+class OnnxAsrModel {
+ public:
+  OnnxAsrModel() = default;
+  void Read(const std::string& model_dir);
+  int right_context() const { return right_context_; }
+  int subsampling_rate() const { return subsampling_rate_; }
+  int sos() const { return sos_; }
+  int eos() const { return eos_; }
+  int encoder_output_size() const { return encoder_output_size_; }
+  int num_blocks() const { return num_blocks_; }
+  int cnn_module_kernel() const { return cnn_module_kernel_; }
+  bool is_bidirectional_decoder() const { return is_bidirectional_decoder_; }
+  std::shared_ptr<Ort::Session> encoder_session() const { return encoder_session_; }
+  std::shared_ptr<Ort::Session> rescore_session() const { return rescore_session_; }
+  std::shared_ptr<Ort::Session> ctc_session() const { return ctc_session_; }
+
+ private:
+  Ort::Env env_;
+  std::shared_ptr<Ort::Session> encoder_session_ = nullptr;
+  std::shared_ptr<Ort::Session> rescore_session_ = nullptr;
+  std::shared_ptr<Ort::Session> ctc_session_ = nullptr;
+  int encoder_output_size_ = 0;
+  int num_blocks_ = 0;
+  int cnn_module_kernel_ = 0;
+  int right_context_ = 1;
+  int subsampling_rate_ = 1;
+  int sos_ = 0;
+  int eos_ = 0;
+  bool is_bidirectional_decoder_ = false;
+
+ public:
+  WENET_DISALLOW_COPY_AND_ASSIGN(OnnxAsrModel);
+};
+
+}  // namespace wenet
+
+#endif  // DECODER_ONNX_ASR_MODEL_H_

--- a/runtime/core/decoder/params.h
+++ b/runtime/core/decoder/params.h
@@ -99,12 +99,12 @@ std::shared_ptr<DecodeOptions> InitDecodeOptionsFromFlags() {
 std::shared_ptr<DecodeResource> InitDecodeResourceFromFlags() {
   auto resource = std::make_shared<DecodeResource>();
 
-  if (!FLAGS_onnx_dir.empty()){
+  if (!FLAGS_onnx_dir.empty()) {
     LOG(INFO) << "Reading onnx model ";
     auto model = std::make_shared<OnnxAsrModel>();
     model->Read(FLAGS_onnx_dir);
     resource->onnx_model = model;
-  }else{
+  } else {
     LOG(INFO) << "Reading model " << FLAGS_model_path;
     auto model = std::make_shared<TorchAsrModel>();
     model->Read(FLAGS_model_path, FLAGS_num_threads);

--- a/runtime/core/decoder/torch_asr_decoder.h
+++ b/runtime/core/decoder/torch_asr_decoder.h
@@ -20,6 +20,7 @@
 #include "decoder/ctc_prefix_beam_search.h"
 #include "decoder/ctc_wfst_beam_search.h"
 #include "decoder/torch_asr_model.h"
+#include "decoder/onnx_asr_model.h"
 #include "frontend/feature_pipeline.h"
 #include "post_processor/post_processor.h"
 #include "utils/utils.h"
@@ -80,6 +81,7 @@ enum DecodeState {
 // decoding threads
 struct DecodeResource {
   std::shared_ptr<TorchAsrModel> model = nullptr;
+  std::shared_ptr<OnnxAsrModel> onnx_model = nullptr;
   std::shared_ptr<fst::SymbolTable> symbol_table = nullptr;
   std::shared_ptr<fst::Fst<fst::StdArc>> fst = nullptr;
   std::shared_ptr<fst::SymbolTable> unit_table = nullptr;

--- a/runtime/server/x86/CMakeLists.txt
+++ b/runtime/server/x86/CMakeLists.txt
@@ -77,6 +77,15 @@ FetchContent_MakeAvailable(libtorch)
 find_package(Torch REQUIRED PATHS ${libtorch_SOURCE_DIR} NO_DEFAULT_PATH)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS} -DC10_USE_GLOG")
 
+# third_party: onnxruntime
+FetchContent_Declare(onnxruntime
+    URL https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz
+    URL_HASH SHA256=f386ab80e9d6d41f14ed9e61bff4acc6bf375770691bc3ba883ba0ba3cabca7f
+)
+FetchContent_MakeAvailable(onnxruntime)
+include_directories("${onnxruntime_SOURCE_DIR}/include")
+link_directories("${onnxruntime_SOURCE_DIR}/lib")
+
 # utils
 add_library(utils STATIC
   utils/string.cc
@@ -143,8 +152,10 @@ add_library(decoder STATIC
   decoder/ctc_endpoint.cc
   decoder/torch_asr_decoder.cc
   decoder/torch_asr_model.cc
+  decoder/onnx_asr_decoder.cc
+  decoder/onnx_asr_model.cc
 )
-target_link_libraries(decoder PUBLIC ${TORCH_LIBRARIES} kaldi-decoder utils post_processor)
+target_link_libraries(decoder PUBLIC ${TORCH_LIBRARIES} kaldi-decoder utils post_processor onnxruntime)
 
 add_executable(ctc_prefix_beam_search_test decoder/ctc_prefix_beam_search_test.cc)
 target_link_libraries(ctc_prefix_beam_search_test PUBLIC gtest_main gmock decoder)
@@ -169,6 +180,8 @@ target_link_libraries(websocket PUBLIC decoder frontend)
 # binary
 add_executable(decoder_main bin/decoder_main.cc)
 target_link_libraries(decoder_main PUBLIC frontend decoder)
+add_executable(decoder_main_onnx bin/decoder_main_onnx.cc)
+target_link_libraries(decoder_main_onnx PUBLIC frontend decoder)
 add_executable(websocket_client_main bin/websocket_client_main.cc)
 target_link_libraries(websocket_client_main PUBLIC websocket)
 add_executable(websocket_server_main bin/websocket_server_main.cc)

--- a/wenet/bin/export_runtime_onnx.py
+++ b/wenet/bin/export_runtime_onnx.py
@@ -96,9 +96,14 @@ def check_encoder_onnx_and_pytorch(encoder_model, torch_encoder_model,
     chunk_onnx_outputs = []
     for i in range(5):
         dummy_input = inputs[i]
-        out, subsampling_cache, elayers_output_cache, conformer_cnn_cache = encoder_model(
-            dummy_input, offset, required_cache_size, subsampling_cache,
-            elayers_output_cache, conformer_cnn_cache)
+        (out, 
+         subsampling_cache, 
+         elayers_output_cache, 
+         conformer_cnn_cache) = encoder_model(dummy_input, offset, 
+                                              required_cache_size, 
+                                              subsampling_cache, 
+                                              elayers_output_cache, 
+                                              conformer_cnn_cache)
         chunk_onnx_outputs.append(out)
         offset += out.size(1)
 
@@ -111,9 +116,14 @@ def check_encoder_onnx_and_pytorch(encoder_model, torch_encoder_model,
 
     for i in range(5):
         dummy_input = inputs[i]
-        out2, subsampling_cache, elayers_output_cache, conformer_cnn_cache = torch_encoder_model(
-            dummy_input, offset, required_cache_size, subsampling_cache,
-            elayers_output_cache, conformer_cnn_cache)
+        (out2,
+         subsampling_cache, 
+         elayers_output_cache, 
+         conformer_cnn_cache) = torch_encoder_model(dummy_input, offset, 
+                                                    required_cache_size, 
+                                                    subsampling_cache,
+                                                    elayers_output_cache, 
+                                                    conformer_cnn_cache)
         torch_outputs.append(out2)
         offset += out2.size(1)
 
@@ -168,9 +178,8 @@ def check_encoder_onnx_and_pytorch(encoder_model, torch_encoder_model,
                                    rtol=1e-03,
                                    atol=1e-05)
 
-    print(
-        "Exported encoder model has been tested with ONNXRuntime, and the result looks good!"
-    )
+    print("Exported encoder model has been tested with ONNXRuntime, \
+and the result looks good!")
 
 
 def output_ctc_onnx(ctc_model, ctc_model_path):
@@ -237,9 +246,8 @@ def check_ctc_onnx_and_pytorch(ctc_model, torch_ctc_model, ctc_model_path):
                                    rtol=1e-03,
                                    atol=1e-05)
 
-    print(
-        "Exported ctc model has been tested with ONNXRuntime, and the result looks good!"
-    )
+    print("Exported ctc model has been tested with ONNXRuntime, \
+and the result looks good!")
 
 
 def output_rescore_onnx(rescore_model, rescore_model_path):
@@ -332,9 +340,8 @@ def check_rescore_onnx_and_pytorch(model, torch_model, decoder_model_path):
                                    rtol=1e-03,
                                    atol=1e-05)
 
-    print(
-        "Exported rescore model has been tested with ONNXRuntime, and the result looks good!"
-    )
+    print("Exported rescore model has been tested with ONNXRuntime, \
+and the result looks good!")
 
 
 if __name__ == '__main__':

--- a/wenet/bin/export_runtime_onnx.py
+++ b/wenet/bin/export_runtime_onnx.py
@@ -1,0 +1,394 @@
+# Copyright 2021 Huya Inc. All Rights Reserved.
+# Author: lizexuan@huya.com (Zexuan Li)
+# Reference from https://github.com/Mashiro009/wenet-onnx.git
+
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+
+import torch
+import yaml
+
+from wenet.transformer.asr_model import init_asr_model
+from wenet.utils.checkpoint import load_checkpoint
+import numpy as np
+try:
+    import onnx
+    import onnxruntime
+except ImportError:
+    print('Please install onnx onnxruntime!')
+    sys.exit(1)
+
+
+def export_conf(model, conf_path):
+    w = open(conf_path, 'w')
+    w.write(str(output_size) + "\n")
+    w.write(str(num_blocks) + "\n")
+    w.write(str(cnn_module_kernel) + "\n")
+    w.write(str(model.subsampling_rate()) + "\n")
+    w.write(str(model.right_context()) + "\n")
+    w.write(str(model.sos_symbol()) + "\n")
+    w.write(str(model.eos_symbol()) + "\n")
+    w.write(('1' if model.is_bidirectional_decoder() else '0') + "\n")
+    w.close()
+
+
+def to_numpy(tensor):
+    return tensor.detach().cpu().numpy(
+    ) if tensor.requires_grad else tensor.cpu().numpy()
+
+
+def output_encoder_conformer_onnx(encoder_model, encoder_model_path):
+    subsampling_cache = torch.zeros(1, 1, output_size)
+    elayers_output_cache = torch.zeros(num_blocks, 1, 1, output_size)
+    conformer_cnn_cache = torch.zeros(num_blocks, 1,
+                                      encoder_model._output_size,
+                                      cnn_module_kernel)
+
+    inputs = [torch.randn(1, 60 * (i + 1), 80) for i in range(5)]
+    dummy_input = inputs[0]
+    offset = torch.LongTensor(1)
+    offset[0] = 1
+    required_cache_size = torch.LongTensor(1)
+    required_cache_size[0] = -1
+
+    torch.onnx.export(
+        encoder_model,
+        (dummy_input, offset, required_cache_size, subsampling_cache,
+         elayers_output_cache, conformer_cnn_cache),
+        encoder_model_path,
+        export_params=True,
+        opset_version=12,
+        do_constant_folding=True,
+        input_names=[
+            'input', 'offset', 'required_cache_size', 'i1', 'i2', 'i3'
+        ],
+        output_names=['output', 'o1', 'o2', 'o3'],
+        dynamic_axes={
+            'input': [1],
+            'i1': [1],
+            'i2': [2],
+            'output': [1],
+            'o1': [1],
+            'o2': [2]
+        },
+        verbose=True)
+    print('export encoder model done')
+
+
+def check_encoder_onnx_and_pytorch(encoder_model, torch_encoder_model,
+                                   encoder_model_path):
+    # following is test torch encoder's function forward_chunk_onnx code
+    inputs = [torch.randn(1, 60 * (i + 1), 80) for i in range(5)]
+    offset = torch.LongTensor(1)
+    offset[0] = 1
+    required_cache_size = torch.LongTensor(1)
+    required_cache_size[0] = -1
+
+    subsampling_cache = torch.zeros(1, 1, encoder_model._output_size)
+    elayers_output_cache = torch.zeros(num_blocks, 1, 1,
+                                       encoder_model._output_size)
+    conformer_cnn_cache = torch.zeros(num_blocks, 1,
+                                      encoder_model._output_size,
+                                      cnn_module_kernel)
+    chunk_onnx_outputs = []
+    for i in range(5):
+        dummy_input = inputs[i]
+        out, subsampling_cache, elayers_output_cache, conformer_cnn_cache = encoder_model(
+            dummy_input, offset, required_cache_size, subsampling_cache,
+            elayers_output_cache, conformer_cnn_cache)
+        chunk_onnx_outputs.append(out)
+        offset += out.size(1)
+
+    offset = torch.tensor(0, dtype=torch.int64)
+    required_cache_size = torch.tensor(-1, dtype=torch.int64)
+    subsampling_cache = None
+    elayers_output_cache = None
+    conformer_cnn_cache = None
+    torch_outputs = []
+
+    for i in range(5):
+        dummy_input = inputs[i]
+        out2, subsampling_cache, elayers_output_cache, conformer_cnn_cache = torch_encoder_model(
+            dummy_input, offset, required_cache_size, subsampling_cache,
+            elayers_output_cache, conformer_cnn_cache)
+        torch_outputs.append(out2)
+        offset += out2.size(1)
+
+    onnx_model = onnx.load(encoder_model_path)
+    onnx.checker.check_model(onnx_model)
+    # Print a human readable representation of the graph
+    onnx.helper.printable_graph(onnx_model.graph)
+    print("encoder onnx_model check pass!")
+
+    ort_session = onnxruntime.InferenceSession(encoder_model_path)
+    print(encoder_model_path + " onnx model has " +
+          str(len(ort_session.get_inputs())) + " args")
+
+    required_cache_size = torch.LongTensor(1)
+    required_cache_size[0] = 3 * 64
+    subsampling_cache = torch.zeros(1, 1, output_size)
+    elayers_output_cache = torch.zeros(num_blocks, 1, 1, output_size)
+    conformer_cnn_cache = torch.zeros(num_blocks, 1,
+                                      encoder_model._output_size,
+                                      cnn_module_kernel)
+    offset = torch.LongTensor(1)
+    offset[0] = 1
+    subsampling_cache = to_numpy(subsampling_cache)
+    elayers_output_cache = to_numpy(elayers_output_cache)
+    conformer_cnn_cache = to_numpy(conformer_cnn_cache)
+    for i in range(5):
+        # compute ONNX Runtime output prediction
+        dummy_input = inputs[i]
+        ort_inputs = {
+            ort_session.get_inputs()[0].name: to_numpy(dummy_input),
+            ort_session.get_inputs()[1].name: to_numpy(offset),
+            ort_session.get_inputs()[2].name: to_numpy(required_cache_size),
+            ort_session.get_inputs()[3].name: subsampling_cache,
+            ort_session.get_inputs()[4].name: elayers_output_cache,
+            ort_session.get_inputs()[5].name: conformer_cnn_cache
+        }
+        ort_outs = ort_session.run(None, ort_inputs)
+        offset += ort_outs[0].shape[1]
+        subsampling_cache = ort_outs[1]
+        elayers_output_cache = ort_outs[2]
+        conformer_cnn_cache = ort_outs[3]
+        np.testing.assert_allclose(to_numpy(torch_outputs[i]),
+                                   ort_outs[0],
+                                   rtol=1e-03,
+                                   atol=1e-05)
+        np.testing.assert_allclose(to_numpy(chunk_onnx_outputs[i]),
+                                   ort_outs[0],
+                                   rtol=1e-03,
+                                   atol=1e-05)
+        np.testing.assert_allclose(to_numpy(chunk_onnx_outputs[i]),
+                                   to_numpy(torch_outputs[i]),
+                                   rtol=1e-03,
+                                   atol=1e-05)
+
+    print(
+        "Exported encoder model has been tested with ONNXRuntime, and the result looks good!"
+    )
+
+
+def output_ctc_onnx(ctc_model, ctc_model_path):
+
+    inputs = [torch.randn(1, 60 * (i + 1), output_size) for i in range(5)]
+    dummy_input = inputs[0]
+    torch.onnx.export(ctc_model, (dummy_input),
+                      ctc_model_path,
+                      export_params=True,
+                      opset_version=12,
+                      do_constant_folding=True,
+                      input_names=['input'],
+                      output_names=['output'],
+                      dynamic_axes={
+                          'input': [1],
+                          'output': [1]},
+                      verbose=True)
+    print('export ctc model done')
+
+
+def check_ctc_onnx_and_pytorch(ctc_model, torch_ctc_model, ctc_model_path):
+
+    inputs = [torch.randn(1, 60 * (i + 1), output_size) for i in range(5)]
+    chunk_onnx_outputs = []
+    for i in range(5):
+        # compute ONNX Runtime output prediction
+        dummy_input = inputs[i]
+        out = torch_ctc_model(dummy_input)
+        chunk_onnx_outputs.append(out)
+
+    torch_outputs = []
+    for i in range(5):
+        dummy_input = inputs[i]
+        out = ctc_model(dummy_input)
+        torch_outputs.append(out)
+
+    onnx_model = onnx.load(ctc_model_path)
+    onnx.checker.check_model(onnx_model)
+    # Print a human readable representation of the graph
+    onnx.helper.printable_graph(onnx_model.graph)
+    print("ctc onnx_model check pass!")
+
+    ort_session = onnxruntime.InferenceSession(ctc_model_path)
+    print(ctc_model_path + " onnx model has " +
+          str(len(ort_session.get_inputs())) + " args")
+
+    for i in range(5):
+        # compute ONNX Runtime output prediction
+        dummy_input = inputs[i]
+        ort_inputs = {
+            ort_session.get_inputs()[0].name: to_numpy(dummy_input),
+        }
+        ort_outs = ort_session.run(None, ort_inputs)
+        np.testing.assert_allclose(to_numpy(torch_outputs[i]),
+                                   ort_outs[0],
+                                   rtol=1e-03,
+                                   atol=1e-05)
+        np.testing.assert_allclose(to_numpy(chunk_onnx_outputs[i]),
+                                   ort_outs[0],
+                                   rtol=1e-03,
+                                   atol=1e-05)
+        np.testing.assert_allclose(to_numpy(chunk_onnx_outputs[i]),
+                                   to_numpy(torch_outputs[i]),
+                                   rtol=1e-03,
+                                   atol=1e-05)
+
+    print(
+        "Exported ctc model has been tested with ONNXRuntime, and the result looks good!"
+    )
+
+
+def output_rescore_onnx(rescore_model, rescore_model_path):
+    inputs = [torch.randn(1, 60 * (i + 1), output_size) for i in range(5)]
+    hyps_pad = (abs(torch.randn(10, 30)) * 1000).ceil().long()
+
+    hyps_lens = torch.arange(0, 33, step=3, dtype=torch.long)[1:]
+
+    # following is output onnx_decoder model code
+    dummy_input = inputs[0]
+    torch.onnx.export(rescore_model, (hyps_pad, hyps_lens, dummy_input),
+                      rescore_model_path,
+                      export_params=True,
+                      opset_version=12,
+                      do_constant_folding=True,
+                      input_names=['hyps_pad', 'hyps_lens', 'encoder_out'],
+                      output_names=['o1', 'o2'],
+                      dynamic_axes={
+                          'hyps_pad': {
+                              0: 'batch_size',
+                              1: 'subsample_len'
+                          },
+                          'hyps_lens': {
+                              0: 'batch_size'
+                          },
+                          'encoder_out': {
+                              1: 'batch_size',
+                              2: 'hyp_max_len'
+                          },
+                          'o1': {
+                              0: 'batch_size',
+                              1: 'hyp_max_len'
+                          },
+                          'o2': {
+                              0: 'batch_size',
+                              1: 'hyp_max_len'
+                          }}, verbose=True)
+    print('export rescore model done')
+
+
+def check_rescore_onnx_and_pytorch(model, torch_model, decoder_model_path):
+    # following is test torch decoder's function forward code
+    inputs = [torch.randn(1, 60 * (i + 1), output_size) for i in range(5)]
+    hyps_pad = (abs(torch.randn(10, 30)) * 1000).ceil().long()
+    hyps_lens = torch.arange(0, 33, step=3, dtype=torch.long)[1:]
+
+    chunk_onnx_outputs = []
+    for i in range(5):
+        # compute ONNX Runtime output prediction
+        dummy_input = inputs[i]
+        rescore_out, _ = model(hyps_pad, hyps_lens, dummy_input)
+        chunk_onnx_outputs.append(rescore_out)
+
+    torch_outputs = []
+    for i in range(5):
+        # compute ONNX Runtime output prediction
+        dummy_input = inputs[i]
+        rescore_out = model(hyps_pad, hyps_lens, dummy_input)
+        torch_outputs.append(rescore_out)
+
+    onnx_model = onnx.load(decoder_model_path)
+    onnx.checker.check_model(onnx_model)
+    # Print a human readable representation of the graph
+    onnx.helper.printable_graph(onnx_model.graph)
+    print("rescore onnx_model check pass!")
+
+    ort_session = onnxruntime.InferenceSession(decoder_model_path)
+    print(decoder_model_path + " onnx model has " +
+          str(len(ort_session.get_inputs())) + " args")
+
+    for i in range(5):
+        # compute ONNX Runtime output prediction
+        dummy_input = inputs[i]
+        ort_inputs = {
+            ort_session.get_inputs()[0].name: to_numpy(hyps_pad),
+            ort_session.get_inputs()[1].name: to_numpy(hyps_lens),
+            ort_session.get_inputs()[2].name: to_numpy(dummy_input),
+        }
+        ort_outs = ort_session.run(None, ort_inputs)
+        np.testing.assert_allclose(to_numpy(torch_outputs[i][0]),
+                                   ort_outs[0],
+                                   rtol=1e-03,
+                                   atol=1e-05)
+        np.testing.assert_allclose(to_numpy(chunk_onnx_outputs[i]),
+                                   ort_outs[0],
+                                   rtol=1e-03,
+                                   atol=1e-05)
+        np.testing.assert_allclose(to_numpy(chunk_onnx_outputs[i]),
+                                   to_numpy(torch_outputs[i][0]),
+                                   rtol=1e-03,
+                                   atol=1e-05)
+
+    print(
+        "Exported rescore model has been tested with ONNXRuntime, and the result looks good!"
+    )
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description='export your script model')
+    parser.add_argument('--config', default='train.yaml', help='config file')
+    parser.add_argument('--checkpoint',
+                        default='avg_8.pt',
+                        help='checkpoint model')
+    parser.add_argument('--output_dir',
+                        default='onnx_model',
+                        help='onnx output dir')
+    parser.add_argument('--check_onnx', default=True, help='check onnx model')
+
+    args = parser.parse_args()
+    output_dir = args.output_dir
+    os.system("mkdir -p " + output_dir)
+
+    with open(args.config, 'r') as fin:
+        configs = yaml.load(fin, Loader=yaml.FullLoader)
+
+    output_size = configs['encoder_conf']['output_size']
+    num_blocks = configs['encoder_conf']['num_blocks']
+    cnn_module_kernel = configs['encoder_conf']['cnn_module_kernel']
+
+    model = init_asr_model(configs, onnx_mode=True)
+    load_checkpoint(model, args.checkpoint)
+    model.eval()
+
+    conf_path = os.path.join(output_dir, 'onnx.conf')
+    export_conf(model, conf_path)
+
+    encoder_model = model.encoder
+    encoder_model.forward = encoder_model.forward_chunk_onnx
+    encoder_model_path = os.path.join(output_dir, 'encoder.onnx')
+    output_encoder_conformer_onnx(encoder_model, encoder_model_path)
+
+    ctc_model = model.ctc
+    ctc_model.forward = ctc_model.log_softmax
+    ctc_model_path = os.path.join(output_dir, 'ctc.onnx')
+    output_ctc_onnx(ctc_model, ctc_model_path)
+
+    model.forward = model.forward_attention_decoder
+    rescore_model_path = os.path.join(output_dir, 'rescore.onnx')
+    output_rescore_onnx(model, rescore_model_path)
+
+    if args.check_onnx:
+        torch_model = init_asr_model(configs, onnx_mode=False)
+        load_checkpoint(torch_model, args.checkpoint)
+        torch_model.eval()
+        torch_model.encoder.forward = torch_model.encoder.forward_chunk
+        torch_model.ctc.forward = torch_model.ctc.log_softmax
+        torch_model.forward = torch_model.forward_attention_decoder
+        check_encoder_onnx_and_pytorch(encoder_model, torch_model.encoder,
+                                       encoder_model_path)
+        check_ctc_onnx_and_pytorch(ctc_model, torch_model.ctc, ctc_model_path)
+        check_rescore_onnx_and_pytorch(model, torch_model, rescore_model_path)

--- a/wenet/bin/export_runtime_onnx.py
+++ b/wenet/bin/export_runtime_onnx.py
@@ -96,13 +96,13 @@ def check_encoder_onnx_and_pytorch(encoder_model, torch_encoder_model,
     chunk_onnx_outputs = []
     for i in range(5):
         dummy_input = inputs[i]
-        (out, 
-         subsampling_cache, 
-         elayers_output_cache, 
-         conformer_cnn_cache) = encoder_model(dummy_input, offset, 
-                                              required_cache_size, 
-                                              subsampling_cache, 
-                                              elayers_output_cache, 
+        (out,
+         subsampling_cache,
+         elayers_output_cache,
+         conformer_cnn_cache) = encoder_model(dummy_input, offset,
+                                              required_cache_size,
+                                              subsampling_cache,
+                                              elayers_output_cache,
                                               conformer_cnn_cache)
         chunk_onnx_outputs.append(out)
         offset += out.size(1)
@@ -117,12 +117,12 @@ def check_encoder_onnx_and_pytorch(encoder_model, torch_encoder_model,
     for i in range(5):
         dummy_input = inputs[i]
         (out2,
-         subsampling_cache, 
-         elayers_output_cache, 
-         conformer_cnn_cache) = torch_encoder_model(dummy_input, offset, 
-                                                    required_cache_size, 
+         subsampling_cache,
+         elayers_output_cache,
+         conformer_cnn_cache) = torch_encoder_model(dummy_input, offset,
+                                                    required_cache_size,
                                                     subsampling_cache,
-                                                    elayers_output_cache, 
+                                                    elayers_output_cache,
                                                     conformer_cnn_cache)
         torch_outputs.append(out2)
         offset += out2.size(1)

--- a/wenet/transformer/asr_model.py
+++ b/wenet/transformer/asr_model.py
@@ -677,7 +677,7 @@ class ASRModel(torch.nn.Module):
         return decoder_out, r_decoder_out
 
 
-def init_asr_model(configs):
+def init_asr_model(configs, onnx_mode=False):
     if configs['cmvn_file'] is not None:
         mean, istd = load_cmvn(configs['cmvn_file'], configs['is_json_cmvn'])
         global_cmvn = GlobalCMVN(
@@ -695,14 +695,14 @@ def init_asr_model(configs):
     if encoder_type == 'conformer':
         encoder = ConformerEncoder(input_dim,
                                    global_cmvn=global_cmvn,
-                                   **configs['encoder_conf'])
+                                   **configs['encoder_conf'], onnx_mode=onnx_mode)
     else:
         encoder = TransformerEncoder(input_dim,
                                      global_cmvn=global_cmvn,
                                      **configs['encoder_conf'])
     if decoder_type == 'transformer':
         decoder = TransformerDecoder(vocab_size, encoder.output_size(),
-                                     **configs['decoder_conf'])
+                                     **configs['decoder_conf'], onnx_mode=onnx_mode)
     else:
         assert 0.0 < configs['model_conf']['reverse_weight'] < 1.0
         assert configs['decoder_conf']['r_num_blocks'] > 0

--- a/wenet/transformer/decoder.py
+++ b/wenet/transformer/decoder.py
@@ -49,6 +49,7 @@ class TransformerDecoder(torch.nn.Module):
         use_output_layer: bool = True,
         normalize_before: bool = True,
         concat_after: bool = False,
+        onnx_mode: bool = False,
     ):
         assert check_argument_types()
         super().__init__()
@@ -57,7 +58,7 @@ class TransformerDecoder(torch.nn.Module):
         if input_layer == "embed":
             self.embed = torch.nn.Sequential(
                 torch.nn.Embedding(vocab_size, attention_dim),
-                PositionalEncoding(attention_dim, positional_dropout_rate),
+                PositionalEncoding(attention_dim, positional_dropout_rate, onnx_mode=onnx_mode),
             )
         else:
             raise ValueError(f"only 'embed' is supported: {input_layer}")

--- a/wenet/transformer/decoder.py
+++ b/wenet/transformer/decoder.py
@@ -58,7 +58,8 @@ class TransformerDecoder(torch.nn.Module):
         if input_layer == "embed":
             self.embed = torch.nn.Sequential(
                 torch.nn.Embedding(vocab_size, attention_dim),
-                PositionalEncoding(attention_dim, positional_dropout_rate, onnx_mode=onnx_mode),
+                PositionalEncoding(attention_dim, positional_dropout_rate,
+                                   onnx_mode=onnx_mode),
             )
         else:
             raise ValueError(f"only 'embed' is supported: {input_layer}")

--- a/wenet/transformer/embedding.py
+++ b/wenet/transformer/embedding.py
@@ -102,9 +102,11 @@ class RelPositionalEncoding(PositionalEncoding):
         dropout_rate (float): Dropout rate.
         max_len (int): Maximum input length.
     """
-    def __init__(self, d_model: int, dropout_rate: float, max_len: int = 5000, onnx_mode: bool = False):
+    def __init__(self, d_model: int, dropout_rate: float, max_len: int = 5000,
+                 onnx_mode: bool = False):
         """Initialize class."""
-        super().__init__(d_model, dropout_rate, max_len, reverse=True, onnx_mode=onnx_mode)
+        super().__init__(d_model, dropout_rate, max_len, reverse=True,
+                         onnx_mode=onnx_mode)
 
     def forward(self,
                 x: torch.Tensor,

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -354,7 +354,8 @@ class BaseEncoder(torch.nn.Module):
 
         r_conformer_cnn_cache = torch.zeros(0, 1, self._output_size,
                                             conformer_cnn_cache.size(3))
-        r_elayers_output_cache = torch.zeros(0, 1, xs.size(1) - next_cache_start + 1, self._output_size)
+        r_elayers_output_cache = torch.zeros(0, 1, xs.size(1) - next_cache_start + 1,
+                                             self._output_size)
         for i, layer in enumerate(self.encoders):
             if elayers_output_cache is None:
                 attn_cache = None

--- a/wenet/transformer/encoder_layer.py
+++ b/wenet/transformer/encoder_layer.py
@@ -281,7 +281,8 @@ class ConformerEncoderLayer(nn.Module):
         if onnx_mode:
             x = torch.nn.functional.pad(x, (0, 0, 1, 0), mode='constant', value=0)
             mask = torch.nn.functional.pad(mask, (1, 0), mode='constant', value=0)
-            new_cnn_cache = torch.nn.functional.pad(new_cnn_cache, (1, 0), mode='constant', value=0)
+            new_cnn_cache = torch.nn.functional.pad(new_cnn_cache, (1, 0),
+                                                    mode='constant', value=0)
 
 
         return x, mask, new_cnn_cache

--- a/wenet/transformer/subsampling.py
+++ b/wenet/transformer/subsampling.py
@@ -19,6 +19,9 @@ class BaseSubsampling(torch.nn.Module):
     def position_encoding(self, offset: int, size: int) -> torch.Tensor:
         return self.pos_enc.position_encoding(offset, size)
 
+    def position_encoding_onnx(self, offset: int, x) -> torch.Tensor:
+        return self.pos_enc.position_encoding_onnx(offset, x)
+
 
 class LinearNoSubsampling(BaseSubsampling):
     """Linear transform the input without subsampling

--- a/wenet/utils/slice_helper.py
+++ b/wenet/utils/slice_helper.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Huya Inc. All Rights Reserved.
 # Author: lizexuan@huya.com (Zexuan Li)
-# Reference from https://github.com/fanlu/wenet/blob/40062b065405280b5ae679c8e6d91a2333294d0a/wenet/transformer/slice_helper.py
+# Reference from https://github.com/fanlu/wenet/blob/\
+# 40062b065405280b5ae679c8e6d91a2333294d0a/wenet/transformer/slice_helper.py
 
 import torch
 

--- a/wenet/utils/slice_helper.py
+++ b/wenet/utils/slice_helper.py
@@ -6,7 +6,7 @@
 import torch
 
 @torch.jit.script
-def slice_helper(x, offset):
+def slice_helper(x: torch.Tensor, offset):
     return x[:, -offset: , :]
 
 @torch.jit.script
@@ -14,11 +14,11 @@ def slice_helper2(x: torch.Tensor, start, end):
     return x[:, start:end]
 
 @torch.jit.script
-def slice_helper3(x, start):
+def slice_helper3(x: torch.Tensor, start):
     return x[:, start:]
 
 @torch.jit.script
-def get_next_start(xs, required_cache_size):
+def get_next_start(xs: torch.Tensor, required_cache_size):
     next_cache_start = 0
     if required_cache_size < 0:
         next_cache_start = 1

--- a/wenet/utils/slice_helper.py
+++ b/wenet/utils/slice_helper.py
@@ -1,0 +1,31 @@
+# Copyright 2021 Huya Inc. All Rights Reserved.
+# Author: lizexuan@huya.com (Zexuan Li)
+# Reference from https://github.com/fanlu/wenet/blob/40062b065405280b5ae679c8e6d91a2333294d0a/wenet/transformer/slice_helper.py
+
+import torch
+
+@torch.jit.script
+def slice_helper(x, offset):
+    return x[:, -offset: , :]
+
+@torch.jit.script
+def slice_helper2(x: torch.Tensor, start, end):
+    return x[:, start:end]
+
+@torch.jit.script
+def slice_helper3(x, start):
+    return x[:, start:]
+
+@torch.jit.script
+def get_next_start(xs, required_cache_size):
+    next_cache_start = 0
+    if required_cache_size < 0:
+        next_cache_start = 1
+    elif required_cache_size == 0:
+        next_cache_start = xs.size(1)
+    else:
+        if xs.size(1) - required_cache_size < 0:
+            next_cache_start = 1
+        else:
+            next_cache_start = xs.size(1) - required_cache_size
+    return torch.tensor(next_cache_start, dtype=torch.int64)


### PR DESCRIPTION
We have implemented the derivation and reasoning of wenet onnxruntime.
On the aishell test dataset, the CER of libtorch and onnx is 2.2, the RTF of libtorch is 0.1379, and the RTF of onnx is 0.1166, which is relatively reduced by 15.45%.