### PR TITLE
Revert "[workflows] Fix markdown version of doc"

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
-        pre-build-command: "pip install markdown==3.3.7 sphinx-markdown-tables nbsphinx jinja2 recommonmark sphinx_rtd_theme"
+        pre-build-command: "pip install sphinx-markdown-tables nbsphinx jinja2 recommonmark sphinx_rtd_theme"
 
 
     # add .nojekyll to notice Pages use the _* dirs


### PR DESCRIPTION
Because `sphinx-markdown-tables` is updated.
Plz see https://github.com/ryanfox/sphinx-markdown-tables/commit/ae777bde2ca9c0ccfbdb90d6270897b4cd27d12b