### PR TITLE
[transducer] unify weight meaning of rescore mode  and fix coredump

### DIFF
--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -83,7 +83,8 @@ def get_args():
                         help='ctc weight for rescoring weight in \
                                   attention rescoring decode mode \
                               ctc weight for rescoring weight in \
-                                  transducer attention rescore decode mode using ctc nbest')
+                                  transducer attention rescore decode mode \
+                                  using ctc nbest')
     parser.add_argument('--transducer_weight',
                         type=float,
                         default=0.0,
@@ -275,7 +276,7 @@ def main():
                     reverse_weight=args.reverse_weight,
                     search_ctc_weight=args.search_ctc_weight,
                     search_transducer_weight=args.search_transducer_weight,
-		    rnnt_aligment_weight=args.transducer_aligment_weight,
+                    rnnt_aligment_weight=args.transducer_aligment_weight,
                     beam_search_type='ctc')
             # ctc_prefix_beam_search and attention_rescoring only return one
             # result in List[int], change it to List[List[int]] for compatible

--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -83,13 +83,17 @@ def get_args():
                         help='ctc weight for rescoring weight in \
                                   attention rescoring decode mode \
                               ctc weight for rescoring weight in \
-                                  transducer attention rescore decode mode')
-
+                                  transducer attention rescore decode mode using ctc nbest')
     parser.add_argument('--transducer_weight',
                         type=float,
                         default=0.0,
                         help='transducer weight for rescoring weight in transducer \
-                                 attention rescore mode')
+                                 attention rescore mode using rnnt nbest')
+    parser.add_argument('--transducer_aligment_weight',
+                        type=float,
+                        default=0.0,
+                        help='aligment weight for rescoring weight in transducer \
+                              attention rescore mode when not using rnnt nbest')
     parser.add_argument('--attn_weight',
                         type=float,
                         default=0.0,
@@ -271,6 +275,7 @@ def main():
                     reverse_weight=args.reverse_weight,
                     search_ctc_weight=args.search_ctc_weight,
                     search_transducer_weight=args.search_transducer_weight,
+		    rnnt_aligment_weight=args.transducer_aligment_weight,
                     beam_search_type='ctc')
             # ctc_prefix_beam_search and attention_rescoring only return one
             # result in List[int], change it to List[List[int]] for compatible

--- a/wenet/transducer/search/prefix_beam_search.py
+++ b/wenet/transducer/search/prefix_beam_search.py
@@ -63,7 +63,8 @@ class PrefixBeamSearch():
             num_decoding_left_chunks)  # (B, maxlen, encoder_dim)
         maxlen = encoder_out.size(1)
 
-        ctc_probs = self.ctc.log_softmax(encoder_out).squeeze(0)
+        if ctc_weight != 0.0
+            ctc_probs = self.ctc.log_softmax(encoder_out).squeeze(0)
         beam_init: List[Sequence] = []
 
         # 2. init beam using Sequence to save beam unit
@@ -96,8 +97,11 @@ class PrefixBeamSearch():
 
             # 3.3 shallow fusion for transducer score
             #     and ctc score where we can also add the LM score
-            logp = torch.log(
-                torch.add(transducer_weight * torch.exp(logp),
+            if ctc_weight != 0.0:
+                logp = torch.log(transducer_weight * torch.exp(logp))
+            else:
+                logp = torch.log(
+                    torch.add(transducer_weight * torch.exp(logp),
                           ctc_weight * torch.exp(ctc_probs[i].unsqueeze(0))))
 
             # 3.4 first beam prune

--- a/wenet/transducer/search/prefix_beam_search.py
+++ b/wenet/transducer/search/prefix_beam_search.py
@@ -97,7 +97,7 @@ class PrefixBeamSearch():
 
             # 3.3 shallow fusion for transducer score
             #     and ctc score where we can also add the LM score
-            if ctc_weight != 0.0:
+            if ctc_weight == 0.0:
                 logp = torch.log(transducer_weight * torch.exp(logp))
             else:
                 logp = torch.log(

--- a/wenet/transducer/search/prefix_beam_search.py
+++ b/wenet/transducer/search/prefix_beam_search.py
@@ -102,7 +102,7 @@ class PrefixBeamSearch():
             else:
                 logp = torch.log(
                     torch.add(transducer_weight * torch.exp(logp),
-                          ctc_weight * torch.exp(ctc_probs[i].unsqueeze(0))))
+                              ctc_weight * torch.exp(ctc_probs[i].unsqueeze(0))))
 
             # 3.4 first beam prune
             top_k_logp, top_k_index = logp.topk(beam_size)  # (N, N)

--- a/wenet/transducer/search/prefix_beam_search.py
+++ b/wenet/transducer/search/prefix_beam_search.py
@@ -63,7 +63,7 @@ class PrefixBeamSearch():
             num_decoding_left_chunks)  # (B, maxlen, encoder_dim)
         maxlen = encoder_out.size(1)
 
-        if ctc_weight != 0.0
+        if ctc_weight != 0.0:
             ctc_probs = self.ctc.log_softmax(encoder_out).squeeze(0)
         beam_init: List[Sequence] = []
 


### PR DESCRIPTION
- 1 in wenet, ctc_weight was used in : 
   ```bash
   ctc_weight * nbest[i] + atten_weight * nbest[i] 
   ```
   so transducer_weight should be used in same way: 
   ``` 
   transducer_weight * nbest[i] + atten_weight * nbest[i]
   ```
   when using ctc nbest to rescore in transducer model, transducer_aligment_weight used in ctc_beam_td_attn_rescoring to fusion

- 2 why very slow
  transducer att rescore fucntion do call rnntloss which using openmp when using cpu, 
  when do openmap thread=1,  if is very slow  both on librispeech and aishell
  
- 3 why coredump
   bpe's sentence of librispeech is very long , so it will coredump when using rnntloss

TODO:
- [ ] librispeech rescore result to see if coredump will happen when not using rnntloss