### PR TITLE
Squeezeformer implementation 

### DIFF
--- a/wenet/transformer/convolution.py
+++ b/wenet/transformer/convolution.py
@@ -63,8 +63,8 @@ class ConvolutionModule(nn.Module):
             padding = (kernel_size - 1) // 2
             self.lorder = 0
         self.depthwise_conv = nn.Conv1d(
-            channels if use_glu else 2*channels,
-            channels if use_glu else 2*channels,
+            channels if use_glu else 2 * channels,
+            channels if use_glu else 2 * channels,
             kernel_size,
             stride=1,
             padding=padding,
@@ -81,7 +81,7 @@ class ConvolutionModule(nn.Module):
             self.norm = nn.LayerNorm(channels)
 
         self.pointwise_conv2 = nn.Conv1d(
-            channels if use_glu else 2*channels,
+            channels if use_glu else 2 * channels,
             channels,
             kernel_size=1,
             stride=1,
@@ -135,9 +135,9 @@ class ConvolutionModule(nn.Module):
             # GLU mechanism
             x = nn.functional.glu(x, dim=1)  # (batch, channel, dim)
         else:
-            # Just use unified activation 
+            # Just use unified activation
             x = self.activation(x)  # (batch, channel, dim)
-            
+
         # 1D Depthwise Conv
         x = self.depthwise_conv(x)
         if self.use_layer_norm:

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -698,7 +698,9 @@ class SqueezeformerEncoder(BaseEncoder):
         )
         activation = get_activation(activation_type)
 
-        assert normalize_before == False, "Squeezeformer must use PostLN rather than PreLN"
+        assert (
+            normalize_before == False
+        ), "Squeezeformer must use PostLN rather than PreLN"
         # self-attention module definition
         if pos_enc_layer_type != "rel_pos":
             encoder_selfattn_layer = MultiHeadedAttention

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -366,6 +366,7 @@ class BaseEncoder(torch.nn.Module):
                 for i, recover_layer in enumerate(self.time_recover_layers):
                     if time_reduce_level == i:
                         xs = recover_layer(xs)
+                xs = xs + residual_xs  # (B,T,D)
             # NOTE(xcsong): Before layer.forward
             #   shape(att_cache[i:i + 1]) is (1, head, cache_t1, d_k * 2),
             #   shape(cnn_cache[i])       is (b=1, hidden-dim, cache_t2)

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -97,7 +97,7 @@ class BaseEncoder(torch.nn.Module):
                 dynamic chunk training
             time_reduce_idx: layer indices list where 2x-time-reduction is applied
             time_recover_idx: layer indices list where 2x-time-recover is applied
-            input_layer_depthwise (bool): to make second conv layer 
+            input_layer_depthwise (bool): to make second conv layer
                 depthwise-separable or not.
                 (This reduces the number of floating point operations.)
         """
@@ -134,10 +134,16 @@ class BaseEncoder(torch.nn.Module):
             input_layer_depthwise,
         )
 
-        self.time_reduce_idx = [int(idx) for idx in time_reduce_idx] \
-            if time_reduce_idx is not None else None
-        self.time_recover_idx = [int(idx) for idx in time_recover_idx] \
-            if time_rcover_idx is not None else None
+        self.time_reduce_idx = (
+            [int(idx) for idx in time_reduce_idx]
+            if time_reduce_idx is not None
+            else None
+        )
+        self.time_recover_idx = (
+            [int(idx) for idx in time_recover_idx]
+            if time_rcover_idx is not None
+            else None
+        )
         if len(time_reduce_idx) > 0:
             assert len(time_recover_idx) > 0
             assert len(time_reduce_idx) == len(time_recover_idx)
@@ -312,15 +318,15 @@ class BaseEncoder(torch.nn.Module):
         # NOTE(hslee):
         #  Current version of att_cache does not consider time_reduction for caching.
         #  It leads to mismatch between forward (train) and forward_chunk (stream),
-        #   since the length of past attention key becomes 
+        #   since the length of past attention key becomes
         #   longer than the length used in forward().
-        #  To resolve the mismatch, required_cache_size should be 
+        #  To resolve the mismatch, required_cache_size should be
         #   reduced as time_reduce_level increases.
         #  However, I just left required_cache_size as it was for the following reasons:
         #   - giving longer past context for attention keys may improve WER/CER.
-        #   - (when dynamic_chunk==true) time reduced layers are 
+        #   - (when dynamic_chunk==true) time reduced layers are
         #      already trained for various length of past context.
-        #   - implementation of variable time reduction rate 
+        #   - implementation of variable time reduction rate
         #      for att_cache seems a bit tricky.
         mask_pad_fake = torch.zeros((0, 0, 0), dtype=xs.dtype, device=xs.device)
         time_reduce_residuals = torch.jit.annotate(

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -699,7 +699,7 @@ class SqueezeformerEncoder(BaseEncoder):
         activation = get_activation(activation_type)
 
         assert (
-            normalize_before == False
+            not normalize_before
         ), "Squeezeformer must use PostLN rather than PreLN"
         # self-attention module definition
         if pos_enc_layer_type != "rel_pos":

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -645,7 +645,7 @@ class SqueezeformerEncoder(BaseEncoder):
         attention_dropout_rate: float = 0.0,
         input_layer: str = "conv2d",
         pos_enc_layer_type: str = "rel_pos",
-        normalize_before: bool = True,
+        normalize_before: bool = False,
         concat_after: bool = False,
         static_chunk_size: int = 0,
         use_dynamic_chunk: bool = False,
@@ -698,6 +698,7 @@ class SqueezeformerEncoder(BaseEncoder):
         )
         activation = get_activation(activation_type)
 
+        assert normalize_before == False, "Squeezeformer must use PostLN rather than PreLN"
         # self-attention module definition
         if pos_enc_layer_type != "rel_pos":
             encoder_selfattn_layer = MultiHeadedAttention

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -141,7 +141,7 @@ class BaseEncoder(torch.nn.Module):
         )
         self.time_recover_idx = (
             [int(idx) for idx in time_recover_idx]
-            if time_rcover_idx is not None
+            if time_recover_idx is not None
             else None
         )
         if len(time_reduce_idx) > 0:

--- a/wenet/transformer/encoder_layer.py
+++ b/wenet/transformer/encoder_layer.py
@@ -270,10 +270,10 @@ class ConformerEncoderLayer(nn.Module):
 
 
 class ScaleBiasLayer(nn.Module):
-    def __init__(self, size:int):
+    def __init__(self, size: int):
         super().__init__()
-        self.scale = torch.nn.parameter.Parameter(torch.ones([size,]))
-        self.bias = torch.nn.parameter.Parameter(torch.zeros([size,]))
+        self.scale = torch.nn.parameter.Parameter(torch.ones([size, ]))
+        self.bias = torch.nn.parameter.Parameter(torch.zeros([size, ]))
 
     def forward(self, x: torch.Tensor):
         """
@@ -282,7 +282,7 @@ class ScaleBiasLayer(nn.Module):
         Returns:
             torch.Tensor: Output tensor (#batch, time, size).
         """
-        return self.scale.reshape([1,1,-1]) * x + self.bias.reshape([1,1,-1])
+        return self.scale.reshape([1, 1, -1]) * x + self.bias.reshape([1, 1, -1])
 
 class SqueezeformerEncoderLayer(nn.Module):
     """Encoder layer module.
@@ -339,7 +339,7 @@ class SqueezeformerEncoderLayer(nn.Module):
         x: torch.Tensor,
         mask: torch.Tensor,
         pos_emb: torch.Tensor,
-        mask_pad: torch.Tensor = torch.ones((0, 0, 0), dtype=torch.bool),
+        mask_pad: torch.Tensor = torch.ones((1, 0, 0), dtype=torch.bool),
         att_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
         cnn_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -368,7 +368,7 @@ class SqueezeformerEncoderLayer(nn.Module):
 
         # multi-headed self-attention module
         residual = x
-        x = self.scale_mha(x) 
+        x = self.scale_mha(x)
         x_att, new_att_cache = self.self_attn(
             x, x, x, mask, pos_emb, att_cache)
         x = residual + self.dropout(x_att)
@@ -376,7 +376,7 @@ class SqueezeformerEncoderLayer(nn.Module):
 
         # feed forward module 1
         residual = x
-        x = self.scale_ff1(x) 
+        x = self.scale_ff1(x)
         x = residual + self.dropout(self.feed_forward1(x))
         x = self.norm_ff1(x)
 
@@ -384,16 +384,15 @@ class SqueezeformerEncoderLayer(nn.Module):
         # Fake new cnn cache here, and then change it in conv_module
         new_cnn_cache = torch.zeros((0, 0, 0), dtype=x.dtype, device=x.device)
         residual = x
-        x = self.scale_conv(x) 
+        x = self.scale_conv(x)
         x, new_cnn_cache = self.conv_module(x, mask_pad, cnn_cache)
         x = residual + self.dropout(x)
         x = self.norm_conv(x)
 
         # feed forward module 2
         residual = x
-        x = self.scale_ff2(x) 
+        x = self.scale_ff2(x)
         x = residual + self.dropout(self.feed_forward2(x))
         x = self.norm_ff2(x)
-
 
         return x, mask, new_att_cache, new_cnn_cache

--- a/wenet/utils/init_model.py
+++ b/wenet/utils/init_model.py
@@ -22,6 +22,7 @@ from wenet.transformer.cmvn import GlobalCMVN
 from wenet.transformer.ctc import CTC
 from wenet.transformer.decoder import BiTransformerDecoder, TransformerDecoder
 from wenet.transformer.encoder import ConformerEncoder, TransformerEncoder
+from wenet.transformer.encoder import SqueezeformerEncoder
 from wenet.utils.cmvn import load_cmvn
 
 
@@ -44,6 +45,10 @@ def init_model(configs):
         encoder = ConformerEncoder(input_dim,
                                    global_cmvn=global_cmvn,
                                    **configs['encoder_conf'])
+    elif encoder_type == 'squeezeformer':
+        encoder = SqueezeformerEncoder(input_dim,
+                                       global_cmvn=global_cmvn,
+                                       **configs['encoder_conf'])
     else:
         encoder = TransformerEncoder(input_dim,
                                      global_cmvn=global_cmvn,


### PR DESCRIPTION
This PR is about my personal implementation of Squeezeformer for WeNet encoder structure.
(Original paper: https://arxiv.org/abs/2206.00888)
(Original code: https://github.com/kssteven418/Squeezeformer)

* Added features
  - [x] SqueezeformerEncoder / SqueezeformerEncoderLayer
    - [x] 2x Time reduce & recover logic (in forward functions of BaseEncoder)
      - [x] TimeReduction2 layer (in subsampling.py)
    - [x] Transformer-style block (Att.->Feedforward->Conv->Feedforward)
    - [x] Scale & Bias layer (in place of pre layer-norm)
    - [x] Option: not to use GLU (in convolution.py)
    - [x] Depthwise conv2d input layers  (in subsampling.py)

* Experimental validation (on LibriSpeech)
  - [x] Batch training  
  - [x] Batch inference (both for full-utterance & chunk-wise)
  - [ ] Streaming inference (e.g, JIT) 
  - [ ] Configuration file and WER results

Squeezeformer can be seen as an extension of the Conformer structure.
Thus it can be implemented by modifying the ConformerEncoder class, but I rather added SqueezeformerEncoder class to avoid confusion.

On the other hand, **2x Time reduce & recover logic** code is inserted in the middle of forward functions in BaseEncoder class, which might cause unintended side effects. 
(Likewise, **Option: not to use GLU** code is inserted in existing scripts of convolution.py)
Special care is needed for reviewing these codes.