### PR TITLE
fix word alignment timestamp

### DIFF
--- a/runtime/core/decoder/asr_decoder.cc
+++ b/runtime/core/decoder/asr_decoder.cc
@@ -153,18 +153,20 @@ void AsrDecoder::UpdateResult(bool finish) {
       CHECK_EQ(input.size(), time_stamp.size());
       for (size_t j = 0; j < input.size(); j++) {
         std::string word = unit_table_->Find(input[j]);
-        int start = time_stamp[j] * frame_shift_in_ms() - time_stamp_gap_ > 0?
-            time_stamp[j] * frame_shift_in_ms() - time_stamp_gap_: 0;
+        int start = time_stamp[j] * frame_shift_in_ms() - time_stamp_gap_ > 0 ?
+            time_stamp[j] * frame_shift_in_ms() - time_stamp_gap_ : 0;
         if (j > 0) {
-          start = (time_stamp[j] - time_stamp[j-1]) * frame_shift_in_ms() < time_stamp_gap_?
-                        (time_stamp[j - 1] + time_stamp[j]) / 2 * frame_shift_in_ms()
-                        : start;
+          start = (time_stamp[j] - time_stamp[j-1]) * frame_shift_in_ms() <
+              time_stamp_gap_ ? (time_stamp[j - 1] + time_stamp[j]) / 2 *
+                                frame_shift_in_ms()
+                              : start;
         }
         int end = time_stamp[j] * frame_shift_in_ms();
         if (j < input.size() - 1) {
-          end = (time_stamp[j + 1] - time_stamp[j]) * frame_shift_in_ms() < time_stamp_gap_?
-                        (time_stamp[j + 1] + time_stamp[j]) / 2 * frame_shift_in_ms()
-                        : end;
+          end = (time_stamp[j + 1] - time_stamp[j]) * frame_shift_in_ms() <
+              time_stamp_gap_ ? (time_stamp[j + 1] + time_stamp[j]) / 2 *
+                                frame_shift_in_ms()
+                              : end;
         }
         WordPiece word_piece(word, offset + start, offset + end);
         path.word_pieces.emplace_back(word_piece);

--- a/runtime/core/decoder/asr_decoder.cc
+++ b/runtime/core/decoder/asr_decoder.cc
@@ -153,12 +153,19 @@ void AsrDecoder::UpdateResult(bool finish) {
       CHECK_EQ(input.size(), time_stamp.size());
       for (size_t j = 0; j < input.size(); j++) {
         std::string word = unit_table_->Find(input[j]);
-        int start = j > 0 ? ((time_stamp[j - 1] + time_stamp[j]) / 2 *
-                             frame_shift_in_ms())
-                          : 0;
-        int end = j < input.size() - 1 ?
-            ((time_stamp[j] + time_stamp[j + 1]) / 2 * frame_shift_in_ms()) :
-            model_->offset() * frame_shift_in_ms();
+        int start = time_stamp[j] * frame_shift_in_ms() - time_stamp_gap_ > 0?
+            time_stamp[j] * frame_shift_in_ms() - time_stamp_gap_: 0;
+        if (j > 0) {
+          start = (time_stamp[j] - time_stamp[j-1]) * frame_shift_in_ms() < time_stamp_gap_?
+                        (time_stamp[j - 1] + time_stamp[j]) / 2 * frame_shift_in_ms()
+                        : start;
+        }
+        int end = time_stamp[j] * frame_shift_in_ms();
+        if (j < input.size() - 1) {
+          end = (time_stamp[j + 1] - time_stamp[j]) * frame_shift_in_ms() < time_stamp_gap_?
+                        (time_stamp[j + 1] + time_stamp[j]) / 2 * frame_shift_in_ms()
+                        : end;
+        }
         WordPiece word_piece(word, offset + start, offset + end);
         path.word_pieces.emplace_back(word_piece);
       }

--- a/runtime/core/decoder/asr_decoder.h
+++ b/runtime/core/decoder/asr_decoder.h
@@ -137,6 +137,7 @@ class AsrDecoder {
   // For continuous decoding
   int num_frames_ = 0;
   int global_frame_offset_ = 0;
+  const int time_stamp_gap_ = 100;  // timestamp gap between words in a sentence
 
   std::unique_ptr<SearchInterface> searcher_;
   std::unique_ptr<CtcEndpoint> ctc_endpointer_;


### PR DESCRIPTION
I have some confusions in my pr, time_stamp_gap_ is not a well variable to define its value, or just use frame_shift_in_ms(), maybe time_stamp_gap_ move to param.h that can be configured.

here just use a gap to limit word align timestamp more accurate, I think if combine blank timestamp, the result will better, but that seems too hard.