### PR TITLE
[bestrq] stable training

### DIFF
--- a/test/test_tokenize.py
+++ b/test/test_tokenize.py
@@ -103,9 +103,9 @@ def test_tokenize(symbol_table_path):
     )
     for (hyp, ref) in zip(outs, refs):
         assert(len(hyp["tokens"]) == len(ref["tokens"]))
-        assert(all([h == r for h, r in zip(hyp["tokens"], ref["tokens"])]))
+        assert(all(h == r for h, r in zip(hyp["tokens"], ref["tokens"])))
         assert(len(hyp["label"]) == len(ref["label"]))
-        assert(all([h == r for h, r in zip(hyp["label"], ref["label"])]))
+        assert(all(h == r for h, r in zip(hyp["label"], ref["label"])))
 
 @pytest.mark.parametrize("use_pbe_model", [True, False])
 def test_non_lang_symbol_tokenize(use_pbe_model):

--- a/wenet/ssl/bestrq/bestqr_model.py
+++ b/wenet/ssl/bestrq/bestqr_model.py
@@ -1,8 +1,54 @@
 from typing import Optional, Tuple
 import torch
 
-from wenet.ssl.bestrq.mask import compute_mask_indices
+from wenet.ssl.bestrq.mask import compute_mask_indices_v2
 from wenet.utils.mask import make_pad_mask
+
+
+def quantize_vector(latent: torch.Tensor, codebook: torch.Tensor):
+    """
+    Symbols in comments:
+    B: batch_size.
+    D: latent_dim.
+    C: num_latent_classes per group
+    G: num of codebook groups.
+
+    Args:
+        latent: [B, D]
+        codebook: [C, G, D // G]
+
+    Returns:
+        (quantized, codes, onehot).
+         - quantized: [B, D]
+         - codes:     [B, G]
+         - onehot:    [B, G, C]
+    """
+
+    assert len(codebook.size()) == 3
+    b, d = latent.size()
+    c, g, _ = codebook.size()
+    assert d % g == 0
+
+    latent = latent.reshape(b, g, d // g)
+
+    # [B, G, C]
+    # torch.transpose(codebook, [2,1,0])
+    distance = (
+        # [b, g, 1]
+        torch.sum(latent**2, -1, keepdim=True) -
+        # [b, g, c]
+        2 * torch.einsum('bgd,cgd->bgc', latent, codebook) +
+        # [1, g, c]
+        torch.sum(codebook.permute([2, 1, 0])**2, 0, keepdim=True))
+
+    # [B, G]
+    codes = torch.argmin(distance, dim=-1)
+
+    # [B, G, C]
+    one_hot = torch.nn.functional.one_hot(codes, c)
+    quantized = torch.einsum('bgc,cgd->bgd', one_hot, codebook)
+    quantized = torch.reshape(quantized, [b, d])
+    return quantized, codes, one_hot
 
 
 class BestRQModel(torch.nn.Module):
@@ -10,50 +56,74 @@ class BestRQModel(torch.nn.Module):
     def __init__(
         self,
         encoder: torch.nn.Module,
-        input_dim: int = 256,
-        embedding_dim: int = 256,
+        num_mel_bins: int = 80,
+        embedding_dim: int = 16,
         num_embeddings: int = 8192,
         num_codebooks: int = 1,
-        dropout_rate: float = 0.1,
         mask_prob: float = 0.01,
         mask_length: int = 10,
         min_masks: int = 2,
-        layer_norm_epsilon=1e-5,
+        norm_epsilon: float = 1e-5,
+        features_regularization_weight: float = 0.01,
     ) -> None:
         super().__init__()
-
         assert mask_prob > 0.0
-
         self.mask_prob = mask_prob
-        # NOTE: should filter audio less than mask_length
         self.mask_length = mask_length
         self.min_masks = min_masks
 
-        self.input_dropout = torch.nn.Dropout(dropout_rate)
+        self.num_codebooks = num_codebooks
+        self.num_embeddings = num_embeddings
+        self.features_regularization_weight = features_regularization_weight
 
-        # [embedding_dim, num_embeddings]
-        random_embedding_weight = torch.empty(num_codebooks,
-                                              embedding_dim,
-                                              num_embeddings,
-                                              requires_grad=False)
-        self.embeddings = torch.nn.init.normal_(random_embedding_weight)
-
-        random_projection_weight = torch.empty(input_dim,
-                                               embedding_dim,
-                                               requires_grad=False)
-        self.projection = torch.nn.init.xavier_normal_(
-            random_projection_weight)
-
-        mask_emb_weight = torch.Tensor(input_dim)
-        mask_emb_weight.requires_grad = True
-        self.mask_emb = torch.nn.init.normal_(mask_emb_weight, mean=0, std=0.1)
-
-        self.input_layer_norm = torch.nn.LayerNorm(input_dim,
-                                                   layer_norm_epsilon)
+        # encoder
         self.encoder = encoder
+        assert self.encoder.global_cmvn is not None
+        self.register_buffer('signal_mean', self.encoder.global_cmvn.mean)
+        self.register_buffer('signal_istd', self.encoder.global_cmvn.istd)
+        self.signal_norm_var = self.encoder.global_cmvn.norm_var
+        # NOTE(Mddct): disable encoder's global_cmvn
+        self.encoder.global_cmvn = None
+
+        # n softmax
         self.encoder_top_n_out = torch.nn.parameter.Parameter(
-            torch.Tensor(num_codebooks, self.encoder.output_size(),
-                         num_embeddings))
+            torch.empty(self.num_codebooks, self.encoder.output_size(),
+                        num_embeddings))
+        torch.nn.init.trunc_normal_(self.encoder_top_n_out, std=0.02)
+        self.encoder_top_n_out_bias = torch.nn.parameter.Parameter(
+            torch.empty(self.num_codebooks, num_embeddings))
+        torch.nn.init.zeros_(self.encoder_top_n_out_bias)
+
+        # mask embedding
+        mask_embedding_dim = num_mel_bins
+        self.mask_emb = torch.nn.parameter.Parameter(
+            torch.empty(mask_embedding_dim), requires_grad=True)
+        torch.nn.init.trunc_normal_(self.mask_emb, std=0.1)
+
+        # stack input: eg: fbank
+        self.stack_frames = self.encoder.embed.right_context + 1
+        self.stride = self.encoder.embed.subsampling_rate
+        input_dim = num_mel_bins * self.stack_frames
+
+        # norm input
+        self.norm = torch.nn.LayerNorm(
+            input_dim, eps=norm_epsilon, elementwise_affine=False
+        ) if self.stack_frames > 1 else torch.nn.Identity()
+
+        # random projectoin
+        self.projection = torch.nn.parameter.Parameter(
+            torch.empty(input_dim, embedding_dim * self.num_codebooks),
+            requires_grad=False,
+        )
+        torch.nn.init.xavier_uniform_(self.projection)
+
+        # codebooks
+        # [num_codebooks, embedding_dim, num_embeddings]
+        self.embeddings = torch.nn.parameter.Parameter(
+            torch.empty(num_embeddings, self.num_codebooks, embedding_dim),
+            requires_grad=False,
+        )
+        torch.nn.init.normal_(self.embeddings)
 
     def forward(
         self,
@@ -62,93 +132,106 @@ class BestRQModel(torch.nn.Module):
         text: Optional[torch.Tensor] = None,
         text_length: Optional[torch.Tensor] = None,
     ):
-        # should support nonstreamming and streamming
-        # TODO(Mddct): streamming future
-        # eg: full attenton and chunk or  dynamic chunk training
-        # 1 forward subsampling
-        xs, pos_emb, masks = self._forward_subsampling(xs, xs_lens)
-        unmasked_xs = xs
-        # 2 mask features
-        # 2.0 apply mask
-        masked_xs, masked_masks = self._apply_mask(xs)
+        # force global cmvn
+        xs = xs - self.signal_mean
+        if self.signal_norm_var:
+            xs = xs * self.signal_istd
+        input = xs
+
+        features_pen: Optional[torch.Tensor] = None
+        if self.features_regularization_weight != 0.0:
+            features_pen = input.pow(2).mean()
+
+        # 0 mask input
+        xs, masked_masks = self._apply_mask_signal(xs, xs_lens)
+
+        # 1 get subsampling mask
+        subsampling_masks = masked_masks.unfold(1,
+                                                size=self.stack_frames,
+                                                step=self.stride)
+        code_ids_mask, _ = torch.max(subsampling_masks, 2)
+
+        # 2.0 stack fbank
+        unmasked_xs = self._stack_features(input)
+        masked_xs = xs
+
         # 2.1 get nearest embedding
         target_ids = self._nearest_embedding_idx(unmasked_xs)
-        # 3 forward xxx-formaer block
-        out, out_mask = self._forward_encoder_blocks(masked_xs, masks, pos_emb,
-                                                     masks)
+
+        # 3 forward xxx-formaer block and its subsampling layer
+        out, out_mask = self.encoder(masked_xs, xs_lens)
+
         # 4 get logits
         out = out.unsqueeze(1)  # [B, 1, T', dim]
         top_n_out = self.encoder_top_n_out.unsqueeze(
-            0)  # [num_codebooks, dim, num_embeddings]
+            0)  # [1, num_codebooks, dim, num_embeddings]
         out = torch.matmul(out,
                            top_n_out)  # [B, num_codebooks, T', num_embeddings]
+        out = out + self.encoder_top_n_out_bias.unsqueeze(0).unsqueeze(2)
 
         # 5 compute loss
-        loss = self._compute_loss(out, target_ids,
-                                  out_mask.squeeze(1) * masked_masks)
-        return {"loss": loss}
+        masks = out_mask.squeeze(1) * code_ids_mask
+        loss = self._compute_loss(out, target_ids, mask=masks)
+        if self.features_regularization_weight != 0.0:
+            loss = loss + self.features_regularization_weight * features_pen
 
-    def _compute_loss(self, input: torch.Tensor, target: torch.Tensor,
-                      mask: torch.Tensor):
-        input = input.transpose(1, 3)  # [B, num_embeddings, T' num_codebooks]
-        entropy = torch.nn.functional.cross_entropy(
-            input, target, reduction='none')  # [B, T', num_codebooks]
-        # stop gradient for non mask area
-        loss = entropy * mask.unsqueeze(2)
-        return loss.sum() / (mask.sum() * loss.size(2))
+        # 6 other info: num codes used in batch, unique num codes used in batch
+        num_codes = masks.sum() * self.num_codebooks
+        uniq_num_codes = torch.tensor(
+            torch.unique(target_ids * masks.unsqueeze(2)).numel()).detach()
+        ids_corr = out.argmax(dim=-1, keepdim=False).transpose(1,
+                                                               2) == target_ids
+        codes_acc = (ids_corr * masks.unsqueeze(2)).sum() / num_codes
+        return {
+            "codes_acc": codes_acc,
+            "features_l2": features_pen,
+            "loss": loss,
+            "num_codes": num_codes,
+            "uniq_num_codes": uniq_num_codes
+        }
 
-    def _forward_encoder_blocks(self, xs: torch.Tensor, xs_masks: torch.Tensor,
-                                pos_emb: torch.Tensor, mask_pad: torch.Tensor):
+    def _apply_mask_signal(
+            self, input: torch.Tensor,
+            input_lens: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        padding_mask = make_pad_mask(input_lens)
+        masks = compute_mask_indices_v2(input.size()[:-1],
+                                        padding_mask,
+                                        self.mask_prob,
+                                        self.mask_length,
+                                        min_masks=self.min_masks,
+                                        device=input.device)
 
-        masks = xs_masks
-        for layer in self.encoder.encoders:
-            xs, masks, _, _ = layer(xs, xs_masks, pos_emb, mask_pad)
-        if self.encoder.normalize_before:
-            xs = self.encoder.after_norm(xs)
-        # Here we assume the mask is not changed in encoder layers, so just
-        # return the masks before encoder layers, and the masks will be used
-        # for cross attention with decoder later
+        masks_expand = masks.unsqueeze(-1)  # [B, T, 1]
+        mask_emb = self.mask_emb.to(input.device).view(1, 1, -1)
+        xs = torch.where(masks_expand, mask_emb, input)
         return xs, masks
 
+    def _stack_features(self, input: torch.Tensor) -> torch.Tensor:
+
+        stack_input = input.unfold(1, size=self.stack_frames, step=self.stride)
+        b, n, f, d = stack_input.size()
+        stack_input = stack_input.reshape(b, n, f * d)
+
+        return stack_input
+
+    def _compute_loss(self, input: torch.Tensor, target: torch.Tensor,
+                      mask: torch.Tensor) -> torch.Tensor:
+        log_probs = torch.log_softmax(input, dim=-1).transpose(
+            1, 2)  # [B, T', num_codebooks, num_embeddings]
+
+        per_example_n_loss = -log_probs.gather(3, target.unsqueeze(3)).squeeze(
+            3)  # [B, T', num_codebooks]
+
+        numerator = torch.sum(per_example_n_loss * mask.unsqueeze(2))
+        denominator = torch.sum(mask) + 1e-5
+        loss = numerator / (denominator * self.num_codebooks)
+        return loss
+
     def _nearest_embedding_idx(self, xs: torch.Tensor) -> torch.Tensor:
-        xs = self.input_layer_norm(xs)
-        xs = self.input_dropout(xs)
+        xs = self.norm(xs)
         xs = torch.matmul(xs, self.projection.to(xs.device))
 
         B, T, C = xs.size()
-        flattened_input = xs.view(-1, C)
-        embeddings = self.embeddings.to(
-            xs.device)  # [num_codebooks, embedding_dim, num_embeddings]
-        # [num_codebooks, B*T, num_embeddings]
-        distance = (
-            torch.sum(flattened_input**2, dim=1, keepdim=True).unsqueeze(0) +
-            torch.sum(embeddings**2, dim=1, keepdim=True) -
-            2 * torch.matmul(flattened_input.unsqueeze(0), embeddings))
-
-        out = torch.argmin(distance, dim=-1)  # [num_codebooks, B*T]
-        out = out.transpose(0, 1)  # [B*T, num_codebooks]
-        return out.reshape(B, T, -1)  # [B, T, num_codebooks]
-
-    def _apply_mask(self,
-                    xs: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        masks = compute_mask_indices(xs.size()[:-1],
-                                     self.mask_prob,
-                                     self.mask_length,
-                                     self.min_masks,
-                                     device=xs.device)
-        masks_expand = masks.unsqueeze(-1)  # [B, T, 1]
-
-        mask_emb = self.mask_emb.to(xs.device).view(1, 1, -1)
-        xs = torch.where(masks_expand, mask_emb, xs)
-        return xs, masks
-
-    def _forward_subsampling(
-        self, xs: torch.Tensor, xs_lens: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-
-        T = xs.size(1)
-        masks = ~make_pad_mask(xs_lens, T).unsqueeze(1)  # (B, 1, T)
-        if self.encoder.global_cmvn is not None:
-            xs = self.encoder.global_cmvn(xs)
-        xs, pos_emb, masks = self.encoder.embed(xs, masks)
-        return xs, pos_emb, masks
+        xs_flatten = xs.view(B * T, C)
+        _, codes, _ = quantize_vector(xs_flatten, self.embeddings)
+        return codes.reshape(B, T, -1)  # [B, T, num_codebooks]

--- a/wenet/ssl/bestrq/mask.py
+++ b/wenet/ssl/bestrq/mask.py
@@ -1,5 +1,5 @@
 import torch
-
+import numpy as np
 
 def _sampler(pdf: torch.Tensor, num_samples: int,
              device=torch.device('cpu')) -> torch.Tensor:
@@ -52,3 +52,108 @@ def compute_mask_indices(
                                  dtype=torch.bool,
                                  device=mask_idxs.device)
     return torch.scatter(full_mask, dim=1, index=mask_idxs, src=ones)
+
+
+def compute_mask_indices_v2(
+        shape,
+        padding_mask,
+        mask_prob: float,
+        mask_length: int,
+        mask_type: str = 'static',
+        mask_other: float = 0.0,
+        min_masks: int = 2,
+        no_overlap: bool = False,
+        min_space: int = 1,
+        device=torch.device('cpu'),
+):
+    bsz, all_sz = shape
+    mask = np.full((bsz, all_sz), False)
+    padding_mask = padding_mask.cpu().numpy()
+    all_num_mask = int(
+        # add a random number for probabilistic rounding
+        mask_prob * all_sz / float(mask_length) + np.random.rand())
+
+    all_num_mask = max(min_masks, all_num_mask)
+
+    mask_idcs = []
+    for i in range(bsz):
+        if padding_mask is not None and not isinstance(padding_mask, bytes):
+            sz = all_sz - padding_mask[i].sum()
+            num_mask = int(
+                # add a random number for probabilistic rounding
+                mask_prob * sz / float(mask_length) + np.random.rand())
+            num_mask = max(min_masks, num_mask)
+        else:
+            sz = all_sz
+            num_mask = all_num_mask
+
+        if mask_type == 'static':
+            lengths = np.full(num_mask, mask_length)
+        elif mask_type == 'uniform':
+            lengths = np.random.randint(mask_other,
+                                        mask_length * 2 + 1,
+                                        size=num_mask)
+        elif mask_type == 'normal':
+            lengths = np.random.normal(mask_length, mask_other, size=num_mask)
+            lengths = [max(1, int(round(x))) for x in lengths]
+        elif mask_type == 'poisson':
+            lengths = np.random.poisson(mask_length, size=num_mask)
+            lengths = [int(round(x)) for x in lengths]
+        else:
+            raise Exception('unknown mask selection ' + mask_type)
+
+        if sum(lengths) == 0:
+            lengths[0] = min(mask_length, sz - 1)
+
+        if no_overlap:
+            mask_idc = []
+
+            def arrange(s, e, length, keep_length, mask_idc):
+                span_start = np.random.randint(s, e - length)
+                mask_idc.extend(span_start + i for i in range(length))
+
+                new_parts = []
+                if span_start - s - min_space >= keep_length:
+                    new_parts.append((s, span_start - min_space + 1))
+                if e - span_start - keep_length - min_space > keep_length:
+                    new_parts.append((span_start + length + min_space, e))
+                return new_parts
+
+            parts = [(0, sz)]
+            min_length = min(lengths)
+            for length in sorted(lengths, reverse=True):
+                lens = np.fromiter(
+                    (e - s if e - s >= length + min_space else 0
+                     for s, e in parts),
+                    np.int,
+                )
+                l_sum = np.sum(lens)
+                if l_sum == 0:
+                    break
+                probs = lens / np.sum(lens)
+                c = np.random.choice(len(parts), p=probs)
+                s, e = parts.pop(c)
+                parts.extend(arrange(s, e, length, min_length, mask_idc))
+            mask_idc = np.asarray(mask_idc)
+        else:
+            min_len = min(lengths)
+            if sz - min_len <= num_mask:
+                min_len = sz - num_mask - 1
+
+            mask_idc = np.random.choice(sz - min_len, num_mask, replace=False)
+
+            mask_idc = np.asarray([
+                mask_idc[j] + offset for j in range(len(mask_idc))
+                for offset in range(lengths[j])
+            ])
+
+        mask_idcs.append(np.unique(mask_idc[mask_idc < sz]))
+
+    min_len = min([len(m) for m in mask_idcs])
+    for i, mask_idc in enumerate(mask_idcs):
+        if len(mask_idc) > min_len:
+            mask_idc = np.random.choice(mask_idc, min_len, replace=False)
+        mask[i, mask_idc] = True
+
+    mask = torch.from_numpy(mask).to(device)
+    return mask


### PR DESCRIPTION
changes:
 -  stack fbank instead of stack features after subsampling  （BEST-RQ paper do stack fbank ）
 -  replace compute_mask_indices_v2 with compute_mask_indices,(v2 from wav2vec2  which compute mask in cpu), The v2 version can consider padding, and the probability of short sequence overmask becomes smaller
 - fbank should do cmvn ， stack fbanks should renorm using unlearnable LN  avoiding codebooks collapse
 - add fbank l2 regularization which can stable training
 - other info about training
 - reset encoder parameter using bert-style:  trunk_norm std==0.02