### PR TITLE
unify all differents chunks to export onnx

### DIFF
--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -248,7 +248,7 @@ class BaseEncoder(torch.nn.Module):
                
         # att_cache.size(2) == 0 means: fake cache and real mask
         # else real cache and fake mask
-        mask_id = torch.where(att_cache.size(2) == 0, 1, 0)
+        mask_id = torch.where(att_cache.size(2) == 1, 1, 0)
         att_mask = torch.ones(xs.size(0), 1, mask_id+att_cache.size(2)+chunk_size)
         # first call until required_catch_size  == att_cache.size(2)
         att_mask[:, :, :mask_id] = 0

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -228,18 +228,18 @@ class BaseEncoder(torch.nn.Module):
         # elif required_cache_size == 0:
         #   next_cache_start = attention_key_size
         # else:
-        #   next_cache_start = max(attention_key_size - required_cache_size, 0)    
+        #   next_cache_start = max(attention_key_size - required_cache_size, 0)
         zeor_tensor = torch.tensor(0)
         lt_zero = torch.less(required_cache_size, zeor_tensor)
         gt_zero = torch.greater(required_cache_size, zeor_tensor)
         # here attention_key_size and required_cache_size are tensors
         tmp_next_cache_start = attention_key_size - required_cache_size
         tmp_next_cache_start = torch.where(
-            torch.greater(tmp_next_cache_start, 0), 
+            torch.greater(tmp_next_cache_start, 0),
             tmp_next_cache_start, 0)
         next_cache_start= torch.where(
-            lt_zero, 
-            zeor_tensor, 
+            lt_zero,
+            zeor_tensor,
             attention_key_size)
         next_cache_start = torch.where(
             gt_zero,

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -246,7 +246,7 @@ class BaseEncoder(torch.nn.Module):
             tmp_next_cache_start,
             next_cache_start)
                
-        # att_cache.size(2) == 0 means: fake cache and real mask
+        # att_cache.size(2) == 1 means: fake cache and real mask
         # else real cache and fake mask
         mask_id = torch.where(att_cache.size(2) == 1, 1, 0)
         att_mask = torch.ones(xs.size(0), 1, mask_id+att_cache.size(2)+chunk_size)

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -170,7 +170,7 @@ class BaseEncoder(torch.nn.Module):
     def forward_chunk(
         self,
         xs: torch.Tensor,
-        offset: int,
+        offset: torch.Tensor,
         required_cache_size: torch.Tensor,
         att_cache: torch.Tensor,
         cnn_cache: torch.Tensor,

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -171,10 +171,9 @@ class BaseEncoder(torch.nn.Module):
         self,
         xs: torch.Tensor,
         offset: int,
-        required_cache_size: int,
-        att_cache: torch.Tensor = torch.zeros(0, 0, 0, 0),
-        cnn_cache: torch.Tensor = torch.zeros(0, 0, 0, 0),
-        att_mask: torch.Tensor = torch.ones((0, 0, 0), dtype=torch.bool),
+        required_cache_size: torch.Tensor,
+        att_cache: torch.Tensor,
+        cnn_cache: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """ Forward just one chunk
 
@@ -183,7 +182,7 @@ class BaseEncoder(torch.nn.Module):
                 where `time == (chunk_size - 1) * subsample_rate + \
                         subsample.right_context + 1`
             offset (int): current offset in encoder output time stamp
-            required_cache_size (int): cache size required for next chunk
+            required_cache_size (torch.Tensor: int): cache size required for next chunk
                 compuation
                 >=0: actual cache size
                 <0: means all history cache is required
@@ -223,12 +222,37 @@ class BaseEncoder(torch.nn.Module):
         attention_key_size = cache_t1 + chunk_size
         pos_emb = self.embed.position_encoding(
             offset=offset - cache_t1, size=attention_key_size)
-        if required_cache_size < 0:
-            next_cache_start = 0
-        elif required_cache_size == 0:
-            next_cache_start = attention_key_size
-        else:
-            next_cache_start = max(attention_key_size - required_cache_size, 0)
+        # below code equal to:
+        # if required_cache_size < 0:
+        #   next_cache_start = 0
+        # elif required_cache_size == 0:
+        #   next_cache_start = attention_key_size
+        # else:
+        #   next_cache_start = max(attention_key_size - required_cache_size, 0)    
+        zeor_tensor = torch.tensor(0)
+        lt_zero = torch.less(required_cache_size, zeor_tensor)
+        gt_zero = torch.greater(required_cache_size, zeor_tensor)
+        # here attention_key_size and required_cache_size are tensors
+        tmp_next_cache_start = attention_key_size - required_cache_size
+        tmp_next_cache_start = torch.where(
+            torch.greater(tmp_next_cache_start, 0), 
+            tmp_next_cache_start, 0)
+        next_cache_start= torch.where(
+            lt_zero, 
+            zeor_tensor, 
+            attention_key_size)
+        next_cache_start = torch.where(
+            gt_zero,
+            tmp_next_cache_start,
+            next_cache_start)
+               
+        # att_cache.size(2) == 0 means: fake cache and real mask
+        # else real cache and fake mask
+        mask_id = torch.where(att_cache.size(2) == 0, 1, 0)
+        att_mask = torch.ones(xs.size(0), 1, mask_id+att_cache.size(2)+chunk_size)
+        # first call until required_catch_size  == att_cache.size(2)
+        att_mask[:, :, :mask_id] = 0
+          
         r_att_cache = []
         r_cnn_cache = []
         for i, layer in enumerate(self.encoders):

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -246,12 +246,8 @@ class BaseEncoder(torch.nn.Module):
             tmp_next_cache_start,
             next_cache_start)
                
-        # att_cache.size(2) == 1 means: fake cache and real mask
-        # else real cache and fake mask
-        mask_id = torch.where(att_cache.size(2) == 1, 1, 0)
-        att_mask = torch.ones(xs.size(0), 1, mask_id+att_cache.size(2)+chunk_size)
-        # first call until required_catch_size  == att_cache.size(2)
-        att_mask[:, :, :mask_id] = 0
+        # att_mask.size(2) will alway equal to att_cache.size(2)+chunk_size
+        att_mask = torch.ones(xs.size(0), 1, att_cache.size(2)+chunk_size)
           
         r_att_cache = []
         r_cnn_cache = []

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -245,10 +245,10 @@ class BaseEncoder(torch.nn.Module):
             gt_zero,
             tmp_next_cache_start,
             next_cache_start)
-               
+        
         # att_mask.size(2) will alway equal to att_cache.size(2)+chunk_size
         att_mask = torch.ones(xs.size(0), 1, att_cache.size(2)+chunk_size)
-          
+        
         r_att_cache = []
         r_cnn_cache = []
         for i, layer in enumerate(self.encoders):

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -245,10 +245,8 @@ class BaseEncoder(torch.nn.Module):
             gt_zero,
             tmp_next_cache_start,
             next_cache_start)
-        
         # att_mask.size(2) will alway equal to att_cache.size(2)+chunk_size
         att_mask = torch.ones(xs.size(0), 1, att_cache.size(2)+chunk_size)
-        
         r_att_cache = []
         r_cnn_cache = []
         for i, layer in enumerate(self.encoders):


### PR DESCRIPTION
This is an incomplete pr and can be used as a reference

- first call： att_cache shape: [num_blocks, head, 0, dim]
   mask will be calculated in forward_chunk

- consecutive call: att_cache shape: [num_blocks, head, ?, dim]
   case 1 : chunk_size * num_left_chunks > att_cache.size(2)
   case 2:  num_left_chunks  ==  att_cache.size(2)
   case 3: num_left_chunks == 0, att_cache shape should be [num_blocks, head, 0, dim] return by prev call

TODO：
- [] export
- [] cer test
- [] runtime