### PR TITLE
conformer encoder modification

### DIFF
--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -79,8 +79,8 @@ class BaseEncoder(torch.nn.Module):
             global_cmvn (Optional[torch.nn.Module]): Optional GlobalCMVN module
             use_dynamic_left_chunk (bool): whether use dynamic left chunk in
                 dynamic chunk training
-            use_feature_norm (bool): whether to use layer_norm after 
-				cnn subsampling
+            use_feature_norm (bool): whether to use layer_norm after
+                cnn subsampling
         """
         assert check_argument_types()
         super().__init__()


### PR DESCRIPTION
We have some model modifications to support the pre-trained conformer encoder
1.Add CNN feature layer norm 
1.Support swap the order of the convolution module and the multi-head self-attention module
  Reference from  https://arxiv.org/abs/2011.10798