### PR TITLE
[runtime] Upgrade iOS LibTorch to 1.11.0 to work with new models …

### DIFF
--- a/runtime/ios/build/Podfile
+++ b/runtime/ios/build/Podfile
@@ -1,2 +1,2 @@
 platform :ios, '14.3'
-pod 'LibTorch', '~>1.9.0'
+pod 'LibTorch', '~>1.11.0'


### PR DESCRIPTION
https://github.com/wenet-e2e/wenet/issues/1579
Upgrade LibTorch version to fix this issue.