### PR TITLE
[runtime] deletion penalty in wfst decoding

### DIFF
--- a/runtime/core/decoder/params.h
+++ b/runtime/core/decoder/params.h
@@ -43,6 +43,7 @@ DEFINE_int32(max_active, 7000, "max active states in ctc wfst search");
 DEFINE_int32(min_active, 200, "min active states in ctc wfst search");
 DEFINE_double(beam, 16.0, "beam in ctc wfst search");
 DEFINE_double(lattice_beam, 10.0, "lattice beam in ctc wfst search");
+DEFINE_double(deletion_penalty, 0.0, "deletion penalty in ctc wfst search");
 DEFINE_double(acoustic_scale, 1.0, "acoustic scale for ctc wfst search");
 DEFINE_double(blank_skip_thresh, 1.0,
               "blank skip thresh for ctc wfst search, 1.0 means no skip");
@@ -85,6 +86,7 @@ std::shared_ptr<DecodeOptions> InitDecodeOptionsFromFlags() {
   decode_config->ctc_wfst_search_opts.min_active = FLAGS_min_active;
   decode_config->ctc_wfst_search_opts.beam = FLAGS_beam;
   decode_config->ctc_wfst_search_opts.lattice_beam = FLAGS_lattice_beam;
+  decode_config->ctc_wfst_search_opts.deletion_penalty = FLAGS_deletion_penalty;
   decode_config->ctc_wfst_search_opts.acoustic_scale = FLAGS_acoustic_scale;
   decode_config->ctc_wfst_search_opts.blank_skip_thresh =
       FLAGS_blank_skip_thresh;

--- a/runtime/core/kaldi/decoder/lattice-faster-decoder.cc
+++ b/runtime/core/kaldi/decoder/lattice-faster-decoder.cc
@@ -921,7 +921,7 @@ void LatticeFasterDecoderTpl<FST, Token>::ProcessNonemitting(BaseFloat cutoff) {
          aiter.Next()) {
       const Arc &arc = aiter.Value();
       if (arc.ilabel == 0) {  // propagate nonemitting only...
-        BaseFloat graph_cost = arc.weight.Value(),
+        BaseFloat graph_cost = arc.weight.Value() - config_.deletion_penalty,
                   tot_cost = cur_cost + graph_cost;
         if (tot_cost < cutoff) {
           bool changed;

--- a/runtime/core/kaldi/decoder/lattice-faster-decoder.h
+++ b/runtime/core/kaldi/decoder/lattice-faster-decoder.h
@@ -49,6 +49,7 @@ struct LatticeFasterDecoderConfig {
                              // command-line program.
   BaseFloat beam_delta;
   BaseFloat hash_ratio;
+  BaseFloat deletion_penalty;
   // Note: we don't make prune_scale configurable on the command line, it's not
   // a very important parameter.  It affects the algorithm that prunes the
   // tokens as we go.
@@ -68,6 +69,7 @@ struct LatticeFasterDecoderConfig {
         determinize_lattice(true),
         beam_delta(0.5),
         hash_ratio(2.0),
+        deletion_penalty(0.0),
         prune_scale(0.1) {}
   void Register(OptionsItf *opts) {
     det_opts.Register(opts);
@@ -97,6 +99,9 @@ struct LatticeFasterDecoderConfig {
     opts->Register("hash-ratio", &hash_ratio,
                    "Setting used in decoder to "
                    "control hash behavior");
+    opts->Register("deletion-penalty", &deletion_penalty,
+                   "Setting used in decoder to "
+                   "decrease deletion errors");
   }
   void Check() const {
     KALDI_ASSERT(beam > 0.0 && max_active > 1 && lattice_beam > 0.0 &&


### PR DESCRIPTION
solve the issue #929
Adding a deletion penalty reduces deletion errors, but increases substitution and insertion errors.
It also makes decoding slower, so I would use it with less beam or min, max active.
In my test set, setting a deletion penalty of 1 gives better performance.