### PR TITLE
add length penalty

### DIFF
--- a/runtime/core/decoder/params.h
+++ b/runtime/core/decoder/params.h
@@ -51,6 +51,9 @@ DEFINE_double(lattice_beam, 10.0, "lattice beam in ctc wfst search");
 DEFINE_double(acoustic_scale, 1.0, "acoustic scale for ctc wfst search");
 DEFINE_double(blank_skip_thresh, 1.0,
               "blank skip thresh for ctc wfst search, 1.0 means no skip");
+DEFINE_double(length_penalty, 0.0, "length penalty ctc wfst search, will not"
+              "apply on self-loop arc, for balancing the del/ins ratio, "
+              "suggest set to -3.0");
 DEFINE_int32(nbest, 10, "nbest for ctc wfst or prefix search");
 
 // SymbolTable flags
@@ -93,6 +96,7 @@ std::shared_ptr<DecodeOptions> InitDecodeOptionsFromFlags() {
   decode_config->ctc_wfst_search_opts.acoustic_scale = FLAGS_acoustic_scale;
   decode_config->ctc_wfst_search_opts.blank_skip_thresh =
       FLAGS_blank_skip_thresh;
+  decode_config->ctc_wfst_search_opts.length_penalty = FLAGS_length_penalty;
   decode_config->ctc_wfst_search_opts.nbest = FLAGS_nbest;
   decode_config->ctc_prefix_search_opts.first_beam_size = FLAGS_nbest;
   decode_config->ctc_prefix_search_opts.second_beam_size = FLAGS_nbest;

--- a/runtime/core/kaldi/decoder/lattice-faster-decoder.cc
+++ b/runtime/core/kaldi/decoder/lattice-faster-decoder.cc
@@ -791,6 +791,9 @@ BaseFloat LatticeFasterDecoderTpl<FST, Token>::ProcessEmitting(
         BaseFloat new_weight = arc.weight.Value() + cost_offset -
                                decodable->LogLikelihood(frame, arc.ilabel) +
                                tok->tot_cost;
+        if (state != arc.nextstate) {
+          new_weight += config_.length_penalty;
+        }
         if (new_weight + adaptive_beam < next_cutoff)
           next_cutoff = new_weight + adaptive_beam;
       }
@@ -817,7 +820,11 @@ BaseFloat LatticeFasterDecoderTpl<FST, Token>::ProcessEmitting(
         if (arc.ilabel != 0) {  // propagate..
           BaseFloat ac_cost = cost_offset -
                               decodable->LogLikelihood(frame, arc.ilabel),
-                    graph_cost = arc.weight.Value(), cur_cost = tok->tot_cost,
+                    graph_cost = arc.weight.Value();
+          if (state != arc.nextstate) {
+            graph_cost += config_.length_penalty;
+          }
+          BaseFloat cur_cost = tok->tot_cost,
                     tot_cost = cur_cost + ac_cost + graph_cost;
           if (tot_cost >= next_cutoff)
             continue;

--- a/runtime/core/kaldi/decoder/lattice-faster-decoder.h
+++ b/runtime/core/kaldi/decoder/lattice-faster-decoder.h
@@ -53,6 +53,7 @@ struct LatticeFasterDecoderConfig {
   // a very important parameter.  It affects the algorithm that prunes the
   // tokens as we go.
   BaseFloat prune_scale;
+  BaseFloat length_penalty; // for balancing the del/ins ratio, suggest set to -3.0
 
   // Most of the options inside det_opts are not actually queried by the
   // LatticeFasterDecoder class itself, but by the code that calls it, for
@@ -68,7 +69,8 @@ struct LatticeFasterDecoderConfig {
         determinize_lattice(true),
         beam_delta(0.5),
         hash_ratio(2.0),
-        prune_scale(0.1) {}
+        prune_scale(0.1),
+        length_penalty(0.0) {}
   void Register(OptionsItf *opts) {
     det_opts.Register(opts);
     opts->Register("beam", &beam,

--- a/tools/decode.sh
+++ b/tools/decode.sh
@@ -19,6 +19,7 @@ lattice_beam=12.0
 min_active=200
 max_active=7000
 blank_skip_thresh=1.0
+length_penalty=0.0
 
 . tools/parse_options.sh || exit 1;
 if [ $# != 5 ]; then
@@ -56,6 +57,7 @@ if [ ! -z $fst_path ]; then
   wfst_decode_opts="$wfst_decode_opts --min_active $min_active"
   wfst_decode_opts="$wfst_decode_opts --acoustic_scale $acoustic_scale"
   wfst_decode_opts="$wfst_decode_opts --blank_skip_thresh $blank_skip_thresh"
+  wfst_decode_opts="$wfst_decode_opts --length_penalty $length_penalty"
   echo $wfst_decode_opts > $dir/config
 fi
 for n in $(seq ${nj}); do


### PR DESCRIPTION
In TLG equipped decoder called 'ctc_wfst_beam_search', the del/ins error ratio is much higher than the one without it called 'ctc_prefix_beam_search'

This PR provides a solution to add length penalty in TLG fst path. Penalty only add on the node where a new word occurs. Besides, it also considered the penalty when caculating beam cut weight.

I also notice another potential solution  to add delete penalty in process noemitting function, but it is added on every new node(i lable=0). It may cause some misunderstanding because a word may last for a long time. See [delete penalty](https://github.com/wenet-e2e/wenet/pull/994)

By comparision, my solution performs better than it. I realize and test both solutions, tables below are the comparison result.

These experiments are performed on aishell-1 using the default decoder.sh and the provided U2++ Conformer pretrained model. Notice that I use the latest chunk cache operators thus the result performs a little better than the number in S0.

Result with parameter ctc weight 0.3, reverse weight 0.5, chunksize -1
![image](https://user-images.githubusercontent.com/13692002/170514310-d314b6c9-ec24-4866-b77e-79ada1b96833.png)
![image](https://user-images.githubusercontent.com/13692002/170514436-226e38a8-9867-4145-ad3a-c2b806b43c5d.png)

Result with parameter ctc weight 0.3, reverse weight 0.5, chunksize 16
![image](https://user-images.githubusercontent.com/13692002/170514538-240ff93c-5265-423e-98ae-3f2c7aa71beb.png)
![image](https://user-images.githubusercontent.com/13692002/170514577-6c440cf2-e39d-4558-bb67-ac9b3c7121b8.png)

In addition, my solution shows stable improvement in my application scenario (Esports live streaming).

Any other experiments on open source data is needed, please commet.


