### PR TITLE
Update recognize_onnx_gpu.py

### DIFF
--- a/wenet/bin/recognize_onnx_gpu.py
+++ b/wenet/bin/recognize_onnx_gpu.py
@@ -128,6 +128,7 @@ def main():
     test_conf['filter_conf']['min_output_input_ratio'] = 0
     test_conf['speed_perturb'] = False
     test_conf['spec_aug'] = False
+    test_conf['spec_sub'] = False
     test_conf['spec_trim'] = False
     test_conf['shuffle'] = False
     test_conf['sort'] = False


### PR DESCRIPTION
如题，今天发现dataset.py里面数据增强选项是根据config文件来的，但是config一直用的是官方的文件，并未做过修改。建议把recognize_onnx_gpu.py改一下，使得模型在推理时自动关掉数据增强选项。
    test_conf['speed_perturb'] = False
    test_conf['spec_aug'] = False
    test_conf['spec_sub'] = False # 加入这一行
    test_conf['spec_trim'] = False
    test_conf['shuffle'] = False
    test_conf['sort'] = False