### PR TITLE
Fix - FLAC ERROR whilst decoding metadata

### DIFF
--- a/wenet/dataset/processor.py
+++ b/wenet/dataset/processor.py
@@ -25,6 +25,8 @@ import torchaudio
 import torchaudio.compliance.kaldi as kaldi
 from torch.nn.utils.rnn import pad_sequence
 
+torchaudio.utils.sox_utils.set_buffer_size(16500)
+
 AUDIO_FORMAT_SETS = set(['flac', 'mp3', 'm4a', 'ogg', 'opus', 'wav', 'wma'])
 
 


### PR DESCRIPTION
Check this [issue](https://github.com/pytorch/audio/issues/2948)

I encounter this issue by using shard to do training on flacs files... Notice the issue only occurs when using torchaudio to load a file-like object not a file path.