### PR TITLE
[runtime] featue pipeline use feats block push and pop

### DIFF
--- a/runtime/core/frontend/feature_pipeline.h
+++ b/runtime/core/frontend/feature_pipeline.h
@@ -93,14 +93,16 @@ class FeaturePipeline {
     return input_finished_ && (frame == num_frames_ - 1);
   }
 
-  int NumQueuedFrames() const { return feature_queue_.Size(); }
+  int NumQueuedFrames() const;
 
  private:
+  bool ReadFromQueue(std::vector<std::vector<float>>* feats);
+
   const FeaturePipelineConfig& config_;
   int feature_dim_;
   Fbank fbank_;
 
-  BlockingQueue<std::vector<float>> feature_queue_;
+  BlockingQueue<std::vector<std::vector<float>>> feature_queue_;
   int num_frames_;
   bool input_finished_;
 
@@ -109,6 +111,10 @@ class FeaturePipeline {
   // The residual waveform sample points after framing are
   // kept to be used in next AcceptWaveform() calling.
   std::vector<float> remained_wav_;
+
+  std::vector<std::vector<float>> remained_feats_;
+  int wait_frames_;
+  mutable std::mutex wait_mutex_;
 
   // Used to block the Read when there is no feature in feature_queue_
   // and the input is not finished.

--- a/runtime/core/test/CMakeLists.txt
+++ b/runtime/core/test/CMakeLists.txt
@@ -11,3 +11,8 @@ add_test(CTC_PREFIX_BEAM_SEARCH_TEST ctc_prefix_beam_search_test)
 add_executable(post_processor_test post_processor_test.cc)
 target_link_libraries(post_processor_test PUBLIC post_processor)
 add_test(POST_PROCESSOR_TEST post_processor_test)
+
+
+add_executable(feature_pipeline_test feature_pipeline_test.cc)
+target_link_libraries(feature_pipeline_test PUBLIC frontend)
+add_test(FEATURE_PIPELINE_TEST feature_pipeline_test)

--- a/runtime/core/test/feature_pipeline_test.cc
+++ b/runtime/core/test/feature_pipeline_test.cc
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 Roney
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "frontend/feature_pipeline.h"
+
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+TEST(FeaturePipelineTest, PipelineTest) {
+  wenet::FeaturePipelineConfig config(80, 8000);
+  wenet::FeaturePipeline feature_pipeline(config);
+  int audio_len = 8 * 55;  // audio len 55ms,4 frames
+  std::vector<float> pcm(audio_len, 0);
+  feature_pipeline.AcceptWaveform(pcm.data(), audio_len);
+  ASSERT_EQ(feature_pipeline.NumQueuedFrames(), 4);
+
+  std::vector<std::vector<float>> out_feats;
+  auto b = feature_pipeline.Read(2, &out_feats);
+  ASSERT_TRUE(b);
+  ASSERT_EQ(out_feats.size(), 2);
+  ASSERT_EQ(feature_pipeline.NumQueuedFrames(), 2);
+
+  std::vector<float> out_feat;
+  b = feature_pipeline.ReadOne(&out_feat);
+  ASSERT_TRUE(b);
+  ASSERT_FALSE(out_feat.empty());
+  ASSERT_EQ(feature_pipeline.NumQueuedFrames(), 1);
+
+  feature_pipeline.set_input_finished();
+  b = feature_pipeline.Read(2, &out_feats);
+  ASSERT_FALSE(b);
+  ASSERT_EQ(out_feats.size(), 1);
+  ASSERT_EQ(feature_pipeline.NumQueuedFrames(), 0);
+
+  feature_pipeline.AcceptWaveform(pcm.data(), audio_len);
+  feature_pipeline.Read(2, &out_feats);
+  feature_pipeline.Reset();
+  feature_pipeline.set_input_finished();
+  b = feature_pipeline.Read(2, &out_feats);
+  ASSERT_FALSE(b);
+  ASSERT_EQ(out_feats.size(), 0);
+  ASSERT_EQ(feature_pipeline.NumQueuedFrames(), 0);
+}


### PR DESCRIPTION
Using feats block transmission in the pipeline theoretically saves lock operations between threads. And compatible with all interfaces