### PR TITLE
Fix absolute position encoding in conformer.

### DIFF
--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -424,7 +424,7 @@ class ConformerEncoder(BaseEncoder):
         activation = get_activation(activation_type)
 
         # self-attention module definition
-        if pos_enc_layer_type == "no_pos":
+        if pos_enc_layer_type != "rel_pos":
             encoder_selfattn_layer = MultiHeadedAttention
         else:
             encoder_selfattn_layer = RelPositionMultiHeadedAttention


### PR DESCRIPTION
when `pos_enc_layer_type = "abs_pos"`, conformer should use `MultiHeadedAttention` rather than `RelPositionMultiHeadedAttention`.
[here](https://github.com/wenet-e2e/wenet/blob/main/wenet/transformer/encoder.py#L427)