### PR TITLE
[doc/onnxruntime] Update README.md

### DIFF
--- a/runtime/onnxruntime/README.md
+++ b/runtime/onnxruntime/README.md
@@ -31,8 +31,10 @@ export GLOG_v=2
 wav_path=your_test_wav_path
 onnx_dir=your_model_dir
 units=units.txt  # Change it to your model units path
+# Make sure that the `chunk_size` and `num_left_chunks` variables are set to the corresponding values used when exporting the ONNX models.
 ./build/bin/decoder_main \
     --chunk_size 16 \
+    --num_left_chunks -1 \
     --wav_path $wav_path \
     --onnx_dir $onnx_dir \
     --unit_path $units 2>&1 | tee log.txt


### PR DESCRIPTION
Remind the user to align the chunksize/leftchunks in the decoder flag with the chunksize/leftchunks used for exporting ONNX models; otherwise, it may result in a segmentation fault.