### PR TITLE
rnnt prefix beam search & ctc+rnnt generation nbest for rnnt attn res…

### DIFF
--- a/examples/aishell/rnnt/run.sh
+++ b/examples/aishell/rnnt/run.sh
@@ -162,8 +162,18 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
   # non-streaming model. The default value is -1, which is full chunk
   # for non-streaming inference.
   decoding_chunk_size=
-  ctc_weight=0.5
+  # 1. when beam search these two weight means the prob add weight
+  # 2. when ctc+rnnt nbest ->  rnnt+attn rescoring these two weight means the prob weight rescoring nbest
+  ctc_weight=0.3
+  transducer_weight=0.7
+  # 2. for ctc+rnnt nbest -> rnnt+attn rescoring this weight meas the weight rescoring nbest 
+  attn_weight=1.0
+  # 2. for ctc+rnnt nbest this weight means the prob weights decoding nbest
+  search_ctc_weight=0.3
+  search_transducer_weight=0.7
+
   reverse_weight=0.0
+
   for mode in ${decode_modes}; do
   {
     test_dir=$dir/test_${mode}
@@ -178,6 +188,11 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
       --batch_size 1 \
       --penalty 0.0 \
       --dict $dict \
+      --ctc_weight $ctc_weight \
+      --transducer_weight $transducer_weight \
+      --attn_weight $attn_weight \
+      --search_ctc_weight $search_ctc_weight \
+      --search_transducer_weight $search_transducer_weigth \
       --ctc_weight $ctc_weight \
       --reverse_weight $reverse_weight \
       --result_file $test_dir/text \

--- a/examples/aishell/rnnt/run.sh
+++ b/examples/aishell/rnnt/run.sh
@@ -167,18 +167,14 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
   rescore_transducer_weight=0.5
   rescore_attn_weight=1.0
   # only used in beam search, either pure beam search mode OR beam search inside rescoring
-  beam_search_ctc_weight=0.3
-  beam_search_transducer_weight=0.7
+  search_ctc_weight=0.3
+  search_transducer_weight=0.7
 
   reverse_weight=0.0
   for mode in ${decode_modes}; do
   {
     test_dir=$dir/test_${mode}
     mkdir -p $test_dir
-    ctc_weight=$([ "$decode_modes" == "rnnt_beam_attn_rescoring" ] && \
-        echo $rescore_ctc_weight || echo $beam_search_ctc_weight)
-    transducer_weight=$([ "$decode_modes" == "rnnt_beam_attn_rescoring" ] && \
-        echo $rescore_transducer_weight || echo $beam_search_transducer_weight)
     python wenet/bin/recognize.py --gpu 0 \
       --mode $mode \
       --config $dir/train.yaml \
@@ -189,9 +185,9 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
       --batch_size 1 \
       --penalty 0.0 \
       --dict $dict \
-      --ctc_weight $ctc_weight \
-      --transducer_weight $transducer_weight \
-      --attn_weight $rescore_attn_weight \
+      --rescore_ctc_weight $rescore_ctc_weight \
+      --rescore_transducer_weight $rescore_transducer_weight \
+      --rescore_attn_weight $rescore_attn_weight \
       --search_ctc_weight $search_ctc_weight \
       --search_transducer_weight $search_transducer_weigth \
       --reverse_weight $reverse_weight \

--- a/examples/aishell/rnnt/run.sh
+++ b/examples/aishell/rnnt/run.sh
@@ -166,7 +166,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
   # 2. when ctc+rnnt nbest ->  rnnt+attn rescoring these two weight means the prob weight rescoring nbest
   ctc_weight=0.3
   transducer_weight=0.7
-  # 2. for ctc+rnnt nbest -> rnnt+attn rescoring this weight meas the weight rescoring nbest 
+  # 2. for ctc+rnnt nbest -> rnnt+attn rescoring this weight meas the weight rescoring nbest
   attn_weight=1.0
   # 2. for ctc+rnnt nbest this weight means the prob weights decoding nbest
   search_ctc_weight=0.3

--- a/examples/aishell/rnnt/run.sh
+++ b/examples/aishell/rnnt/run.sh
@@ -189,7 +189,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
       --transducer_weight $rescore_transducer_weight \
       --attn_weight $rescore_attn_weight \
       --search_ctc_weight $search_ctc_weight \
-      --search_transducer_weight $search_transducer_weigth \
+      --search_transducer_weight $search_transducer_weight \
       --reverse_weight $reverse_weight \
       --result_file $test_dir/text \
       ${decoding_chunk_size:+--decoding_chunk_size $decoding_chunk_size}

--- a/examples/aishell/rnnt/run.sh
+++ b/examples/aishell/rnnt/run.sh
@@ -185,9 +185,9 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
       --batch_size 1 \
       --penalty 0.0 \
       --dict $dict \
-      --rescore_ctc_weight $rescore_ctc_weight \
-      --rescore_transducer_weight $rescore_transducer_weight \
-      --rescore_attn_weight $rescore_attn_weight \
+      --ctc_weight $rescore_ctc_weight \
+      --transducer_weight $rescore_transducer_weight \
+      --attn_weight $rescore_attn_weight \
       --search_ctc_weight $search_ctc_weight \
       --search_transducer_weight $search_transducer_weigth \
       --reverse_weight $reverse_weight \

--- a/examples/aishell/rnnt/run.sh
+++ b/examples/aishell/rnnt/run.sh
@@ -168,8 +168,8 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
   rescore_attn_weight=1.0
   # only used in beam search, either pure beam search mode OR beam search inside rescoring
   beam_search_ctc_weight=0.3
-  beam_search_transducer_weight=0.7 
- 
+  beam_search_transducer_weight=0.7
+
   reverse_weight=0.0
   for mode in ${decode_modes}; do
   {

--- a/examples/aishell/rnnt/run.sh
+++ b/examples/aishell/rnnt/run.sh
@@ -194,7 +194,6 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
       --attn_weight $rescore_attn_weight \
       --search_ctc_weight $search_ctc_weight \
       --search_transducer_weight $search_transducer_weigth \
-      --ctc_weight $ctc_weight \
       --reverse_weight $reverse_weight \
       --result_file $test_dir/text \
       ${decoding_chunk_size:+--decoding_chunk_size $decoding_chunk_size}

--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -80,8 +80,10 @@ def get_args():
     parser.add_argument('--ctc_weight',
                         type=float,
                         default=0.0,
-                        help='ctc weight for rescoring weight in attention rescoring decode mode \
-                              ctc weight for rescoring weight in transducer attention rescore decode mode')
+                        help='ctc weight for rescoring weight in \
+                                  attention rescoring decode mode \
+                              ctc weight for rescoring weight in \
+                                  transducer attention rescore decode mode')
 
     parser.add_argument('--transducer_weight',
                         type=float,

--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -80,18 +80,18 @@ def get_args():
     parser.add_argument('--ctc_weight',
                         type=float,
                         default=0.0,
-                        help='ctc weight for attention rescoring decode mode
-                              ctc weight for nbest generation in beam search decode mode
+                        help='ctc weight for attention rescoring decode mode \
+                              ctc weight for nbest generation in beam search decode mode \
                               ctc weight for rescoring weight in transducer attention rescore mode')
     parser.add_argument('--transducer_weight',
                         type=float,
                         default=0.0,
-                        help='transducer weight for nbest generation in beam search decode mode
+                        help='transducer weight for nbest generation in beam search decode mode \
                               transducer weight for rescoring weight in transducer attention rescore mode')
     parser.add_argument('--attn_weight',
                         type=float,
                         default=0.0,
-                        help='attention weight for attention rescoring decode mode
+                        help='attention weight for attention rescoring decode mode \
                               attention weight for rescoring weight in transducer attention rescore mode')
     parser.add_argument('--decoding_chunk_size',
                         type=int,

--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -79,7 +79,7 @@ def get_args():
                         default=0.0,
                         help='transducer weight for nbest generation in transducer \
                                   attention rescoring decode mode')
-    parser.add_argument('--ctc_weight',
+    parser.add_argument('--rescore_ctc_weight',
                         type=float,
                         default=0.0,
                         help='ctc weight for attention rescoring decode mode \
@@ -87,14 +87,14 @@ def get_args():
                                   decode mode \
                               ctc weight for rescoring weight in transducer attention \
                                   rescore mode')
-    parser.add_argument('--transducer_weight',
+    parser.add_argument('--rescore_transducer_weight',
                         type=float,
                         default=0.0,
                         help='transducer weight for nbest generation in beam \
                                  search decode mode \
                               transducer weight for rescoring weight in transducer \
                                  attention rescore mode')
-    parser.add_argument('--attn_weight',
+    parser.add_argument('--rescore_attn_weight',
                         type=float,
                         default=0.0,
                         help='attention weight for attention rescoring decode mode \
@@ -242,8 +242,8 @@ def main():
                     beam_size=args.beam_size,
                     num_decoding_left_chunks=args.num_decoding_left_chunks,
                     simulate_streaming=args.simulate_streaming,
-                    ctc_weight=args.ctc_weight,
-                    transducer_weight=args.transducer_weight)
+                    ctc_weight=args.search_ctc_weight,
+                    transducer_weight=args.search_transducer_weight)
             elif args.mode == 'rnnt_beam_attn_rescoring':
                 assert (feats.size(0) == 1)
                 assert 'predictor' in configs
@@ -254,9 +254,9 @@ def main():
                     beam_size=args.beam_size,
                     num_decoding_left_chunks=args.num_decoding_left_chunks,
                     simulate_streaming=args.simulate_streaming,
-                    ctc_weight=args.ctc_weight,
-                    transducer_weight=args.transducer_weight,
-                    attn_weight=args.attn_weight,
+                    ctc_weight=args.rescore_ctc_weight,
+                    transducer_weight=args.rescore_transducer_weight,
+                    attn_weight=args.rescore_attn_weight,
                     reverse_weight=args.reverse_weight,
                     search_ctc_weight=args.search_ctc_weight,
                     search_transducer_weight=args.search_transducer_weight)
@@ -281,7 +281,7 @@ def main():
                     args.beam_size,
                     decoding_chunk_size=args.decoding_chunk_size,
                     num_decoding_left_chunks=args.num_decoding_left_chunks,
-                    ctc_weight=args.ctc_weight,
+                    ctc_weight=args.rescore_ctc_weight,
                     simulate_streaming=args.simulate_streaming,
                     reverse_weight=args.reverse_weight)
                 hyps = [hyp]

--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -64,7 +64,7 @@ def get_args():
                             'attention', 'ctc_greedy_search',
                             'ctc_prefix_beam_search', 'attention_rescoring',
                             'rnnt_greedy_search', 'rnnt_beam_search',
-                            'rnnt_attn_rescoring', 'rnnt_beam_attn_rescoring'
+                            'rnnt_beam_attn_rescoring'
                         ],
                         default='attention',
                         help='decoding mode')

--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -63,8 +63,8 @@ def get_args():
                         choices=[
                             'attention', 'ctc_greedy_search',
                             'ctc_prefix_beam_search', 'attention_rescoring',
-                            'rnnt_greedy_search','rnnt_beam_search',
-                            'rnnt_attn_rescoring','rnnt_beam_attn_rescoring'
+                            'rnnt_greedy_search', 'rnnt_beam_search',
+                            'rnnt_attn_rescoring', 'rnnt_beam_attn_rescoring'
                         ],
                         default='attention',
                         help='decoding mode')
@@ -72,27 +72,34 @@ def get_args():
     parser.add_argument('--search_ctc_weight',
                         type=float,
                         default=1.0,
-                        help='ctc weight for nbest generation in transducer attention rescoring decode mode')
+                        help='ctc weight for nbest generation in transducer \
+                                  attention rescoring decode mode')
     parser.add_argument('--search_transducer_weight',
                         type=float,
                         default=0.0,
-                        help='transducer weight for nbest generation in transducer attention rescoring decode mode')
+                        help='transducer weight for nbest generation in transducer \
+                                  attention rescoring decode mode')
     parser.add_argument('--ctc_weight',
                         type=float,
                         default=0.0,
                         help='ctc weight for attention rescoring decode mode \
-                              ctc weight for nbest generation in beam search decode mode \
-                              ctc weight for rescoring weight in transducer attention rescore mode')
+                              ctc weight for nbest generation in beam search \
+                                  decode mode \
+                              ctc weight for rescoring weight in transducer attention \
+                                  rescore mode')
     parser.add_argument('--transducer_weight',
                         type=float,
                         default=0.0,
-                        help='transducer weight for nbest generation in beam search decode mode \
-                              transducer weight for rescoring weight in transducer attention rescore mode')
+                        help='transducer weight for nbest generation in beam \
+                                 search decode mode \
+                              transducer weight for rescoring weight in transducer \
+                                 attention rescore mode')
     parser.add_argument('--attn_weight',
                         type=float,
                         default=0.0,
                         help='attention weight for attention rescoring decode mode \
-                              attention weight for rescoring weight in transducer attention rescore mode')
+                              attention weight for rescoring weight in transducer \
+                              attention rescore mode')
     parser.add_argument('--decoding_chunk_size',
                         type=int,
                         default=-1,

--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -80,19 +80,19 @@ def get_args():
     parser.add_argument('--ctc_weight',
                         type=float,
                         default=0.0,
-                        help='1. ctc weight for attention rescoring decode mode 
-                              2. ctc weight for nbest generation in beam search decode mode 
-                              3. ctc weight for rescoring weight in transducer attention rescore mode')
+                        help='ctc weight for attention rescoring decode mode
+                              ctc weight for nbest generation in beam search decode mode
+                              ctc weight for rescoring weight in transducer attention rescore mode')
     parser.add_argument('--transducer_weight',
                         type=float,
                         default=0.0,
-                        help='1. transducer weight for nbest generation in beam search decode mode
-                              2. transducer weight for rescoring weight in transducer attention rescore mode')
+                        help='transducer weight for nbest generation in beam search decode mode
+                              transducer weight for rescoring weight in transducer attention rescore mode')
     parser.add_argument('--attn_weight',
                         type=float,
                         default=0.0,
-                        help='1. attention weight for attention rescoring decode mode
-                              2. attention weight for rescoring weight in transducer attention rescore mode')
+                        help='attention weight for attention rescoring decode mode
+                              attention weight for rescoring weight in transducer attention rescore mode')
     parser.add_argument('--decoding_chunk_size',
                         type=int,
                         default=-1,

--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -79,22 +79,19 @@ def get_args():
                         default=0.0,
                         help='transducer weight for nbest generation in transducer \
                                   attention rescoring decode mode')
-    parser.add_argument('--rescore_ctc_weight',
+    parser.add_argument('--ctc_weight',
                         type=float,
                         default=0.0,
-                        help='ctc weight for attention rescoring decode mode \
-                              ctc weight for nbest generation in beam search \
-                                  decode mode \
-                              ctc weight for rescoring weight in transducer attention \
-                                  rescore mode')
-    parser.add_argument('--rescore_transducer_weight',
+                        help='ctc weight for attention rescoring decode mode')
+
+    parser.add_argument('--transducer_weight',
                         type=float,
                         default=0.0,
                         help='transducer weight for nbest generation in beam \
                                  search decode mode \
                               transducer weight for rescoring weight in transducer \
                                  attention rescore mode')
-    parser.add_argument('--rescore_attn_weight',
+    parser.add_argument('--attn_weight',
                         type=float,
                         default=0.0,
                         help='attention weight for attention rescoring decode mode \
@@ -254,9 +251,9 @@ def main():
                     beam_size=args.beam_size,
                     num_decoding_left_chunks=args.num_decoding_left_chunks,
                     simulate_streaming=args.simulate_streaming,
-                    ctc_weight=args.rescore_ctc_weight,
-                    transducer_weight=args.rescore_transducer_weight,
-                    attn_weight=args.rescore_attn_weight,
+                    ctc_weight=args.ctc_weight,
+                    transducer_weight=args.transducer_weight,
+                    attn_weight=args.attn_weight,
                     reverse_weight=args.reverse_weight,
                     search_ctc_weight=args.search_ctc_weight,
                     search_transducer_weight=args.search_transducer_weight)
@@ -281,7 +278,7 @@ def main():
                     args.beam_size,
                     decoding_chunk_size=args.decoding_chunk_size,
                     num_decoding_left_chunks=args.num_decoding_left_chunks,
-                    ctc_weight=args.rescore_ctc_weight,
+                    ctc_weight=args.ctc_weight,
                     simulate_streaming=args.simulate_streaming,
                     reverse_weight=args.reverse_weight)
                 hyps = [hyp]

--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -72,30 +72,26 @@ def get_args():
     parser.add_argument('--search_ctc_weight',
                         type=float,
                         default=1.0,
-                        help='ctc weight for nbest generation in transducer \
-                                  attention rescoring decode mode')
+                        help='ctc weight for nbest generation')
     parser.add_argument('--search_transducer_weight',
                         type=float,
                         default=0.0,
-                        help='transducer weight for nbest generation in transducer \
-                                  attention rescoring decode mode')
+                        help='transducer weight for nbest generation')
     parser.add_argument('--ctc_weight',
                         type=float,
                         default=0.0,
-                        help='ctc weight for attention rescoring decode mode')
+                        help='ctc weight for rescoring weight in attention rescoring decode mode \
+                              ctc weight for rescoring weight in transducer attention rescore decode mode')
 
     parser.add_argument('--transducer_weight',
                         type=float,
                         default=0.0,
-                        help='transducer weight for nbest generation in beam \
-                                 search decode mode \
-                              transducer weight for rescoring weight in transducer \
+                        help='transducer weight for rescoring weight in transducer \
                                  attention rescore mode')
     parser.add_argument('--attn_weight',
                         type=float,
                         default=0.0,
-                        help='attention weight for attention rescoring decode mode \
-                              attention weight for rescoring weight in transducer \
+                        help='attention weight for rescoring weight in transducer \
                               attention rescore mode')
     parser.add_argument('--decoding_chunk_size',
                         type=int,

--- a/wenet/transducer/predictor.py
+++ b/wenet/transducer/predictor.py
@@ -107,8 +107,9 @@ class RNNPredictor(torch.nn.Module):
         out, (m, c) = self.rnn(embed, (state_m, state_c))
 
         out = self.projection(out)
-        m = ApplyPadding(m, padding, state_m)
-        c = ApplyPadding(c, padding, state_c)
+        if padding is not None:
+            m = ApplyPadding(m, padding, state_m)
+            c = ApplyPadding(c, padding, state_c)
         return out, m, c
 
 

--- a/wenet/transducer/search/prefix_beam_search.py
+++ b/wenet/transducer/search/prefix_beam_search.py
@@ -2,7 +2,9 @@ import torch
 from wenet.utils.common import log_add
 
 class Sequence():
+
     __slots__ = {'hyp', 'score', 'h_0', 'c_0', 'last'}
+
     def __init__(
         self,
         hyp: torch.Tensor,

--- a/wenet/transducer/search/prefix_beam_search.py
+++ b/wenet/transducer/search/prefix_beam_search.py
@@ -96,7 +96,7 @@ class PrefixBeamSearch():
             # decoder taking the last token to predict the next token
             input_hyp = [ s.hyp[-1]  for s in beam_init]
             input_hyp_tensor = torch.tensor(input_hyp, dtype=torch.int, device=device)
-            # building statement from beam 
+            # building statement from beam
             h_0 = torch.cat(
                 [s.h_0 for s in beam_init], dim = 1
             ).to(device)
@@ -120,7 +120,7 @@ class PrefixBeamSearch():
             # 3.4 first beam prune
             top_k_logp, top_k_index = logp.topk(beam_size)  # (N, N)
             scores = torch.add(scores.unsqueeze(1), top_k_logp)
-            
+
             # 3.5 generate new beam (N*N)
             beam_A = []
             for j in range(len(beam_init)):
@@ -185,7 +185,7 @@ class PrefixBeamSearch():
                         fusion_A[t].score = log_add([fusion_A[t].score, s1.score])
                         if_do_append = False
                         break
-                if if_do_append: 
+                if if_do_append:
                     fusion_A.append(s1)
 
             # 4. second pruned

--- a/wenet/transducer/search/prefix_beam_search.py
+++ b/wenet/transducer/search/prefix_beam_search.py
@@ -41,9 +41,9 @@ class PrefixBeamSearch():
         c_0: torch.Tensor,
     ):
         pre_t, h_1, c_1 = self.predictor.forward_step(
-            pre_t.unsqueeze(-1), 
-            None, 
-            h_0, 
+            pre_t.unsqueeze(-1),
+            None,
+            h_0,
             c_0
         )
         x = self.joint(encoder_x, pre_t)
@@ -122,8 +122,12 @@ class PrefixBeamSearch():
 
             # 3.3 shallow fusion for transducer score
             #     and ctc score where we can also add the LM score
-            logp = torch.log(torch.add(transducer_weight * torch.exp(logp),
-                ctc_weight * torch.exp(ctc_probs[i].unsqueeze(0))))
+            logp = torch.log(
+                torch.add(
+                    transducer_weight * torch.exp(logp),
+                    ctc_weight * torch.exp(ctc_probs[i].unsqueeze(0))
+                )
+            )
 
             # 3.4 first beam prune
             top_k_logp, top_k_index = logp.topk(beam_size)  # (N, N)

--- a/wenet/transducer/search/prefix_beam_search.py
+++ b/wenet/transducer/search/prefix_beam_search.py
@@ -1,0 +1,202 @@
+import torch
+from wenet.utils.common import log_add
+class Sequence():
+    def __init__(
+        self,
+        hyp:torch.Tensor,
+        score,
+        h_0:torch.Tensor,
+        c_0: torch.Tensor,
+        last,
+    ):
+        self.hyp = hyp
+        self.score = score
+        self.h_0 = h_0
+        self.c_0 = c_0
+        self.last = last
+
+class PrefixBeamSearch():
+    def __init__(
+        self,
+        encoder,
+        predictor,
+        joint,
+        ctc,
+        sos,
+        blank
+    ):
+        self.encoder = encoder 
+        self.predictor = predictor
+        self.joint = joint
+        self.ctc = ctc
+        self.sos = sos
+        self.blank = blank
+    
+    def forward_decoder_one_step(
+        self,
+        encoder_x: torch.Tensor,
+        pre_t: torch.Tensor,
+        h_0: torch.Tensor,
+        c_0: torch.Tensor,
+    ):
+        
+        pre_t,h_1, c_1 = self.predictor.forward_step(pre_t.unsqueeze(-1),None, h_0,c_0 )
+        x = self.joint(encoder_x, pre_t)
+        x = x.log_softmax(dim=-1)
+        
+        return x, (h_1,c_1)
+
+    def prefix_beam_search(
+        self,
+        speech: torch.Tensor,
+        speech_lengths: torch.Tensor,
+        decoding_chunk_size: int = -1,
+        beam_size: int = 5,
+        num_decoding_left_chunks: int = -1,
+        simulate_streaming: bool = False,
+        ctc_weight: float= 0.3,
+        transducer_weight: float = 0.7
+    ):
+        """prefix beam search
+           also see wenet.transducer.transducer.beam_search
+        """
+        assert speech.shape[0] == speech_lengths.shape[0]
+        assert decoding_chunk_size != 0
+        device = speech.device
+        batch_size = speech.shape[0]
+        assert batch_size == 1
+
+        # 1. Encoder
+        encoder_out, encoder_mask = self.encoder(
+            speech, speech_lengths, decoding_chunk_size,
+            num_decoding_left_chunks)  # (B, maxlen, encoder_dim)
+        maxlen = encoder_out.size(1)
+        encoder_dim = encoder_out.size(2)
+        running_size = batch_size * beam_size
+        predictor_num = self.predictor.n_layers
+
+        ctc_probs = self.ctc.log_softmax(
+                encoder_out).squeeze(0)
+        beam_init=[]
+        
+        # 2. init beam using Sequence to save beam unit
+        h_0,c_0 = self.predictor.init_state(1, method="zero")
+        beam_init.append( 
+            Sequence(
+                hyp = [self.blank],
+                score = torch.tensor(0.0),
+                h_0 = h_0,
+                c_0 = c_0,
+                last = self.blank,
+            ) 
+        )
+        # 3. start decoding (notice: we use breathwise first searching)
+        # !!!! In this decoding method: one frame do not output multi units. !!!!
+        # !!!!    Experiments show that this strategy has little impact      !!!!
+        for  i in range(maxlen):
+            # 3.1 building input
+            # decoder taking the last token to predict the next token
+            input_hyp = [ s.hyp[-1]  for s in beam_init]
+            input_hyp_tensor = torch.tensor(input_hyp, dtype=torch.int, device=device)
+            # building statement from beam 
+            h_0 = torch.cat(
+                [s.h_0 for s in beam_init], dim = 1
+            ).to(device)
+            c_0 = torch.concat(
+                [s.c_0 for s in beam_init], dim = 1
+            ).to(device)
+            # build score tensor to do torch.add() function
+            scores = torch.concat(
+                [s.score.unsqueeze(0) for s in beam_init], dim = 0
+            ).to(device)
+
+            # 3.2 forward decoder 
+            logp, (h_1, c_1) = self.forward_decoder_one_step(
+                encoder_out[:,i,:].unsqueeze(1), input_hyp_tensor, h_0, c_0
+            )# logp: (N, 1, 1, vocab_size)
+            logp = logp.squeeze(1).squeeze(1) # logp: (N, vocab_size)
+
+            # 3.3 shallow fusion for transducer score and ctc score where we can also add the LM score
+            logp = torch.log(torch.add(transducer_weight * torch.exp(logp), ctc_weight * torch.exp(ctc_probs[i].unsqueeze(0))))
+           
+            # 3.4 first beam prune
+            top_k_logp, top_k_index = logp.topk(beam_size)  # (N, N)
+            scores = torch.add(scores.unsqueeze(1), top_k_logp)
+            
+            # 3.5 generate new beam (N*N)
+            beam_A = []
+            for j in range(len(beam_init)):
+                # update seq
+                base_seq = beam_init[j]
+                for t in range(beam_size):
+                    # blank: only update the score and last 
+                    if top_k_index[j,t] == self.blank:
+                        new_seq = Sequence(
+                            hyp = base_seq.hyp.copy(),
+                            score = scores[j,t],
+                            h_0 = h_0[:,j,:].unsqueeze(1),
+                            c_0 = c_0[:,j,:].unsqueeze(1),
+                            last=self.blank
+                        )
+
+                        beam_A.append(new_seq)
+                    # hyp[-1]: if last is blank{update hyp and statement} 
+                    #          else {dont update hyp and statement}
+                    elif top_k_index[j,t] == base_seq.hyp[-1] :
+                        if base_seq.last == self.blank:
+                            hyp_new = base_seq.hyp.copy()
+                            hyp_new.append(top_k_index[j,t].item())
+                            new_seq = Sequence(
+                                hyp = hyp_new,
+                                score = scores[j,t],
+                                h_0 = h_1[:,j,:].unsqueeze(1),
+                                c_0 = c_1[:,j,:].unsqueeze(1),
+                                last = top_k_index[j,t].item()
+                            )
+                            
+                            beam_A.append(new_seq)
+                        else:
+                            new_seq = Sequence(
+                                hyp = base_seq.hyp.copy(),
+                                score = scores[j,t],
+                                h_0 = h_0[:,j,:].unsqueeze(1),
+                                c_0 = c_0[:,j,:].unsqueeze(1),
+                                last=top_k_index[j,t].item()
+                            )
+
+                            beam_A.append(new_seq)
+                    # other unit: update hyp score statement and last
+                    else:
+                        hyp_new = base_seq.hyp.copy()
+                        hyp_new.append(top_k_index[j,t].item())
+                        new_seq = Sequence(
+                            hyp = hyp_new,
+                            score = scores[j,t],
+                            h_0 = h_1[:,j,:].unsqueeze(1),
+                            c_0 = c_1[:,j,:].unsqueeze(1),
+                            last = top_k_index[j,t].item()
+                        )
+                        
+                        beam_A.append(new_seq)
+            
+            # 3.6 prefix fusion
+            fusion_A = [beam_A[0]]
+            for j in range(1,len(beam_A)):
+                s1 = beam_A[j]
+                if_do_append = True
+                for t in range(len(fusion_A)):
+                    # notice: A_ can not fusion with A  
+                    if s1.hyp == fusion_A[t].hyp and s1.last == fusion_A[t].last :
+                        fusion_A[t].score = log_add([fusion_A[t].score, s1.score])
+                        if_do_append = False
+                        break
+                if if_do_append:   
+                    fusion_A.append(s1)
+
+            # 4. second pruned
+            fusion_A.sort(key=lambda x:x.score, reverse=True)
+            beam_init = fusion_A[:beam_size]
+        
+        return beam_init,encoder_out
+
+    

--- a/wenet/transducer/search/prefix_beam_search.py
+++ b/wenet/transducer/search/prefix_beam_search.py
@@ -40,7 +40,12 @@ class PrefixBeamSearch():
         h_0: torch.Tensor,
         c_0: torch.Tensor,
     ):
-        pre_t, h_1, c_1 = self.predictor.forward_step(pre_t.unsqueeze(-1), None, h_0, c_0)
+        pre_t, h_1, c_1 = self.predictor.forward_step(
+            pre_t.unsqueeze(-1), 
+            None, 
+            h_0, 
+            c_0
+        )
         x = self.joint(encoder_x, pre_t)
         x = x.log_softmax(dim=-1)
         return x, (h_1, c_1)
@@ -115,10 +120,10 @@ class PrefixBeamSearch():
             )  # logp: (N, 1, 1, vocab_size)
             logp = logp.squeeze(1).squeeze(1)  # logp: (N, vocab_size)
 
-            # 3.3 shallow fusion for transducer score 
+            # 3.3 shallow fusion for transducer score
             #     and ctc score where we can also add the LM score
-            logp = torch.log(torch.add(transducer_weight * torch.exp(logp), \
-                          ctc_weight * torch.exp(ctc_probs[i].unsqueeze(0))))
+            logp = torch.log(torch.add(transducer_weight * torch.exp(logp),
+                ctc_weight * torch.exp(ctc_probs[i].unsqueeze(0))))
 
             # 3.4 first beam prune
             top_k_logp, top_k_index = logp.topk(beam_size)  # (N, N)
@@ -149,7 +154,7 @@ class PrefixBeamSearch():
                             hyp_new.append(top_k_index[j, t].item())
                             new_seq = Sequence(
                                 hyp=hyp_new,
-                                score=scores[j,t],
+                                score=scores[j, t],
                                 h_0=h_1[:, j, :].unsqueeze(1),
                                 c_0=c_1[:, j, :].unsqueeze(1),
                                 last=top_k_index[j, t].item()

--- a/wenet/transducer/search/prefix_beam_search.py
+++ b/wenet/transducer/search/prefix_beam_search.py
@@ -1,11 +1,12 @@
 import torch
 from wenet.utils.common import log_add
+
 class Sequence():
     def __init__(
         self,
-        hyp:torch.Tensor,
+        hyp: torch.Tensor,
         score,
-        h_0:torch.Tensor,
+        h_0: torch.Tensor,
         c_0: torch.Tensor,
         last,
     ):
@@ -39,10 +40,10 @@ class PrefixBeamSearch():
         h_0: torch.Tensor,
         c_0: torch.Tensor,
     ):
-        pre_t,h_1, c_1 = self.predictor.forward_step(pre_t.unsqueeze(-1),None, h_0,c_0 )
+        pre_t, h_1, c_1 = self.predictor.forward_step(pre_t.unsqueeze(-1), None, h_0, c_0)
         x = self.joint(encoder_x, pre_t)
         x = x.log_softmax(dim=-1)
-        return x, (h_1,c_1)
+        return x, (h_1, c_1)
 
     def prefix_beam_search(
         self,
@@ -52,7 +53,7 @@ class PrefixBeamSearch():
         beam_size: int = 5,
         num_decoding_left_chunks: int = -1,
         simulate_streaming: bool = False,
-        ctc_weight: float= 0.3,
+        ctc_weight: float = 0.3,
         transducer_weight: float = 0.7
     ):
         """prefix beam search
@@ -74,48 +75,50 @@ class PrefixBeamSearch():
         predictor_num = self.predictor.n_layers
 
         ctc_probs = self.ctc.log_softmax(
-                encoder_out).squeeze(0)
-        beam_init=[]
+            encoder_out).squeeze(0)
+        beam_init = []
 
         # 2. init beam using Sequence to save beam unit
-        h_0,c_0 = self.predictor.init_state(1, method="zero")
+        h_0, c_0 = self.predictor.init_state(1, method="zero")
         beam_init.append(
             Sequence(
-                hyp = [self.blank],
-                score = torch.tensor(0.0),
-                h_0 = h_0,
-                c_0 = c_0,
-                last = self.blank,
+                hyp=[self.blank],
+                score=torch.tensor(0.0),
+                h_0=h_0,
+                c_0=c_0,
+                last=self.blank,
             )
         )
         # 3. start decoding (notice: we use breathwise first searching)
         # !!!! In this decoding method: one frame do not output multi units. !!!!
         # !!!!    Experiments show that this strategy has little impact      !!!!
-        for  i in range(maxlen):
+        for i in range(maxlen):
             # 3.1 building input
             # decoder taking the last token to predict the next token
-            input_hyp = [ s.hyp[-1]  for s in beam_init]
+            input_hyp = [s.hyp[-1] for s in beam_init]
             input_hyp_tensor = torch.tensor(input_hyp, dtype=torch.int, device=device)
             # building statement from beam
             h_0 = torch.cat(
-                [s.h_0 for s in beam_init], dim = 1
+                [s.h_0 for s in beam_init], dim=1
             ).to(device)
             c_0 = torch.concat(
-                [s.c_0 for s in beam_init], dim = 1
+                [s.c_0 for s in beam_init], dim=1
             ).to(device)
             # build score tensor to do torch.add() function
             scores = torch.concat(
-                [s.score.unsqueeze(0) for s in beam_init], dim = 0
+                [s.score.unsqueeze(0) for s in beam_init], dim=0
             ).to(device)
 
             # 3.2 forward decoder
             logp, (h_1, c_1) = self.forward_decoder_one_step(
-                encoder_out[:,i,:].unsqueeze(1), input_hyp_tensor, h_0, c_0
-            )# logp: (N, 1, 1, vocab_size)
-            logp = logp.squeeze(1).squeeze(1) # logp: (N, vocab_size)
+                encoder_out[:, i, :].unsqueeze(1), input_hyp_tensor, h_0, c_0
+            )  # logp: (N, 1, 1, vocab_size)
+            logp = logp.squeeze(1).squeeze(1)  # logp: (N, vocab_size)
 
-            # 3.3 shallow fusion for transducer score and ctc score where we can also add the LM score
-            logp = torch.log(torch.add(transducer_weight * torch.exp(logp), ctc_weight * torch.exp(ctc_probs[i].unsqueeze(0))))
+            # 3.3 shallow fusion for transducer score 
+            #     and ctc score where we can also add the LM score
+            logp = torch.log(torch.add(transducer_weight * torch.exp(logp), \
+                          ctc_weight * torch.exp(ctc_probs[i].unsqueeze(0))))
 
             # 3.4 first beam prune
             top_k_logp, top_k_index = logp.topk(beam_size)  # (N, N)
@@ -128,55 +131,55 @@ class PrefixBeamSearch():
                 base_seq = beam_init[j]
                 for t in range(beam_size):
                     # blank: only update the score and last
-                    if top_k_index[j,t] == self.blank:
+                    if top_k_index[j, t] == self.blank:
                         new_seq = Sequence(
-                            hyp = base_seq.hyp.copy(),
-                            score = scores[j,t],
-                            h_0 = h_0[:,j,:].unsqueeze(1),
-                            c_0 = c_0[:,j,:].unsqueeze(1),
+                            hyp=base_seq.hyp.copy(),
+                            score=scores[j, t],
+                            h_0=h_0[:, j, :].unsqueeze(1),
+                            c_0=c_0[:, j, :].unsqueeze(1),
                             last=self.blank
                         )
 
                         beam_A.append(new_seq)
                     # hyp[-1]: if last is blank{update hyp and statement}
                     #          else {dont update hyp and statement}
-                    elif top_k_index[j,t] == base_seq.hyp[-1] :
+                    elif top_k_index[j, t] == base_seq.hyp[-1] :
                         if base_seq.last == self.blank:
                             hyp_new = base_seq.hyp.copy()
-                            hyp_new.append(top_k_index[j,t].item())
+                            hyp_new.append(top_k_index[j, t].item())
                             new_seq = Sequence(
-                                hyp = hyp_new,
-                                score = scores[j,t],
-                                h_0 = h_1[:,j,:].unsqueeze(1),
-                                c_0 = c_1[:,j,:].unsqueeze(1),
-                                last = top_k_index[j,t].item()
+                                hyp=hyp_new,
+                                score=scores[j,t],
+                                h_0=h_1[:, j, :].unsqueeze(1),
+                                c_0=c_1[:, j, :].unsqueeze(1),
+                                last=top_k_index[j, t].item()
                             )
                             beam_A.append(new_seq)
                         else:
                             new_seq = Sequence(
-                                hyp = base_seq.hyp.copy(),
-                                score = scores[j,t],
-                                h_0 = h_0[:,j,:].unsqueeze(1),
-                                c_0 = c_0[:,j,:].unsqueeze(1),
-                                last=top_k_index[j,t].item()
+                                hyp=base_seq.hyp.copy(),
+                                score=scores[j, t],
+                                h_0=h_0[:, j, :].unsqueeze(1),
+                                c_0=c_0[:, j, :].unsqueeze(1),
+                                last=top_k_index[j, t].item()
                             )
                             beam_A.append(new_seq)
                     # other unit: update hyp score statement and last
                     else:
                         hyp_new = base_seq.hyp.copy()
-                        hyp_new.append(top_k_index[j,t].item())
+                        hyp_new.append(top_k_index[j, t].item())
                         new_seq = Sequence(
-                            hyp = hyp_new,
-                            score = scores[j,t],
-                            h_0 = h_1[:,j,:].unsqueeze(1),
-                            c_0 = c_1[:,j,:].unsqueeze(1),
-                            last = top_k_index[j,t].item()
+                            hyp=hyp_new,
+                            score=scores[j, t],
+                            h_0=h_1[:, j, :].unsqueeze(1),
+                            c_0=c_1[:, j, :].unsqueeze(1),
+                            last=top_k_index[j, t].item()
                         )
                         beam_A.append(new_seq)
 
             # 3.6 prefix fusion
             fusion_A = [beam_A[0]]
-            for j in range(1,len(beam_A)):
+            for j in range(1, len(beam_A)):
                 s1 = beam_A[j]
                 if_do_append = True
                 for t in range(len(fusion_A)):
@@ -189,6 +192,6 @@ class PrefixBeamSearch():
                     fusion_A.append(s1)
 
             # 4. second pruned
-            fusion_A.sort(key=lambda x:x.score, reverse=True)
+            fusion_A.sort(key=lambda x: x.score, reverse=True)
             beam_init = fusion_A[:beam_size]
-        return beam_init,encoder_out
+        return beam_init, encoder_out

--- a/wenet/transducer/search/prefix_beam_search.py
+++ b/wenet/transducer/search/prefix_beam_search.py
@@ -2,6 +2,7 @@ import torch
 from wenet.utils.common import log_add
 
 class Sequence():
+    __slots__ = {'hyp', 'score', 'h_0', 'c_0', 'last'}
     def __init__(
         self,
         hyp: torch.Tensor,

--- a/wenet/transducer/transducer.py
+++ b/wenet/transducer/transducer.py
@@ -251,15 +251,15 @@ class Transducer(nn.Module):
             simulate_streaming (bool): whether do encoder forward in a
                 streaming fashion
             ctc_weight (float): ctc probability weight using in rescoring.
-                rescore_prob = ctc_weight * ctc_prob + 
+                rescore_prob = ctc_weight * ctc_prob +
                                transducer_weight * (transducer_loss * -1) +
                                attn_weight * attn_prob
             attn_weight (float): attn probability weight using in rescoring.
             transducer_weight (float): transducer probability weight using in
                 rescoring
-            search_ctc_weight (float): ctc weight using 
+            search_ctc_weight (float): ctc weight using
                                in rnnt beam search (seeing in self.beam_search)
-            search_transducer_weight (float): transducer weight using 
+            search_transducer_weight (float): transducer weight using
                                in rnnt beam search (seeing in self.beam_search)
         Returns:
             List[List[int]]: best path result
@@ -294,7 +294,7 @@ class Transducer(nn.Module):
         hyps_pad = pad_sequence([
             torch.tensor(hyp, device=device, dtype=torch.long)
             for hyp in hyps
-        ], True, self.ignore_id)# (beam_size, max_hyps_len)
+        ], True, self.ignore_id)  # (beam_size, max_hyps_len)
         # (beam_size, max_hyps_len)
         hyps_pad_blank = add_blank(hyps_pad, self.blank, self.ignore_id)
         ori_hyps_pad = hyps_pad
@@ -362,8 +362,8 @@ class Transducer(nn.Module):
                 score = score * (1 - reverse_weight) + r_score * reverse_weight
             # add ctc score
             score = score * attn_weight + \
-                    beam_score[i] * ctc_weight + \
-                    td_s * transducer_weight
+                beam_score[i] * ctc_weight + \
+                td_s * transducer_weight
             if score > best_score:
                 best_score = score
                 best_index = i

--- a/wenet/transducer/transducer.py
+++ b/wenet/transducer/transducer.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Optional, Tuple, Union
-
+from collections import defaultdict
+ 
 import torch
 import torchaudio
 from torch import nn
@@ -7,8 +8,10 @@ from typeguard import check_argument_types
 from wenet.transformer.ctc import CTC
 from wenet.transformer.decoder import BiTransformerDecoder, TransformerDecoder
 from wenet.transformer.label_smoothing_loss import LabelSmoothingLoss
-from wenet.utils.common import (IGNORE_ID, add_blank, add_sos_eos,
+from wenet.utils.common import (IGNORE_ID, add_blank, add_sos_eos,log_add,
                                 reverse_pad_list, th_accuracy)
+from wenet.transducer.search.prefix_beam_search import PrefixBeamSearch
+from torch.nn.utils.rnn import pad_sequence
 
 
 class Transducer(nn.Module):
@@ -50,6 +53,7 @@ class Transducer(nn.Module):
         self.joint = joint
         self.ctc = ctc
         self.attention_decoder = attention_decoder
+        self.bs = None
         if attention_decoder is not None:
             self.criterion_att = LabelSmoothingLoss(
                 size=vocab_size,
@@ -161,6 +165,210 @@ class Transducer(nn.Module):
         )
         return loss_att, acc_att
 
+    def init_bs(self):
+        if self.bs is None:
+            self.bs = PrefixBeamSearch(
+                self.encoder, 
+                self.predictor, 
+                self.joint,
+                self.ctc,
+                self.sos,
+                self.blank)
+
+    def beam_search(
+        self,
+        speech: torch.Tensor,
+        speech_lengths: torch.Tensor,
+        decoding_chunk_size: int = -1,
+        beam_size: int = 5,
+        num_decoding_left_chunks: int = -1,
+        simulate_streaming: bool = False,
+        ctc_weight: float= 0.3,
+        transducer_weight: float = 0.7,
+    ):
+        """beam search
+
+        Args:
+            speech (torch.Tensor): (batch=1, max_len, feat_dim)
+            speech_length (torch.Tensor): (batch, )
+            beam_size (int): beam size for beam search
+            decoding_chunk_size (int): decoding chunk for dynamic chunk
+                trained model.
+                <0: for decoding, use full chunk.
+                >0: for decoding, use fixed chunk size as set.
+                0: used for training, it's prohibited here
+            simulate_streaming (bool): whether do encoder forward in a
+                streaming fashion
+            ctc_weight (float): ctc probability weight in transducer 
+                prefix beam search.
+                final_prob = ctc_weight * ctc_prob + transducer_weight * transducer_prob
+            transducer_weight (float): transducer probability weight in 
+                prefix beam search
+        Returns:
+            List[List[int]]: best path result
+
+        """
+        self.init_bs()
+        beam,_ = self.bs.prefix_beam_search(
+            speech,
+            speech_lengths,
+            decoding_chunk_size,
+            beam_size,
+            num_decoding_left_chunks,
+            simulate_streaming,
+            ctc_weight,
+            transducer_weight,
+        )
+        return beam[0].hyp[1:], beam[0].score
+
+
+
+    def transducer_attention_rescoring(
+        self,
+        speech: torch.Tensor,
+        speech_lengths: torch.Tensor,
+        beam_size: int,
+        decoding_chunk_size: int = -1,
+        num_decoding_left_chunks: int = -1,
+        simulate_streaming: bool = False,
+        reverse_weight: float = 0.0,
+        ctc_weight: float = 0.0,
+        attn_weight: float = 0.0,
+        transducer_weight: float=0.0,
+        search_ctc_weight: float=1.0,
+        search_transducer_weight: float = 0.0
+    ) -> List[List[int]]:
+        """beam search
+
+        Args:
+            speech (torch.Tensor): (batch=1, max_len, feat_dim)
+            speech_length (torch.Tensor): (batch, )
+            beam_size (int): beam size for beam search
+            decoding_chunk_size (int): decoding chunk for dynamic chunk
+                trained model.
+                <0: for decoding, use full chunk.
+                >0: for decoding, use fixed chunk size as set.
+                0: used for training, it's prohibited here
+            simulate_streaming (bool): whether do encoder forward in a
+                streaming fashion
+            ctc_weight (float): ctc probability weight using in rescoring.
+                rescore_prob = ctc_weight * ctc_prob + transducer_weight * (transducer_loss * -1 ) 
+                             + attn_weight * attn_prob 
+            attn_weight (float): attn probability weight using in rescoring.
+            transducer_weight (float): transducer probability weight using in
+                rescoring
+            search_ctc_weight (float): ctc weight using in rnnt beam search (seeing in self.beam_search)
+            search_transducer_weight (float): transducer weight using in rnnt beam search (seeing in self.beam_search)
+        Returns:
+            List[List[int]]: best path result
+
+        """
+
+        assert speech.shape[0] == speech_lengths.shape[0]
+        assert decoding_chunk_size != 0
+        if reverse_weight > 0.0:
+            # decoder should be a bitransformer decoder if reverse_weight > 0.0
+            assert hasattr(self.decoder, 'right_decoder')
+        device = speech.device
+        batch_size = speech.shape[0]
+        # For attention rescoring we only support batch_size=1
+        assert batch_size == 1
+        # encoder_out: (1, maxlen, encoder_dim), len(hyps) = beam_size
+        self.init_bs()
+        beam, encoder_out = self.bs.prefix_beam_search(
+            speech,
+            speech_lengths,
+            decoding_chunk_size=decoding_chunk_size,
+            beam_size=beam_size,
+            num_decoding_left_chunks=num_decoding_left_chunks,
+            ctc_weight=search_ctc_weight,
+            transducer_weight=search_transducer_weight,
+        )
+        
+
+        hyps = [s.hyp[1:]  for s in beam]
+        beam_score = [s.score for s in beam]
+        
+
+        assert len(hyps) == beam_size
+        hyps_pad = pad_sequence([
+            torch.tensor(hyp, device=device, dtype=torch.long)
+            for hyp in hyps
+        ], True, self.ignore_id)  # (beam_size, max_hyps_len)
+        hyps_pad_blank = add_blank(hyps_pad,self.blank, self.ignore_id) # (beam_size, max_hyps_len)
+        ori_hyps_pad = hyps_pad
+        hyps_lens = torch.tensor([len(hyp) for hyp in hyps],
+                                 device=device,
+                                 dtype=torch.long)  # (beam_size,)
+
+
+
+        encoder_out = encoder_out.repeat(beam_size, 1, 1)
+        encoder_mask = torch.ones(beam_size,
+                                  1,
+                                  encoder_out.size(1),
+                                  dtype=torch.bool,
+                                  device=device)
+        
+        xs_in_lens = encoder_mask.squeeze(1).sum(1).int()
+
+        # 1. Forward decoder
+        predictor_out = self.predictor(hyps_pad_blank)
+        # joint
+        joint_out = self.joint(encoder_out, predictor_out)
+        rnnt_text = hyps_pad.to(torch.int64)
+        rnnt_text = torch.where(rnnt_text == self.ignore_id, 0,
+                                rnnt_text).to(torch.int32)
+        # 2. Compute attention loss
+        loss_td = torchaudio.functional.rnnt_loss(joint_out,
+                                               rnnt_text,
+                                               xs_in_lens,
+                                               hyps_lens.int(),
+                                               blank=self.blank,
+                                               reduction='none')
+    
+        td_score = loss_td * -1
+        hyps_pad, _ = add_sos_eos(hyps_pad, self.sos, self.eos, self.ignore_id)
+        hyps_lens = hyps_lens + 1  # Add <sos> at begining
+        # used for right to left decoder
+        r_hyps_pad = reverse_pad_list(ori_hyps_pad, hyps_lens, self.ignore_id)
+        r_hyps_pad, _ = add_sos_eos(r_hyps_pad, self.sos, self.eos,
+                                    self.ignore_id)
+        decoder_out, r_decoder_out, _ = self.attention_decoder(
+            encoder_out, encoder_mask, hyps_pad, hyps_lens, r_hyps_pad,
+            reverse_weight)  # (beam_size, max_hyps_len, vocab_size)
+        decoder_out = torch.nn.functional.log_softmax(decoder_out, dim=-1)
+        decoder_out = decoder_out.cpu().numpy()
+        # r_decoder_out will be 0.0, if reverse_weight is 0.0 or decoder is a
+        # conventional transformer decoder.
+        r_decoder_out = torch.nn.functional.log_softmax(r_decoder_out, dim=-1)
+        r_decoder_out = r_decoder_out.cpu().numpy()
+        # Only use decoder score for rescoring
+        best_score = -float('inf')
+        best_index = 0
+        for i, hyp in enumerate(hyps):
+            score = 0.0
+            for j, w in enumerate(hyp):
+                score += decoder_out[i][j][w]
+            score += decoder_out[i][len(hyp)][self.eos]
+            td_s = td_score[i]
+            # add right to left decoder score
+            if reverse_weight > 0:
+                r_score = 0.0
+                for j, w in enumerate(hyp):
+                    r_score += r_decoder_out[i][len(hyp) - j - 1][w]
+                r_score += r_decoder_out[i][len(hyp)][self.eos]
+                score = score * (1 - reverse_weight) + r_score * reverse_weight
+            # add ctc score
+            
+            score = score * attn_weight + beam_score[i] * ctc_weight + td_s * transducer_weight
+            if score > best_score:
+                best_score = score
+                best_index = i
+
+        return hyps[best_index], best_score
+
+
     def greedy_search(
         self,
         speech: torch.Tensor,
@@ -190,6 +398,7 @@ class Transducer(nn.Module):
         assert speech.shape[0] == speech_lengths.shape[0]
         assert decoding_chunk_size != 0
         batch_size = speech.shape[0]
+        device = speech.device
         # Let's assume B = batch_size
         # NOTE(Mddct): only support non streamming for now
         num_decoding_left_chunks = -1
@@ -205,10 +414,12 @@ class Transducer(nn.Module):
         encoder_out_lens = encoder_mask.squeeze(1).sum()
 
         # fake padding
-        padding = torch.zeros(1, 1)
+        padding = torch.zeros(1, 1).to(device)
         # sos
-        pred_input_step = torch.tensor([self.blank]).reshape(1, 1)
+        pred_input_step = torch.tensor([self.blank],device=device).reshape(1, 1)
         state_m, state_c = self.predictor.init_state(1, method="zero")
+        state_m = state_m.to(device)
+        state_c = state_c.to(device)
         t = 0
         hyps = []
         prev_out_nblk = True
@@ -224,6 +435,7 @@ class Transducer(nn.Module):
             joint_out_step = self.joint(encoder_out_step,
                                         pred_out_step)  # [1,1,v]
             joint_out_probs = joint_out_step.log_softmax(dim=-1)
+            
             joint_out_max = joint_out_probs.argmax(dim=-1).squeeze()  # []
             if joint_out_max != self.blank:
                 hyps.append(joint_out_max.item())
@@ -231,8 +443,10 @@ class Transducer(nn.Module):
                 per_frame_noblk = per_frame_noblk + 1
                 pred_input_step = joint_out_max.reshape(1, 1)
                 state_m, state_c = state_out_m, state_out_c
+                t = t+1
 
-            if joint_out_max == self.blank or per_frame_noblk >= per_frame_max_noblk:
+            # if joint_out_max == self.blank or per_frame_noblk >= per_frame_max_noblk:
+            if joint_out_max == self.blank:
                 if per_frame_noblk >= per_frame_max_noblk:
                     prev_out_nblk = False
                 # TODO(Mddct): make t in chunk for streamming


### PR DESCRIPTION
1. add `wenet.transducer.search.prefix_beam_search  ` : notice the decoding method do not support one frame output multi units.  I have done some experiments in greedy search which shows some influence.
2. add two decode mode: **rnnt_beam_search** normal transducer prefix beam search. see in `wenet.transducer.transducer`; **rnnt_beam_attn_rescoring** transducer using to generate nbest sequence, then using transducer loss and attention to rescore.
3. beam search result: 4.80 for 0.3 ctc weight and 0.7 transducer weight
4. rnnt beam attn rescoring result: 4.58