### PR TITLE
Update context_graph.cc

### DIFF
--- a/runtime/core/decoder/context_graph.cc
+++ b/runtime/core/decoder/context_graph.cc
@@ -66,7 +66,7 @@ void ContextGraph::BuildContextGraph(
     for (size_t i = 0; i < words.size(); ++i) {
       int word_id = symbol_table_->Find(words[i]);
       float score = config_.context_score * UTF8StringLength(words[i]);
-      score = (static_cast<float>(i) / words.size() + 1.0) * score;
+      score = ((static_cast<float>(i) / words.size()) * config_.incremental_context_score + 1.0) * score;
       next_state = (i < words.size() - 1) ? ofst->AddState() : start_state;
       ofst->AddArc(prev_state,
                    fst::StdArc(word_id, word_id, score, next_state));

--- a/runtime/core/decoder/context_graph.cc
+++ b/runtime/core/decoder/context_graph.cc
@@ -65,8 +65,8 @@ void ContextGraph::BuildContextGraph(
     float escape_score = 0;
     for (size_t i = 0; i < words.size(); ++i) {
       int word_id = symbol_table_->Find(words[i]);
-      float score = (config_.context_score + 
-                     i * config_.incremental_context_score) * UTF8StringLength(words[i]);
+      float score = (config_.context_score +i * config_.incremental_context_score)
+          * UTF8StringLength(words[i]);
       next_state = (i < words.size() - 1) ? ofst->AddState() : start_state;
       ofst->AddArc(prev_state,
                    fst::StdArc(word_id, word_id, score, next_state));

--- a/runtime/core/decoder/context_graph.cc
+++ b/runtime/core/decoder/context_graph.cc
@@ -66,7 +66,7 @@ void ContextGraph::BuildContextGraph(
     for (size_t i = 0; i < words.size(); ++i) {
       int word_id = symbol_table_->Find(words[i]);
       float score = config_.context_score * UTF8StringLength(words[i]);
-      score = (float(i) / words.size() + 1.0) * score;
+      score = (static_cast<float>(i) / words.size() + 1.0) * score;
       next_state = (i < words.size() - 1) ? ofst->AddState() : start_state;
       ofst->AddArc(prev_state,
                    fst::StdArc(word_id, word_id, score, next_state));

--- a/runtime/core/decoder/context_graph.cc
+++ b/runtime/core/decoder/context_graph.cc
@@ -66,7 +66,7 @@ void ContextGraph::BuildContextGraph(
     for (size_t i = 0; i < words.size(); ++i) {
       int word_id = symbol_table_->Find(words[i]);
       float score = config_.context_score * UTF8StringLength(words[i]);
-      score = ((static_cast<float>(i) / words.size()) 
+      score = ((static_cast<float>(i) / words.size())
                * config_.incremental_context_score + 1.0) * score;
       next_state = (i < words.size() - 1) ? ofst->AddState() : start_state;
       ofst->AddArc(prev_state,

--- a/runtime/core/decoder/context_graph.cc
+++ b/runtime/core/decoder/context_graph.cc
@@ -65,8 +65,8 @@ void ContextGraph::BuildContextGraph(
     float escape_score = 0;
     for (size_t i = 0; i < words.size(); ++i) {
       int word_id = symbol_table_->Find(words[i]);
-      float score = (config_.context_score +i * config_.incremental_context_score)
-          * UTF8StringLength(words[i]);
+      float score = (i * config_.incremental_context_score
+                     + config_.context_score) * UTF8StringLength(words[i]);
       next_state = (i < words.size() - 1) ? ofst->AddState() : start_state;
       ofst->AddArc(prev_state,
                    fst::StdArc(word_id, word_id, score, next_state));

--- a/runtime/core/decoder/context_graph.cc
+++ b/runtime/core/decoder/context_graph.cc
@@ -65,9 +65,8 @@ void ContextGraph::BuildContextGraph(
     float escape_score = 0;
     for (size_t i = 0; i < words.size(); ++i) {
       int word_id = symbol_table_->Find(words[i]);
-      float score = config_.context_score * UTF8StringLength(words[i]);
-      score = ((static_cast<float>(i) / words.size())
-               * config_.incremental_context_score + 1.0) * score;
+      float score = (config_.context_score + 
+                     i * config_.incremental_context_score) * UTF8StringLength(words[i]);
       next_state = (i < words.size() - 1) ? ofst->AddState() : start_state;
       ofst->AddArc(prev_state,
                    fst::StdArc(word_id, word_id, score, next_state));

--- a/runtime/core/decoder/context_graph.cc
+++ b/runtime/core/decoder/context_graph.cc
@@ -66,8 +66,8 @@ void ContextGraph::BuildContextGraph(
     for (size_t i = 0; i < words.size(); ++i) {
       int word_id = symbol_table_->Find(words[i]);
       float score = config_.context_score * UTF8StringLength(words[i]);
-      score = 
-          ((static_cast<float>(i) / words.size()) * config_.incremental_context_score + 1.0) * score;
+      score = ((static_cast<float>(i) / words.size()) 
+               * config_.incremental_context_score + 1.0) * score;
       next_state = (i < words.size() - 1) ? ofst->AddState() : start_state;
       ofst->AddArc(prev_state,
                    fst::StdArc(word_id, word_id, score, next_state));

--- a/runtime/core/decoder/context_graph.cc
+++ b/runtime/core/decoder/context_graph.cc
@@ -66,7 +66,8 @@ void ContextGraph::BuildContextGraph(
     for (size_t i = 0; i < words.size(); ++i) {
       int word_id = symbol_table_->Find(words[i]);
       float score = config_.context_score * UTF8StringLength(words[i]);
-      score = ((static_cast<float>(i) / words.size()) * config_.incremental_context_score + 1.0) * score;
+      score = 
+          ((static_cast<float>(i) / words.size()) * config_.incremental_context_score + 1.0) * score;
       next_state = (i < words.size() - 1) ? ofst->AddState() : start_state;
       ofst->AddArc(prev_state,
                    fst::StdArc(word_id, word_id, score, next_state));

--- a/runtime/core/decoder/context_graph.cc
+++ b/runtime/core/decoder/context_graph.cc
@@ -66,6 +66,7 @@ void ContextGraph::BuildContextGraph(
     for (size_t i = 0; i < words.size(); ++i) {
       int word_id = symbol_table_->Find(words[i]);
       float score = config_.context_score * UTF8StringLength(words[i]);
+      score = (float(i) / words.size() + 1.0) * score;
       next_state = (i < words.size() - 1) ? ofst->AddState() : start_state;
       ofst->AddArc(prev_state,
                    fst::StdArc(word_id, word_id, score, next_state));

--- a/runtime/core/decoder/context_graph.h
+++ b/runtime/core/decoder/context_graph.h
@@ -32,6 +32,7 @@ struct ContextConfig {
   int max_contexts = 5000;
   int max_context_length = 100;
   float context_score = 3.0;
+  float incremental_context_score = 0.0;
 };
 
 class ContextGraph {


### PR DESCRIPTION
使用递增的context score，让context score随着context的深度逐渐增加。

在我的实验中，这种做法对WFST的热词效果有改善，热词命中率从68/96(命中数/总数) 提升到 78/96(命中数/总数)。

