### PR TITLE
[fix] fix bug in forward_chunk_by_chunk(ctc_greedy_search)

### DIFF
--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -312,7 +312,7 @@ class BaseEncoder(torch.nn.Module):
             outputs.append(y)
             offset += y.size(1)
         ys = torch.cat(outputs, 1)
-        masks = torch.ones((0, 0, 0), device=ys.device, dtype=torch.bool)
+        masks = torch.ones((1, 1, ys.size(1)), device=ys.device, dtype=torch.bool)
         return ys, masks
 
 


### PR DESCRIPTION
In https://github.com/wenet-e2e/wenet/pull/1002, I only test `forward_chunk_by_chunk` with attention_rescoring and it works well. However, when decoding with ctc_greedy_search, shape of encoder_mask cannot be (0, 0, 0), because it will be 
used to calculate encoder_out_lens. see https://github.com/wenet-e2e/wenet/blob/main/wenet/transformer/asr_model.py#L318