### PR TITLE
transducer model init has no lfmmi dir

### DIFF
--- a/wenet/transducer/transducer.py
+++ b/wenet/transducer/transducer.py
@@ -29,6 +29,7 @@ class Transducer(ASRModel):
         attention_decoder: Optional[Union[TransformerDecoder,
                                           BiTransformerDecoder]] = None,
         ctc: Optional[CTC] = None,
+        lfmmi_dir: str = '',
         ctc_weight: float = 0,
         ignore_id: int = IGNORE_ID,
         reverse_weight: float = 0.0,
@@ -39,7 +40,7 @@ class Transducer(ASRModel):
     ) -> None:
         assert check_argument_types()
         assert attention_weight + ctc_weight + transducer_weight == 1.0
-        super().__init__(vocab_size, encoder, attention_decoder, ctc,
+        super().__init__(vocab_size, encoder, attention_decoder, ctc, lfmmi_dir,
                          ctc_weight, ignore_id, reverse_weight, lsm_weight,
                          length_normalized_loss)
 

--- a/wenet/utils/init_model.py
+++ b/wenet/utils/init_model.py
@@ -100,6 +100,7 @@ def init_model(configs):
                            attention_decoder=decoder,
                            joint=joint,
                            ctc=ctc,
+                           lfmmi_dir=configs.get('lfmmi_dir', ''),
                            **configs['model_conf'])
     else:
         model = ASRModel(vocab_size=vocab_size,


### PR DESCRIPTION
Encounter such error when run aishell/rnnt/run.sh 
  _File "/wenet/wenet/wenet/transducer/transducer.py", line 42, in __init__
    super().__init__(vocab_size, encoder, attention_decoder, ctc,
  File "/wenet/wenet/wenet/transformer/asr_model.py", line 60, in __init__
    assert 0.0 <= ctc_weight <= 1.0, ctc_weight
AssertionError: -1_

It is missing lfmmi dir args when init transducer model.