### PR TITLE
[doc] update onnxruntime README

### DIFF
--- a/runtime/onnxruntime/README.md
+++ b/runtime/onnxruntime/README.md
@@ -5,7 +5,7 @@
 ``` sh
 exp=exp  # Change it to your experiment dir
 onnx_dir=onnx
-python wenet/bin/export_onnx_cpu.py \
+python -m wenet.bin.export_onnx_cpu \
   --config $exp/train.yaml \
   --checkpoint $exp/final.pt \
   --chunk_size 16 \


### PR DESCRIPTION
run wenet/bin/export_onnx_cpu.py as package, otherwise `ModuleNotFoundError: No module named 'wenet'`.