### PR TITLE
[runtime] add jemalloc

### DIFF
--- a/runtime/server/x86/CMakeLists.txt
+++ b/runtime/server/x86/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 project(wenet VERSION 0.1)
 
 option(GRPC "whether to build gRPC" OFF)
+option(JEMALLOC "whether to use jemalloc" OFF)
 
 include_directories(
 ${CMAKE_CURRENT_SOURCE_DIR}
@@ -149,6 +150,26 @@ add_library(decoder STATIC
   decoder/torch_asr_model.cc
 )
 target_link_libraries(decoder PUBLIC ${TORCH_LIBRARIES} kaldi-decoder utils post_processor)
+
+if(JEMALLOC)
+  set(jemalloc_SOURCE_DIR ${fc_base}/jemalloc-src CACHE PATH "jemalloc source directory")
+  set(jemalloc_BINARY_DIR ${fc_base}/jemalloc-build CACHE PATH "jemalloc build directory")
+  set(jemalloc_SUBBUILD_DIR ${fc_base}/jemalloc-subbuild CACHE PATH "jemalloc subbuild directory")
+  set(jemalloc_PREFIX_DIR ${jemalloc_SUBBUILD_DIR}/jemalloc-populate-prefix CACHE PATH "jemalloc prefix directory")
+  ExternalProject_Add(jemalloc
+    URL               https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2
+    URL_HASH          SHA256=34330e5ce276099e2e8950d9335db5a875689a4c6a56751ef3b1d8c537f887f6
+    TMP_DIR           ${jemalloc_SUBBUILD_DIR}/tmp
+    STAMP_DIR         ${jemalloc_SUBBUILD_DIR}/src/jemalloc-stamp
+    DOWNLOAD_DIR      ${jemalloc_SUBBUILD_DIR}/src
+    SOURCE_DIR        ${jemalloc_SOURCE_DIR}
+    BINARY_DIR        ${jemalloc_BINARY_DIR}
+    INSTALL_DIR       ${jemalloc_PREFIX_DIR}
+    CONFIGURE_COMMAND ${jemalloc_SOURCE_DIR}/configure --prefix=${jemalloc_PREFIX_DIR}
+    BUILD_COMMAND     make -j 4
+  )
+  target_link_libraries(decoder PUBLIC ${jemalloc_PREFIX_DIR}/lib/libjemalloc.a)
+endif(JEMALLOC)
 
 add_executable(ctc_prefix_beam_search_test decoder/ctc_prefix_beam_search_test.cc)
 target_link_libraries(ctc_prefix_beam_search_test PUBLIC gtest_main gmock decoder)

--- a/runtime/server/x86/README.md
+++ b/runtime/server/x86/README.md
@@ -74,6 +74,11 @@ Or you can do the WebSocket server/client testing as described in the `WebSocket
 ``` sh
 mkdir build && cd build && cmake .. && cmake --build .
 ```
+*Tips*: If you want to reduce memory usage, you can use `jemalloc`.
+
+``` sh
+mkdir build && cd build && cmake -DJEMALLOC=on .. && cmake --build .
+```
 
 * Step 3. Testing, the RTF(real time factor) is shown in the console.
 

--- a/runtime/server/x86/README_CN.md
+++ b/runtime/server/x86/README_CN.md
@@ -34,6 +34,12 @@ docker run --rm -it -p 10086:10086 -v $model_dir:/home/wenet/model mobvoiwenet/w
 # 当前目录为 wenet/runtime/server/x86
 mkdir build && cd build && cmake .. && cmake --build .
 ```
+*注意*：编译时可选择`jemalloc`进行内存管理，达到减少内存占用的效果。
+
+``` sh
+mkdir build && cd build && cmake -DJEMALLOC=on .. && cmake --build .
+```
+
 或者使用命令编译以支持 gRPC。
 
 ``` sh


### PR DESCRIPTION
solve the issue #352 #961 .
After replacing malloc with jemalloc, the memory useage is reduced by a factor of 10.
The content of the experiment is as follows:
Start websocket_server_main based on w/ jemalloc and w/o jemalloc respectively, use 57 different audio requests to the server, and test for a total of 5 rounds.
The image below shows the memory and CPU usage.

**CPU**
![CPU](https://raw.githubusercontent.com/zhangyuteng/img_repo/main/img/CPU.png)

**Memory**
![Memory](https://raw.githubusercontent.com/zhangyuteng/img_repo/main/img/%E5%86%85%E5%AD%98.png)