### PR TITLE
fix(decoder): fix check bug of decoder_main in continuous decoding mode

### DIFF
--- a/runtime/core/bin/decoder_main.cc
+++ b/runtime/core/bin/decoder_main.cc
@@ -20,6 +20,7 @@ DEFINE_bool(output_nbest, false, "output n-best of decode result");
 DEFINE_string(wav_path, "", "single wave path");
 DEFINE_string(wav_scp, "", "input wav scp");
 DEFINE_string(result, "", "result output file");
+DEFINE_bool(continuous_decoding, false, "continuous decoding mode");
 
 int main(int argc, char *argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, false);
@@ -85,9 +86,12 @@ int main(int argc, char *argv[]) {
         LOG(INFO) << "Partial result: " << decoder.result()[0].sentence;
       }
 
-      if (state == wenet::DecodeState::kEndpoint) {
-        decoder.Rescoring();
-        final_result.append(decoder.result()[0].sentence);
+      if (FLAGS_continuous_decoding &&
+          state == wenet::DecodeState::kEndpoint) {
+        if (decoder.DecodedSomething()) {
+          decoder.Rescoring();
+          final_result.append(decoder.result()[0].sentence);
+        }
         decoder.ResetContinuousDecoding();
       }
 

--- a/runtime/core/decoder/ctc_prefix_beam_search.cc
+++ b/runtime/core/decoder/ctc_prefix_beam_search.cc
@@ -34,6 +34,8 @@ void CtcPrefixBeamSearch::Reset() {
   prefix_score.v_ns = 0.0;
   std::vector<int> empty;
   cur_hyps_[empty] = prefix_score;
+  hypotheses_.emplace_back(empty);
+  likelihood_.emplace_back(prefix_score.total_score());
 }
 
 static bool PrefixScoreCompare(


### PR DESCRIPTION
`cur_hyps_` will add an empty hypotheses after Reset() function.
https://github.com/wenet-e2e/wenet/blob/ea81aaad6421601428b3d0d6745176616bb46b36/runtime/core/decoder/ctc_prefix_beam_search.cc#L36