### PR TITLE
 fix CHECK_EQ(input.size(), time_stamp.size()) failed

### DIFF
--- a/runtime/core/decoder/ctc_prefix_beam_search.cc
+++ b/runtime/core/decoder/ctc_prefix_beam_search.cc
@@ -38,6 +38,7 @@ void CtcPrefixBeamSearch::Reset() {
   outputs_.emplace_back(empty);
   hypotheses_.emplace_back(empty);
   likelihood_.emplace_back(prefix_score.total_score());
+  times_.emplace_back(empty);
 }
 
 static bool PrefixScoreCompare(


### PR DESCRIPTION
fix CHECK_EQ(input.size(), time_stamp.size()) failed

related pr and discussion:
https://github.com/wenet-e2e/wenet/pull/991
https://github.com/wenet-e2e/wenet/pull/1051