### PR TITLE
[dataset] add simple rir perturb

### DIFF
--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -160,6 +160,7 @@ def main():
     test_conf['filter_conf']['max_output_input_ratio'] = 102400
     test_conf['filter_conf']['min_output_input_ratio'] = 0
     test_conf['speed_perturb'] = False
+    test_conf['rir_perturb'] = False
     test_conf['spec_aug'] = False
     test_conf['spec_sub'] = False
     test_conf['shuffle'] = False

--- a/wenet/dataset/dataset.py
+++ b/wenet/dataset/dataset.py
@@ -19,7 +19,7 @@ import torch.distributed as dist
 from torch.utils.data import IterableDataset
 
 import wenet.dataset.processor as processor
-from wenet.utils.file_utils import read_lists
+from wenet.utils.file_utils import read_lists, random_line_generator
 
 
 class Processor(IterableDataset):
@@ -155,6 +155,14 @@ def Dataset(data_type,
     speed_perturb = conf.get('speed_perturb', False)
     if speed_perturb:
         dataset = Processor(dataset, processor.speed_perturb)
+
+    rir_perturb = conf.get('rir_perturb', False)
+    rir_file = conf.get('rir_file', None)
+    if rir_perturb:
+        assert rir_file is not None
+        rir_g = random_line_generator(rir_file)
+        rir_prob = conf.get('rir_prob', 0.2)
+        dataset = Processor(dataset, processor.rir_perturb, rir_g, rir_prob)
 
     feats_type = conf.get('feats_type', 'fbank')
     assert feats_type in ['fbank', 'mfcc']

--- a/wenet/dataset/processor.py
+++ b/wenet/dataset/processor.py
@@ -252,7 +252,7 @@ def speed_perturb(data, speeds=None):
         yield sample
 
 
-def rir_perturb(data, rir_generator = None, prob=0.2):
+def rir_perturb(data, rir_generator=None, prob=0.2):
     """ Apply rir perturb to the data.
         Inplace operation.
 
@@ -269,7 +269,7 @@ def rir_perturb(data, rir_generator = None, prob=0.2):
         assert 'wav' in sample
         sample_rate = sample['sample_rate']
         waveform = sample['wav']
-        rir_if = random.choices([0.0,1.0], weights=[1-prob, prob], k=1)[0]
+        rir_if = random.choices([0.0, 1.0], weights=[1 - prob, prob], k=1)[0]
         if rir_if == 1.0:
             rir_wav, rir_sf = torchaudio.load(next(rir_generator))
             assert sample_rate == rir_sf

--- a/wenet/utils/convolve.py
+++ b/wenet/utils/convolve.py
@@ -13,9 +13,10 @@ def next_fast_len(size):
     Returns the next largest number ``n >= size`` whose prime factors are all
     2, 3, or 5. These sizes are efficient for fast fourier transforms.
     Equivalent to :func:`scipy.fftpack.next_fast_len`.
-    Note: This function was originally copied from the https://github.com/pyro-ppl/pyro
-    repository, where the license was Apache 2.0. Any modifications to the original code can be
-    found at https://github.com/asteroid-team/torch-audiomentations/commits
+    Note: This function was originally copied from the
+    https://github.com/pyro-ppl/pyro repository, where the license was
+    Apache 2.0. Any modifications to the original code can be found at
+    https://github.com/asteroid-team/torch-audiomentations/commits
     :param int size: A positive number.
     :returns: A possibly larger number.
     :rtype int:
@@ -43,8 +44,10 @@ def fft_convolve(signal, kernel, mode="full"):
     Computes the 1-d convolution of signal by kernel using FFTs.
     The two arguments should have the same rightmost dim, but may otherwise be
     arbitrarily broadcastable.
-    Note: This function was originally copied from the https://github.com/pyro-ppl/pyro
-    repository, where the license was Apache 2.0. Any modifications to the original code can be
+    Note: This function was originally copied from the
+    https://github.com/pyro-ppl/pyro repository,
+    where the license was Apache 2.0.
+    Any modifications to the original code can be
     found at https://github.com/asteroid-team/torch-audiomentations/commits
     :param torch.Tensor signal: A signal to convolve.
     :param torch.Tensor kernel: A convolution kernel.

--- a/wenet/utils/convolve.py
+++ b/wenet/utils/convolve.py
@@ -1,0 +1,80 @@
+#
+# code copy from scipy
+#
+"""Unility functions for perturb"""
+
+from torch.fft import irfft, rfft
+
+_NEXT_FAST_LEN = {}
+
+
+def next_fast_len(size):
+    """
+    Returns the next largest number ``n >= size`` whose prime factors are all
+    2, 3, or 5. These sizes are efficient for fast fourier transforms.
+    Equivalent to :func:`scipy.fftpack.next_fast_len`.
+    Note: This function was originally copied from the https://github.com/pyro-ppl/pyro
+    repository, where the license was Apache 2.0. Any modifications to the original code can be
+    found at https://github.com/asteroid-team/torch-audiomentations/commits
+    :param int size: A positive number.
+    :returns: A possibly larger number.
+    :rtype int:
+    """
+    try:
+        return _NEXT_FAST_LEN[size]
+    except KeyError:
+        pass
+
+    assert isinstance(size, int) and size > 0
+    next_size = size
+    while True:
+        remaining = next_size
+        for n in (2, 3, 5):
+            while remaining % n == 0:
+                remaining //= n
+        if remaining == 1:
+            _NEXT_FAST_LEN[size] = next_size
+            return next_size
+        next_size += 1
+
+
+def fft_convolve(signal, kernel, mode="full"):
+    """
+    Computes the 1-d convolution of signal by kernel using FFTs.
+    The two arguments should have the same rightmost dim, but may otherwise be
+    arbitrarily broadcastable.
+    Note: This function was originally copied from the https://github.com/pyro-ppl/pyro
+    repository, where the license was Apache 2.0. Any modifications to the original code can be
+    found at https://github.com/asteroid-team/torch-audiomentations/commits
+    :param torch.Tensor signal: A signal to convolve.
+    :param torch.Tensor kernel: A convolution kernel.
+    :param str mode: One of: 'full', 'valid', 'same'.
+    :return: A tensor with broadcasted shape. Letting ``m = signal.size(-1)``
+        and ``n = kernel.size(-1)``, the rightmost size of the result will be:
+        ``m + n - 1`` if mode is 'full';
+        ``max(m, n) - min(m, n) + 1`` if mode is 'valid'; or
+        ``max(m, n)`` if mode is 'same'.
+    :rtype torch.Tensor:
+    """
+    m = signal.size(-1)
+    n = kernel.size(-1)
+    if mode == "full":
+        truncate = m + n - 1
+    elif mode == "valid":
+        truncate = max(m, n) - min(m, n) + 1
+    elif mode == "same":
+        truncate = max(m, n)
+    else:
+        raise ValueError("Unknown mode: {}".format(mode))
+
+    # Compute convolution using fft.
+    padded_size = m + n - 1
+    # Round up for cheaper fft.
+    fast_ftt_size = next_fast_len(padded_size)
+    f_signal = rfft(signal, n=fast_ftt_size)
+    f_kernel = rfft(kernel, n=fast_ftt_size)
+    f_result = f_signal * f_kernel
+    result = irfft(f_result, n=fast_ftt_size)
+
+    start_idx = (padded_size - truncate) // 2
+    return result[..., start_idx:start_idx + truncate]

--- a/wenet/utils/file_utils.py
+++ b/wenet/utils/file_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import random
 import re
 
 
@@ -64,3 +65,10 @@ def read_symbol_table(symbol_table_file):
             assert len(arr) == 2
             symbol_table[arr[0]] = int(arr[1])
     return symbol_table
+
+
+def random_line_generator(list_file: str):
+    lists = read_lists(list_file)
+    while True:
+        index = random.randint(0, len(lists)-1)
+        yield lists[index]

--- a/wenet/utils/file_utils.py
+++ b/wenet/utils/file_utils.py
@@ -70,5 +70,5 @@ def read_symbol_table(symbol_table_file):
 def random_line_generator(list_file: str):
     lists = read_lists(list_file)
     while True:
-        index = random.randint(0, len(lists)-1)
+        index = random.randint(0, len(lists) - 1)
         yield lists[index]


### PR DESCRIPTION
copy some code from scipy to support rir convolve

Note: torchaudio also supplies convolve in  prototype: https://pytorch.org/audio/master/prototype.functional.html
when stable, we can replace fft_convolve with  torchaudio.convolve