### PR TITLE
[tools] fix compile_lexicon_token_fst.sh to avoid duplicate symbols

### DIFF
--- a/tools/fst/compile_lexicon_token_fst.sh
+++ b/tools/fst/compile_lexicon_token_fst.sh
@@ -60,7 +60,7 @@ tools/fst/ctc_token_fst_compact.py $dir/tokens.txt | \
   fstarcsort --sort_type=olabel > $dir/T.fst || exit 1;
 
 # Encode the words with indices. Will be used in lexicon and language model FST compiling.
-cat $tmpdir/lexiconp.txt | awk '{print $1}' | sort | awk '
+cat $tmpdir/lexiconp.txt | awk '{print $1}' | sort | uniq | awk '
   BEGIN {
     print "<eps> 0";
   }


### PR DESCRIPTION
If a word in lexicon.txt has several pronunciations, the words.txt maybe contains duplicate symbols.
So, add `uniq` to avoid that