### PR TITLE
[fix] prepare_dict support english and chinese in one lexicon.txt

### DIFF
--- a/tools/fst/prepare_dict.py
+++ b/tools/fst/prepare_dict.py
@@ -41,7 +41,10 @@ with open(sys.argv[2], 'r', encoding='utf8') as fin, \
             if word in lexicon_table:
                 continue
             if bpemode:
-                pieces = sp.EncodeAsPieces(word)
+                if word.encode('utf8').isalpha():
+                    pieces = sp.EncodeAsPieces(word)
+                else:
+                    pieces = word
                 if contain_oov(pieces):
                     print(
                         'Ignoring words {}, which contains oov unit'.format(

--- a/tools/fst/prepare_dict.py
+++ b/tools/fst/prepare_dict.py
@@ -41,6 +41,9 @@ with open(sys.argv[2], 'r', encoding='utf8') as fin, \
             if word in lexicon_table:
                 continue
             if bpemode:
+                # We assume that the lexicon does not contain code-switch, i.e., the word contains both English and Chinese.
+                # see PR https://github.com/wenet-e2e/wenet/pull/1693
+                # and Issue https://github.com/wenet-e2e/wenet/issues/1653
                 if word.encode('utf8').isalpha():
                     pieces = sp.EncodeAsPieces(word)
                 else:

--- a/tools/fst/prepare_dict.py
+++ b/tools/fst/prepare_dict.py
@@ -41,7 +41,8 @@ with open(sys.argv[2], 'r', encoding='utf8') as fin, \
             if word in lexicon_table:
                 continue
             if bpemode:
-                # We assume that the lexicon does not contain code-switch, i.e., the word contains both English and Chinese.
+                # We assume that the lexicon does not contain code-switch, 
+                # i.e. the word contains both English and Chinese.
                 # see PR https://github.com/wenet-e2e/wenet/pull/1693
                 # and Issue https://github.com/wenet-e2e/wenet/issues/1653
                 if word.encode('utf8').isalpha():

--- a/tools/fst/prepare_dict.py
+++ b/tools/fst/prepare_dict.py
@@ -41,7 +41,7 @@ with open(sys.argv[2], 'r', encoding='utf8') as fin, \
             if word in lexicon_table:
                 continue
             if bpemode:
-                # We assume that the lexicon does not contain code-switch, 
+                # We assume that the lexicon does not contain code-switch,
                 # i.e. the word contains both English and Chinese.
                 # see PR https://github.com/wenet-e2e/wenet/pull/1693
                 # and Issue https://github.com/wenet-e2e/wenet/issues/1653

--- a/wenet/utils/scheduler.py
+++ b/wenet/utils/scheduler.py
@@ -112,7 +112,7 @@ class WarmupPolicy(_LRScheduler):
             warnings.warn(
                 "To get the last learning rate computed "
                 "by the scheduler, please use `get_last_lr()`.",
-                UserWarning
+                UserWarning, stacklevel=2
             )
 
         step = self.last_epoch
@@ -173,7 +173,7 @@ class SquareRootConstantPolicy(_LRScheduler):
             warnings.warn(
                 "To get the last learning rate computed "
                 "by the scheduler, please use `get_last_lr()`.",
-                UserWarning
+                UserWarning, stacklevel=2
             )
 
         step = self.last_epoch
@@ -255,7 +255,7 @@ class WarmupHoldPolicy(WarmupPolicy):
             warnings.warn(
                 "To get the last learning rate computed by the scheduler,"
                 " " "please use `get_last_lr()`.",
-                UserWarning
+                UserWarning, stacklevel=2
             )
 
         step = self.last_epoch
@@ -336,7 +336,7 @@ class WarmupAnnealHoldPolicy(_LRScheduler):
             warnings.warn(
                 "To get the last learning rate computed "
                 "by the scheduler, please use `get_last_lr()`.",
-                UserWarning
+                UserWarning, stacklevel=2
             )
 
         step = self.last_epoch
@@ -554,7 +554,7 @@ class NoamAnnealing(_LRScheduler):
             warnings.warn(
                 "To get the last learning rate computed "
                 "by the scheduler, please use `get_last_lr()`.",
-                UserWarning
+                UserWarning, stacklevel=2
             )
 
         step = max(1, self.last_epoch)


### PR DESCRIPTION
tools/fst/prepare_dict.py, it can't split chinese phrase into character when bpemodel given [issus](https://github.com/wenet-e2e/wenet/issues/1653).  Now It can process english and chinese in one lexicon.txt .