### PR TITLE
fix override-config bug when override item type is boolean.

### DIFF
--- a/wenet/utils/config.py
+++ b/wenet/utils/config.py
@@ -14,10 +14,10 @@ def override_config(configs, override_list):
                 print(f"the overrive {item} format not correct, skip it")
             if i == len(keys) - 1:
                 param_type = type(s_configs[key])
-                if param_type!= bool:
+                if param_type != bool:
                     s_configs[key] = param_type(arr[1])
                 else:
-                    s_configs[key] = arr[1] in ['true','True']
+                    s_configs[key] = arr[1] in ['true', 'True']
                 print(f"override {arr[0]} with {arr[1]}")
             else:
                 s_configs = s_configs[key]

--- a/wenet/utils/config.py
+++ b/wenet/utils/config.py
@@ -14,7 +14,10 @@ def override_config(configs, override_list):
                 print(f"the overrive {item} format not correct, skip it")
             if i == len(keys) - 1:
                 param_type = type(s_configs[key])
-                s_configs[key] = param_type(arr[1])
+                if param_type!= bool:
+                    s_configs[key] = param_type(arr[1])
+                else:
+                    s_configs[key] = arr[1] in ['true','True']
                 print(f"override {arr[0]} with {arr[1]}")
             else:
                 s_configs = s_configs[key]


### PR DESCRIPTION
Fix override-config bug when override item type is boolean. [#709 ](https://github.com/wenet-e2e/wenet/pull/709)