### PR TITLE
[refactor] update&bugfix, onnx_cpu

### DIFF
--- a/wenet/transformer/attention.py
+++ b/wenet/transformer/attention.py
@@ -89,6 +89,8 @@ class MultiHeadedAttention(nn.Module):
         #   2. pytorch training
         if mask.size(2) > 0 :  # time2 > 0
             mask = mask.unsqueeze(1).eq(0)  # (batch, 1, *, time2)
+            # For last chunk, time2 might be larger than scores.size(-1)
+            mask = mask[:, :, :, :scores.size(-1)]  # (batch, 1, *, time2)
             scores = scores.masked_fill(mask, -float('inf'))
             attn = torch.softmax(scores, dim=-1).masked_fill(
                 mask, 0.0)  # (batch, head, time1, time2)


### PR DESCRIPTION
# Update

1. Instead of manually popping out input nodes according to different `chunk_size/num_left_chunks`, we now read in/out nodes from model.onnx and save their names, names are then used to decide which tensor should be poped.
2. We keep dynamic axes even if in 16/4 mode, this is to avoid padding the last chunk (which usually contains less frames than required). For users who want static axes, just pop out specific axis.
3. Fix bug when exporting Bi-rescore decoder.