### PR TITLE
unify all differents chunks to export onnx

### DIFF
--- a/wenet/bin/export_onnx_cpu.py
+++ b/wenet/bin/export_onnx_cpu.py
@@ -19,6 +19,7 @@ import argparse
 import os
 import copy
 import sys
+from urllib import request
 
 import torch
 import yaml
@@ -40,8 +41,6 @@ def get_args():
     parser.add_argument('--config', required=True, help='config file')
     parser.add_argument('--checkpoint', required=True, help='checkpoint model')
     parser.add_argument('--output_dir', required=True, help='output directory')
-    parser.add_argument('--chunk_size', required=True,
-                        type=int, help='decoding chunk size')
     parser.add_argument('--num_decoding_left_chunks', required=True,
                         type=int, help='cache chunks')
     parser.add_argument('--reverse_weight', default=0.5,
@@ -79,161 +78,52 @@ def export_encoder(asr_model, args):
     print("\tStage-1.1: prepare inputs for encoder")
     chunk = torch.randn(
         (args['batch'], args['decoding_window'], args['feature_size']))
-    offset = 0
-    # NOTE(xcsong): The uncertainty of `next_cache_start` only appears
-    #   in the first few chunks, this is caused by dynamic att_cache shape, i,e
-    #   (0, 0, 0, 0) for 1st chunk and (elayers, head, ?, d_k*2) for subsequent
-    #   chunks. One way to ease the ONNX export is to keep `next_cache_start`
-    #   as a fixed value. To do this, for the **first** chunk, if
-    #   left_chunks > 0, we feed real cache & real mask to the model, otherwise
-    #   fake cache & fake mask. In this way, we get:
-    #   1. 16/-1 mode: next_cache_start == 0 for all chunks
-    #   2. 16/4  mode: next_cache_start == chunk_size for all chunks
-    #   3. 16/0  mode: next_cache_start == chunk_size for all chunks
-    #   4. -1/-1 mode: next_cache_start == 0 for all chunks
-    #   NO MORE DYNAMIC CHANGES!!
-    if args['left_chunks'] > 0:  # 16/4
-        required_cache_size = args['chunk_size'] * args['left_chunks']
-        offset = required_cache_size
-        # Real cache
-        att_cache = torch.zeros(
-            (args['num_blocks'], args['head'], required_cache_size,
-             args['output_size'] // args['head'] * 2))
-        # Real mask
-        att_mask = torch.ones(
-            (args['batch'], 1, required_cache_size + args['chunk_size']),
-            dtype=torch.bool)
-        att_mask[:, :, :required_cache_size] = 0
-    elif args['left_chunks'] <= 0:  # 16/-1, -1/-1, 16/0
-        required_cache_size = -1 if args['left_chunks'] < 0 else 0
-        # Fake cache
-        att_cache = torch.zeros(
-            (args['num_blocks'], args['head'], 0,
-             args['output_size'] // args['head'] * 2))
-        # Fake mask
-        att_mask = torch.ones((0, 0, 0), dtype=torch.bool)
+
+    # offset is a tensor
+    offset = torch.tensor(0)
+    # Note:
+    # first call： att_cache shape: [num_blocks, head, 0, dim]
+    # consecutive call: att_cache shape: [num_blocks, head, ?, dim]
+    #   case 1: chunk_size * num_left_chunks > att_cache.size(2)
+    #   case 2: num_left_chunks == att_cache.size(2)
+    #   case 3: num_left_chunks == 0, 
+    #           att_cache shape should be [num_blocks, head, 0, dim] return by prev call
+    att_cache = torch.zeros(
+        (args['num_blocks'], args['head'], 0, # dynamic_axes 
+        args['output_size'] // args['head'] * 2))
+
     cnn_cache = torch.zeros(
         (args['num_blocks'], args['batch'],
          args['output_size'], args['cnn_module_kernel'] - 1))
+
+    # required_cache_size: can be any value like torchscript
+    required_cache_size = torch.tensor(16*4)
     inputs = (chunk, offset, required_cache_size,
-              att_cache, cnn_cache, att_mask)
+              att_cache, cnn_cache)
     print("\t\tchunk.size(): {}\n".format(chunk.size()),
           "\t\toffset: {}\n".format(offset),
           "\t\trequired_cache: {}\n".format(required_cache_size),
           "\t\tatt_cache.size(): {}\n".format(att_cache.size()),
-          "\t\tcnn_cache.size(): {}\n".format(cnn_cache.size()),
-          "\t\tatt_mask.size(): {}\n".format(att_mask.size()))
+          "\t\tcnn_cache.size(): {}\n".format(cnn_cache.size()))
 
     print("\tStage-1.2: torch.onnx.export")
     dynamic_axes = {
         'chunk': {1: 'T'},
         'att_cache': {2: 'T_CACHE'},
-        'att_mask': {2: 'T_ADD_T_CACHE'},
         'output': {1: 'T'},
         'r_att_cache': {2: 'T_CACHE'},
     }
-    # NOTE(xcsong): We keep dynamic axes even if in 16/4 mode, this is
-    #   to avoid padding the last chunk (which usually contains less
-    #   frames than required). For users who want static axes, just pop
-    #   out specific axis.
-    # if args['chunk_size'] > 0:  # 16/4, 16/-1, 16/0
-    #     dynamic_axes.pop('chunk')
-    #     dynamic_axes.pop('output')
-    # if args['left_chunks'] >= 0:  # 16/4, 16/0
-    #     # NOTE(xsong): since we feed real cache & real mask into the
-    #     #   model when left_chunks > 0, the shape of cache will never
-    #     #   be changed.
-    #     dynamic_axes.pop('att_cache')
-    #     dynamic_axes.pop('r_att_cache')
+
     torch.onnx.export(
         encoder, inputs, encoder_outpath, opset_version=13,
         export_params=True, do_constant_folding=True,
         input_names=[
             'chunk', 'offset', 'required_cache_size',
-            'att_cache', 'cnn_cache', 'att_mask'
+            'att_cache', 'cnn_cache'
         ],
         output_names=['output', 'r_att_cache', 'r_cnn_cache'],
         dynamic_axes=dynamic_axes, verbose=False)
     onnx_encoder = onnx.load(encoder_outpath)
-    for (k, v) in args.items():
-        meta = onnx_encoder.metadata_props.add()
-        meta.key, meta.value = str(k), str(v)
-    onnx.checker.check_model(onnx_encoder)
-    onnx.helper.printable_graph(onnx_encoder.graph)
-    # NOTE(xcsong): to add those metadatas we need to reopen
-    #   the file and resave it.
-    onnx.save(onnx_encoder, encoder_outpath)
-    print_input_output_info(onnx_encoder, "onnx_encoder")
-    print('\t\tExport onnx_encoder, done! see {}'.format(encoder_outpath))
-
-    print("\tStage-1.3: check onnx_encoder and torch_encoder")
-    torch_output = []
-    torch_chunk = copy.deepcopy(chunk)
-    torch_offset = copy.deepcopy(offset)
-    torch_required_cache_size = copy.deepcopy(required_cache_size)
-    torch_att_cache = copy.deepcopy(att_cache)
-    torch_cnn_cache = copy.deepcopy(cnn_cache)
-    torch_att_mask = copy.deepcopy(att_mask)
-    for i in range(10):
-        print("\t\ttorch chunk-{}: {}, offset: {}, att_cache: {},"
-              " cnn_cache: {}, att_mask: {}".format(
-                  i, list(torch_chunk.size()), torch_offset,
-                  list(torch_att_cache.size()),
-                  list(torch_cnn_cache.size()), list(torch_att_mask.size())))
-        # NOTE(xsong): att_mask of the first few batches need changes if
-        #   we use 16/4 mode.
-        if args['left_chunks'] > 0:  # 16/4
-            torch_att_mask[:, :, -(args['chunk_size'] * (i + 1)):] = 1
-        out, torch_att_cache, torch_cnn_cache = encoder(
-            torch_chunk, torch_offset, torch_required_cache_size,
-            torch_att_cache, torch_cnn_cache, torch_att_mask)
-        torch_output.append(out)
-        torch_offset += out.size(1)
-    torch_output = torch.cat(torch_output, dim=1)
-
-    onnx_output = []
-    onnx_chunk = to_numpy(chunk)
-    onnx_offset = np.array((offset)).astype(np.int64)
-    onnx_required_cache_size = np.array((required_cache_size)).astype(np.int64)
-    onnx_att_cache = to_numpy(att_cache)
-    onnx_cnn_cache = to_numpy(cnn_cache)
-    onnx_att_mask = to_numpy(att_mask)
-    ort_session = onnxruntime.InferenceSession(encoder_outpath)
-    input_names = [node.name for node in onnx_encoder.graph.input]
-    for i in range(10):
-        print("\t\tonnx  chunk-{}: {}, offset: {}, att_cache: {},"
-              " cnn_cache: {}, att_mask: {}".format(
-                  i, onnx_chunk.shape, onnx_offset, onnx_att_cache.shape,
-                  onnx_cnn_cache.shape, onnx_att_mask.shape))
-        # NOTE(xsong): att_mask of the first few batches need changes if
-        #   we use 16/4 mode.
-        if args['left_chunks'] > 0:  # 16/4
-            onnx_att_mask[:, :, -(args['chunk_size'] * (i + 1)):] = 1
-        ort_inputs = {
-            'chunk': onnx_chunk, 'offset': onnx_offset,
-            'required_cache_size': onnx_required_cache_size,
-            'att_cache': onnx_att_cache, 'cnn_cache': onnx_cnn_cache,
-            'att_mask': onnx_att_mask
-        }
-        # NOTE(xcsong): If we use 16/-1, -1/-1 or 16/0 mode, `next_cache_start`
-        #   will be hardcoded to 0 or chunk_size by ONNX, thus
-        #   required_cache_size and att_mask are no more needed and they will
-        #   be removed by ONNX automatically.
-        for k in list(ort_inputs):
-            if k not in input_names:
-                ort_inputs.pop(k)
-        ort_outs = ort_session.run(None, ort_inputs)
-        onnx_att_cache, onnx_cnn_cache = ort_outs[1], ort_outs[2]
-        onnx_output.append(ort_outs[0])
-        onnx_offset += ort_outs[0].shape[1]
-    onnx_output = np.concatenate(onnx_output, axis=1)
-
-    np.testing.assert_allclose(to_numpy(torch_output), onnx_output,
-                               rtol=1e-03, atol=1e-05)
-    meta = ort_session.get_modelmeta()
-    print("\t\tcustom_metadata_map={}".format(meta.custom_metadata_map))
-    print("\t\tCheck onnx_encoder, pass!")
-
 
 def export_ctc(asr_model, args):
     print("Stage-2: export ctc")


### PR DESCRIPTION

This is an incomplete pr and can be used as a reference

1  first call： att_cache shape: [num_blocks, head, 0, dim]
    mask will be calculated in forward_chunk  by att_cache.size(2)==0 

2  consecutive call: att_cache shape: [num_blocks, head, ?, dim]
- case 1: chunk_size * num_left_chunks > att_cache.size(2)  at the beginning of the call
- case 2: num_left_chunks == att_cache.size(2)
- case 3: num_left_chunks == 0,   att_cache shape should be [num_blocks, head, 0, dim] return by prev call