### PR TITLE
fix lfmmi script typo

### DIFF
--- a/tools/k2/prepare_mmi.sh
+++ b/tools/k2/prepare_mmi.sh
@@ -31,7 +31,7 @@ ln -s lexicon.txt $tgt_dir/uniq_lexicon.txt
 
 # 2. prepare token level bigram
 cat $train_dir/text | awk '{print $2}'| sed -r 's/(.)/ \1/g' > $tgt_dir/transcript_chars.txt
-cat $train_dir/text | awk '{print $2}'| sed -r 's/(.)/ \1/g' >> $tgt_dir/transcript_chars.txt
+cat $dev_dir/text | awk '{print $2}'| sed -r 's/(.)/ \1/g' >> $tgt_dir/transcript_chars.txt
 
 ./shared/make_kn_lm.py \
     -ngram-order 2 \


### PR DESCRIPTION
This is a typo.  Should change train_dir to dev_dir, or it will result compose fail and loss inf in dev stage
