### PR TITLE
[model] new API for efficient cache control

### DIFF
--- a/runtime/core/decoder/torch_asr_model.h
+++ b/runtime/core/decoder/torch_asr_model.h
@@ -44,9 +44,10 @@ class TorchAsrModel: public AsrModel {
   std::shared_ptr<TorchModule> model_ = nullptr;
   std::vector<torch::Tensor> encoder_outs_;
   torch::jit::IValue subsampling_cache_;
-  // transformer/conformer encoder layers output cache
-  torch::jit::IValue elayers_output_cache_;
-  torch::jit::IValue conformer_cnn_cache_;
+  // transformer/conformer attention cache
+  torch::Tensor att_cache_ = torch::zeros({0, 0, 0, 0});
+  // conformer-only conv_module cache
+  torch::Tensor cnn_cache_ = torch::zeros({0, 0, 0, 0});
 };
 
 }  // namespace wenet

--- a/wenet/transformer/decoder_layer.py
+++ b/wenet/transformer/decoder_layer.py
@@ -103,11 +103,11 @@ class DecoderLayer(nn.Module):
 
         if self.concat_after:
             tgt_concat = torch.cat(
-                (tgt_q, self.self_attn(tgt_q, tgt, tgt, tgt_q_mask)), dim=-1)
+                (tgt_q, self.self_attn(tgt_q, tgt, tgt, tgt_q_mask)[0]), dim=-1)
             x = residual + self.concat_linear1(tgt_concat)
         else:
             x = residual + self.dropout(
-                self.self_attn(tgt_q, tgt, tgt, tgt_q_mask))
+                self.self_attn(tgt_q, tgt, tgt, tgt_q_mask)[0])
         if not self.normalize_before:
             x = self.norm1(x)
 
@@ -116,11 +116,11 @@ class DecoderLayer(nn.Module):
             x = self.norm2(x)
         if self.concat_after:
             x_concat = torch.cat(
-                (x, self.src_attn(x, memory, memory, memory_mask)), dim=-1)
+                (x, self.src_attn(x, memory, memory, memory_mask)[0]), dim=-1)
             x = residual + self.concat_linear2(x_concat)
         else:
             x = residual + self.dropout(
-                self.src_attn(x, memory, memory, memory_mask))
+                self.src_attn(x, memory, memory, memory_mask)[0])
         if not self.normalize_before:
             x = self.norm2(x)
 


### PR DESCRIPTION
# Benchmark(cpp)
Model: Aishell-1 u2++ Conformer (with **dynamic quantization**)
Config: num_bins 80, ctc_weight 0.3, rescoring_weight 1.0, reverse_weight 0.5
Test-set: Aishell-1 test-set, 7176 sentences
| API   | chunk_size | num_left_chunks | RTF(OMP_NUM_THREADS=1) | WER(int8) | WER(float32) |
|-|-|-|-|-|-|
| old   | -1 | -1  |  0.05871  |  4.89 %  |  4.68 %  |
|         | 16 | -1  | 0.1057 |  5.27 %    | 5.07 % |
|         | 16 | 4   | 0.08996  |  5.73 % | 5.60 %  |
| new | -1  | -1  |  0.05859 | 4.89 %  | 4.68 % |
|         | 16 | -1  | 0.07453 | 5.19 %  | 5.07 % |
|         | 16 | 4   | 0.07064  | 5.68 %  | 5.60 % |

# Benchmark(python)
Model: Aishell-1 u2++ Conformer
Config: num_bins 80, ctc_weight 0.3, rescoring_weight 1.0, reverse_weight 0.5
Test-set: Aishell-1 test-set, 7176 sentences
| API   | chunk_size | num_left_chunks | WER(float32) |
|-|-|-|-|
| old   | -1 | -1  |  4.68 %  |
|         | 16 | -1  | 5.07 % |
|         | 16 | 4   | 5.60 %  |
| new | -1  | -1  | 4.68 % |
|         | 16 | -1  | 5.07 % |
|         | 16 | 4   | 5.60 % |

# TODO
- [x] cpp benchmark tests using libtorch and `forward_chunk`
- [x] python benchmark tests using PyTorch and `forward_chunk_by_chunk`
- [x] check training behaviour, should be equal to old API.

# Q&A
1. Why new API is faster than old API ?
 
![cache-control](https://user-images.githubusercontent.com/13466943/161366079-c4ab1f59-f35b-4ead-8048-3014de0fe806.png)

2. Why new API is more accurate than old API for **dynamically quantized model**?

In dynamic quantization, the scale factor for activations is determined dynamically based on the data range observed at runtime, this means that different input results in different scale factor. In old API, the input of `ffn_macaron` contains 5 chunks (4 cache + 1 data), The output of `ffn_macaron` corresponding to the cache chunk might be changed due to the recalculation of scale point which is observed on both cache and data. However, in new API, cache will never be changed.