### PR TITLE
Update train_deprecated.py

### DIFF
--- a/wenet/bin/train_deprecated.py
+++ b/wenet/bin/train_deprecated.py
@@ -240,6 +240,7 @@ the future, please move to the new IO !!!
     for epoch in range(start_epoch, num_epochs):
         if distributed:
             train_sampler.set_epoch(epoch)
+        configs['epoch'] = epoch
         lr = optimizer.param_groups[0]['lr']
         logging.info('Epoch {} TRAIN info lr {}'.format(epoch, lr))
         executor.train(model, optimizer, scheduler, train_data_loader, device,


### PR DESCRIPTION
Fix the problem that the epoch is not updated in log when training aishell/s1