### PR TITLE
[runtime] copy onnx dlls to cmake_binary_dir

### DIFF
--- a/runtime/core/cmake/onnx.cmake
+++ b/runtime/core/cmake/onnx.cmake
@@ -17,5 +17,10 @@ FetchContent_Declare(onnxruntime
   URL_HASH ${URL_HASH}
 )
 FetchContent_MakeAvailable(onnxruntime)
-include_directories("${onnxruntime_SOURCE_DIR}/include")
-link_directories("${onnxruntime_SOURCE_DIR}/lib")
+include_directories(${onnxruntime_SOURCE_DIR}/include)
+link_directories(${onnxruntime_SOURCE_DIR}/lib)
+
+if(MSVC)
+  file(GLOB ONNX_DLLS "${onnxruntime_SOURCE_DIR}/lib/*.dll")
+  file(COPY ${ONNX_DLLS} DESTINATION ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+endif()

--- a/runtime/core/decoder/onnx_asr_model.cc
+++ b/runtime/core/decoder/onnx_asr_model.cc
@@ -88,7 +88,7 @@ void OnnxAsrModel::Read(const std::string& model_dir) {
                                                   session_options_);
 #endif
   } catch (std::exception const& e) {
-    LOG(ERROR) << "error when load onnx model";
+    LOG(ERROR) << "error when load onnx model: " << e.what();
     exit(0);
   }
 


### PR DESCRIPTION
Please see:
* https://github.com/microsoft/onnxruntime/issues/11480
* https://github.com/microsoft/onnxruntime/issues/6243