### PR TITLE
Update wenet_api.cc

### DIFF
--- a/runtime/core/api/wenet_api.cc
+++ b/runtime/core/api/wenet_api.cc
@@ -120,8 +120,8 @@ class Recognizer {
         break;
       } else if (state == DecodeState::kEndpoint && continuous_decoding_) {
         decoder_->Rescoring();
-        decoder_->ResetContinuousDecoding();
         UpdateResult(true);
+        decoder_->ResetContinuousDecoding();
       } else {  // kEndBatch
         UpdateResult(false);
       }


### PR DESCRIPTION
In branch "(state == DecodeState::kEndpoint && continuous_decoding_)", reverse the order of "UpdateResult(true)" and "decoder_->ResetContinuousDecoding()".

Because "decoder_.result_.clear()" is executed in "decoder_->ResetContinuousDecoding()", the decoded result cannot be obtained from "decoder_->result()" when calling "UpdateResult(true)".

This problem can be avoided by modifying the calling sequence. Calling "UpdateResult(true)" first can ensure that the decoding result obtained from "decoder_->result()" is placed in the member variable "result_" of "class Recognize", and then calling "decoder_.result_.clear()" called by "decoder_->ResetContinuousDecoding()" has no effect.