### PR TITLE
[runtime/binding] support ort backend in wenetruntime

### DIFF
--- a/runtime/binding/python/CMakeLists.txt
+++ b/runtime/binding/python/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
 project(wenet VERSION 0.1)
 
-set(TORCH ON)  # Use torch for binding backend
-set(ONNX OFF)  # ONNX is not used
+option(TORCH "whether to build with Torch" ON)
+option(ONNX "whether to build with ONNX" OFF)
 set(CXX11_ABI OFF)
 set(FST_HAVE_BIN OFF)
 set(CMAKE_VERBOSE_MAKEFILE OFF)
@@ -25,7 +25,12 @@ else()
   add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 endif()
 
-include(libtorch)
+if(TORCH)
+  include(libtorch)
+endif()
+if(ONNX)
+  include(onnx)
+endif()
 include(openfst)
 include(pybind11)
 

--- a/runtime/binding/python/setup.py
+++ b/runtime/binding/python/setup.py
@@ -79,7 +79,8 @@ setuptools.setup(
     cmdclass={"build_ext": BuildExtension},
     zip_safe=False,
     setup_requires=["tqdm"],
-    install_requires=["torch", "tqdm"],
+    install_requires=["torch", "tqdm"] if "ONNX=ON" not in
+        os.environ.get("WENET_CMAKE_ARGS", "") else ["tqdm"],
     classifiers=[
         "Programming Language :: C++",
         "Programming Language :: Python :: 3",

--- a/runtime/core/api/CMakeLists.txt
+++ b/runtime/core/api/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(TORCH)
+if(TORCH OR ONNX)
  add_library(wenet_api SHARED wenet_api.cc)
  target_link_libraries(wenet_api PUBLIC decoder)
 endif()

--- a/runtime/core/api/wenet_api.cc
+++ b/runtime/core/api/wenet_api.cc
@@ -52,7 +52,7 @@ class Recognizer {
 
     auto model = std::make_shared<wenet::TorchAsrModel>();
 #else
-    LOG(FATAL) << "Please rebuild with cmake options '-DONNX=ON' or '-DTORCH=ON'.";
+    LOG(FATAL) << "Please rebuild with options '-DONNX=ON' or '-DTORCH=ON'.";
 #endif
     model->Read(model_path);
     resource_->model = model;

--- a/runtime/core/api/wenet_api.cc
+++ b/runtime/core/api/wenet_api.cc
@@ -19,7 +19,12 @@
 #include <vector>
 
 #include "decoder/asr_decoder.h"
+#ifdef USE_ONNX
+#include "decoder/onnx_asr_model.h"
+#endif
+#ifdef USE_TORCH
 #include "decoder/torch_asr_model.h"
+#endif
 #include "post_processor/post_processor.h"
 #include "utils/file.h"
 #include "utils/json.h"
@@ -34,11 +39,21 @@ class Recognizer {
         std::make_shared<wenet::FeaturePipeline>(*feature_config_);
     // Resource init
     resource_ = std::make_shared<wenet::DecodeResource>();
+#ifdef USE_ONNX
+    LOG(INFO) << "Reading onnx model ";
+    wenet::OnnxAsrModel::InitEngineThreads();
+    std::string model_path = model_dir;
+    auto model = std::make_shared<wenet::OnnxAsrModel>();
+#elif USE_TORCH
+    LOG(INFO) << "Reading torch model ";
     wenet::TorchAsrModel::InitEngineThreads();
     std::string model_path = wenet::JoinPath(model_dir, "final.zip");
     CHECK(wenet::FileExists(model_path));
 
     auto model = std::make_shared<wenet::TorchAsrModel>();
+#else
+    LOG(FATAL) << "Please rebuild with cmake options '-DONNX=ON' or '-DTORCH=ON'.";
+#endif
     model->Read(model_path);
     resource_->model = model;
 


### PR DESCRIPTION
For aarch64 systems (raspberry pi, horizonx3 pi, etc), ort backend is a better choice. 

Test success on x3 pi: 

![0ac85073-f913-40f9-9700-d8a3c998079b](https://user-images.githubusercontent.com/13466943/221369401-ee4e86d4-0a54-4eee-9a8b-aca6e9662a19.jpeg)

TODO (in next PR, not this one):
- [ ] update `binding/python/py/hub.py`, add download for onnx model
- [ ] update README 
- [ ] support `pip install wenetruntime==v1.0.0.onnx` , `pip install wenetruntime==v1.0.0.torch`, etc
- [ ] cross-compile, so we can upload pypi packages in github workflow