### PR TITLE
[tools] normalize the audio before resample

### DIFF
--- a/tools/make_shard_list.py
+++ b/tools/make_shard_list.py
@@ -66,8 +66,16 @@ def write_tar_file(data_list,
 
                 # resample
                 if sample_rate != resample:
-                    audio = torchaudio.transforms.Resample(
-                        sample_rate, resample)(audio)
+                    if not audio.is_floating_point():
+                        # normalize the audio before resample
+                        # because resample can't process int audio
+                        audio = audio / (1 << 15)
+                        audio = torchaudio.transforms.Resample(
+                            sample_rate, resample)(audio)
+                        audio = (audio * (1 << 15)).short()
+                    else:
+                        audio = torchaudio.transforms.Resample(
+                            sample_rate, resample)(audio)
 
                 ts = time.time()
                 f = io.BytesIO()


### PR DESCRIPTION
According to [pytorchaudio issues](https://github.com/pytorch/audio/issues/2294), resample can't process the int audio.
And `waveforms, sample_rate = sox.load(wav, normalize=False)`, so the type of waveforms from wav is int16.
Therefore normalize the audio before resample by dividing (1<<15).
