### PR TITLE
[fix] Update filter_conf

### DIFF
--- a/examples/librispeech/s0/conf/train_conformer.yaml
+++ b/examples/librispeech/s0/conf/train_conformer.yaml
@@ -41,8 +41,8 @@ dataset_conf:
         min_length: 50
         token_max_length: 400
         token_min_length: 1
-        min_output_input_ratio: 0.05
-        max_output_input_ratio: 10.0
+        min_output_input_ratio: 0.0005
+        max_output_input_ratio: 0.1
     resample_conf:
         resample_rate: 16000
     speed_perturb: true

--- a/examples/librispeech/s0/conf/train_conformer_bidecoder_large.yaml
+++ b/examples/librispeech/s0/conf/train_conformer_bidecoder_large.yaml
@@ -44,8 +44,8 @@ dataset_conf:
         min_length: 50
         token_max_length: 400
         token_min_length: 1
-        min_output_input_ratio: 0.05
-        max_output_input_ratio: 10.0
+        min_output_input_ratio: 0.0005
+        max_output_input_ratio: 0.1
     resample_conf:
         resample_rate: 16000
     speed_perturb: true

--- a/examples/librispeech/s0/conf/train_u2++_conformer.yaml
+++ b/examples/librispeech/s0/conf/train_u2++_conformer.yaml
@@ -47,8 +47,8 @@ dataset_conf:
         min_length: 50
         token_max_length: 400
         token_min_length: 1
-        min_output_input_ratio: 0.05
-        max_output_input_ratio: 10.0
+        min_output_input_ratio: 0.0005
+        max_output_input_ratio: 0.1
     resample_conf:
         resample_rate: 16000
     speed_perturb: true

--- a/examples/librispeech/s0/conf/train_unified_conformer.yaml
+++ b/examples/librispeech/s0/conf/train_unified_conformer.yaml
@@ -44,8 +44,8 @@ dataset_conf:
         min_length: 50
         token_max_length: 400
         token_min_length: 1
-        min_output_input_ratio: 0.05
-        max_output_input_ratio: 10.0
+        min_output_input_ratio: 0.0005
+        max_output_input_ratio: 0.1
     resample_conf:
         resample_rate: 16000
     speed_perturb: true


### PR DESCRIPTION
The relevant parameters in filter_conf (min_output_input_ratio: 0.05, max_output_input_ratio: 10.0) are given as percentages.
But the filter class (wenet.dataset.processor.filter) does not treat them as expected.