### PR TITLE
[model] fix unused parameters in `encoder_layer.py` and `decoder_layer.py`

### DIFF
--- a/wenet/transformer/decoder_layer.py
+++ b/wenet/transformer/decoder_layer.py
@@ -52,8 +52,9 @@ class DecoderLayer(nn.Module):
         self.dropout = nn.Dropout(dropout_rate)
         self.normalize_before = normalize_before
         self.concat_after = concat_after
-        self.concat_linear1 = nn.Linear(size + size, size)
-        self.concat_linear2 = nn.Linear(size + size, size)
+        if self.concat_after == True:
+            self.concat_linear1 = nn.Linear(size + size, size)
+            self.concat_linear2 = nn.Linear(size + size, size)
 
     def forward(
         self,

--- a/wenet/transformer/decoder_layer.py
+++ b/wenet/transformer/decoder_layer.py
@@ -55,6 +55,9 @@ class DecoderLayer(nn.Module):
         if self.concat_after:
             self.concat_linear1 = nn.Linear(size + size, size)
             self.concat_linear2 = nn.Linear(size + size, size)
+        else:
+            self.concat_linear1 = nn.Identity()
+            self.concat_linear2 = nn.Identity()
 
     def forward(
         self,

--- a/wenet/transformer/decoder_layer.py
+++ b/wenet/transformer/decoder_layer.py
@@ -52,7 +52,7 @@ class DecoderLayer(nn.Module):
         self.dropout = nn.Dropout(dropout_rate)
         self.normalize_before = normalize_before
         self.concat_after = concat_after
-        if self.concat_after == True:
+        if self.concat_after:
             self.concat_linear1 = nn.Linear(size + size, size)
             self.concat_linear2 = nn.Linear(size + size, size)
 

--- a/wenet/transformer/encoder_layer.py
+++ b/wenet/transformer/encoder_layer.py
@@ -52,6 +52,8 @@ class TransformerEncoderLayer(nn.Module):
         self.concat_after = concat_after
         if concat_after:
             self.concat_linear = nn.Linear(size + size, size)
+        else:
+            self.concat_linear = nn.Identity()
 
     def forward(
         self,
@@ -168,6 +170,9 @@ class ConformerEncoderLayer(nn.Module):
         self.concat_after = concat_after
         if self.concat_after:
             self.concat_linear = nn.Linear(size + size, size)
+        else:
+            self.concat_linear = nn.Identity()
+
 
     def forward(
         self,

--- a/wenet/transformer/encoder_layer.py
+++ b/wenet/transformer/encoder_layer.py
@@ -166,7 +166,8 @@ class ConformerEncoderLayer(nn.Module):
         self.size = size
         self.normalize_before = normalize_before
         self.concat_after = concat_after
-        self.concat_linear = nn.Linear(size + size, size)
+        if self.concat_after:
+            self.concat_linear = nn.Linear(size + size, size)
 
     def forward(
         self,

--- a/wenet/transformer/encoder_layer.py
+++ b/wenet/transformer/encoder_layer.py
@@ -50,9 +50,8 @@ class TransformerEncoderLayer(nn.Module):
         self.size = size
         self.normalize_before = normalize_before
         self.concat_after = concat_after
-        # concat_linear may be not used in forward fuction,
-        # but will be saved in the *.pt
-        self.concat_linear = nn.Linear(size + size, size)
+        if concat_after == True:
+            self.concat_linear = nn.Linear(size + size, size)
 
     def forward(
         self,

--- a/wenet/transformer/encoder_layer.py
+++ b/wenet/transformer/encoder_layer.py
@@ -50,7 +50,7 @@ class TransformerEncoderLayer(nn.Module):
         self.size = size
         self.normalize_before = normalize_before
         self.concat_after = concat_after
-        if concat_after == True:
+        if concat_after:
             self.concat_linear = nn.Linear(size + size, size)
 
     def forward(

--- a/wenet/utils/checkpoint.py
+++ b/wenet/utils/checkpoint.py
@@ -17,7 +17,7 @@ def load_checkpoint(model: torch.nn.Module, path: str) -> dict:
     else:
         logging.info('Checkpoint: loading from checkpoint %s for CPU' % path)
         checkpoint = torch.load(path, map_location='cpu')
-    model.load_state_dict(checkpoint)
+    model.load_state_dict(checkpoint, strict=False)
     info_path = re.sub('.pt$', '.yaml', path)
     configs = {}
     if os.path.exists(info_path):


### PR DESCRIPTION
 Hi,

I find some unused parameters at [`wenet/wenet/transformer/encoder_layer.py`](https://github.com/wenet-e2e/wenet/blob/6f884838c460510d8f6943ce1a3bc908ee40d349/wenet/transformer/encoder_layer.py#L55) and [`wenet/wenet/transformer/decoder_layer.py`](https://github.com/wenet-e2e/wenet/blob/6f884838c460510d8f6943ce1a3bc908ee40d349/wenet/transformer/decoder_layer.py#L55).

The default configuration of `concat_after` is `False`. 
This will lead the `self.concat_linear` to be unsed and bring redundancy in whole Conformer network.

Therefore, I add if statements to fix this problem.
