### PR TITLE
[doc] update referrence paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,17 +98,10 @@ Or you can directly discuss on [Github Issues](https://github.com/wenet-e2e/wene
   organization={IEEE}
 }
 
-@article{zhang2020unified,
-  title={Unified Streaming and Non-streaming Two-pass End-to-end Model for Speech Recognition},
-  author={Zhang, Binbin and Wu, Di and Yao, Zhuoyuan and Wang, Xiong and Yu, Fan and Yang, Chao and Guo, Liyong and Hu, Yaguang and Xie, Lei and Lei, Xin},
-  journal={arXiv preprint arXiv:2012.05481},
-  year={2020}
-}
-
-@article{wu2021u2++,
-  title={U2++: Unified Two-pass Bidirectional End-to-end Model for Speech Recognition},
-  author={Wu, Di and Zhang, Binbin and Yang, Chao and Peng, Zhendong and Xia, Wenjing and Chen, Xiaoyu and Lei, Xin},
-  journal={arXiv preprint arXiv:2106.05642},
-  year={2021}
+@article{zhang2022wenet,
+  title={WeNet 2.0: More Productive End-to-End Speech Recognition Toolkit},
+  author={Zhang, Binbin and Wu, Di and Peng, Zhendong and Song, Xingchen and Yao, Zhuoyuan and Lv, Hang and Xie, Lei and Yang, Chao and Pan, Fuping and Niu, Jianwei},
+  journal={arXiv preprint arXiv:2203.15455},
+  year={2022}
 }
 ```

--- a/docs/papers.md
+++ b/docs/papers.md
@@ -1,7 +1,5 @@
 ## Papers
 
-* [U2: Unified Streaming and Non-streaming Two-pass End-to-end Model for Speech Recognition](https://arxiv.org/abs/2012.05481)
-* [WeNet: Production First and Production Ready End-to-End Speech Recognition Toolkit](https://arxiv.org/pdf/2102.01547v1.pdf), v1.
-* [WeNet: Production Oriented Streaming and Non-streaming End-to-End Speech Recognition Toolkit](https://arxiv.org/pdf/2102.01547.pdf), v2, accepted by InterSpeech 2021.
-* [U2++: Unified Two-pass Bidirectional End-to-end Model for Speech Recognition](https://arxiv.org/pdf/2106.05642.pdf)
+* [WeNet: Production Oriented Streaming and Non-streaming End-to-End Speech Recognition Toolkit](https://arxiv.org/pdf/2102.01547.pdf), accepted by InterSpeech 2021.
+* [WeNet 2.0: More Productive End-to-End Speech Recognition Toolkit](https://arxiv.org/pdf/2203.15455.pdf), submitted to InterSpeech 2022.
 


### PR DESCRIPTION
In order to simplify referrence for users, I deleted some of our articles that are not complete like U2/U2++/Production First ..., I 
 only keep the two papers WeNet 1.0/2.0 which are well finished, and accepted or submitted to Conferrence.