### PR TITLE
[runtime/onnx] fix the bug of OrtEnv singleton lifetime.

### DIFF
--- a/runtime/core/decoder/onnx_asr_model.cc
+++ b/runtime/core/decoder/onnx_asr_model.cc
@@ -61,7 +61,7 @@ void OnnxAsrModel::Read(const std::string& model_dir, const int num_threads) {
 
   // 1. Load sessions
   try {
-    Ort::Env env;
+    static Ort::Env env;
     Ort::SessionOptions session_options;
     session_options.SetIntraOpNumThreads(num_threads);
     session_options.SetInterOpNumThreads(num_threads);


### PR DESCRIPTION
The OrtEnv singleton will be release, When the Env object destruct. So need use static mark Env live in whole process. 