### PR TITLE
[wenet] Add the context decoding graph, which supports context biasin…

### DIFF
--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -166,9 +166,8 @@ def get_args():
     parser.add_argument('--context_graph_score',
                         type=float,
                         default=0.0,
-                        help='''The higher the score, the greater the degree of 
+                        help='''The higher the score, the greater the degree of
                                 bias using decoding-graph for biasing''')
-    
 
     args = parser.parse_args()
     print(args)

--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -30,6 +30,7 @@ from wenet.utils.checkpoint import load_checkpoint
 from wenet.utils.file_utils import read_symbol_table, read_non_lang_symbols
 from wenet.utils.config import override_config
 from wenet.utils.init_model import init_model
+from wenet.utils.context_graph import ContextGraph
 
 
 def get_args():
@@ -153,6 +154,22 @@ def get_args():
                         default=0.0,
                         help='lm scale for hlg attention rescore decode')
 
+    parser.add_argument('--context_bias_mode',
+                        type=str,
+                        default='',
+                        help='''Context bias mode, selectable from the following
+                                option: decoding-graph、deep-biasing''')
+    parser.add_argument('--context_list_path',
+                        type=str,
+                        default='',
+                        help='Context list path')
+    parser.add_argument('--context_graph_score',
+                        type=float,
+                        default=0.0,
+                        help='''The higher the score, the greater the degree of 
+                                bias using decoding-graph for biasing''')
+    
+
     args = parser.parse_args()
     print(args)
     return args
@@ -228,6 +245,14 @@ def main():
         paraformer_beam_search = build_beam_search(model, args, device)
     else:
         paraformer_beam_search = None
+
+    context_graph = None
+    if 'decoding-graph' in args.context_bias_mode:
+        context_graph = ContextGraph(args.context_list_path,
+                                     symbol_table,
+                                     args.bpe_model,
+                                     args.context_graph_score)
+
 
     with torch.no_grad(), open(args.result_file, 'w') as fout:
         for batch_idx, batch in enumerate(test_data_loader):
@@ -317,7 +342,8 @@ def main():
                     args.beam_size,
                     decoding_chunk_size=args.decoding_chunk_size,
                     num_decoding_left_chunks=args.num_decoding_left_chunks,
-                    simulate_streaming=args.simulate_streaming)
+                    simulate_streaming=args.simulate_streaming,
+                    context_graph=context_graph)
                 hyps = [hyp]
             elif args.mode == 'attention_rescoring':
                 assert (feats.size(0) == 1)
@@ -329,7 +355,8 @@ def main():
                     num_decoding_left_chunks=args.num_decoding_left_chunks,
                     ctc_weight=args.ctc_weight,
                     simulate_streaming=args.simulate_streaming,
-                    reverse_weight=args.reverse_weight)
+                    reverse_weight=args.reverse_weight,
+                    context_graph=context_graph)
                 hyps = [hyp]
             elif args.mode == 'hlg_onebest':
                 hyps = model.hlg_onebest(

--- a/wenet/transformer/asr_model.py
+++ b/wenet/transformer/asr_model.py
@@ -357,6 +357,7 @@ class ASRModel(torch.nn.Module):
         decoding_chunk_size: int = -1,
         num_decoding_left_chunks: int = -1,
         simulate_streaming: bool = False,
+        context_graph: ContextGraph = None,
     ) -> Tuple[List[List[int]], torch.Tensor]:
         """ CTC prefix beam search inner implementation
 
@@ -393,140 +394,93 @@ class ASRModel(torch.nn.Module):
             encoder_out)  # (1, maxlen, vocab_size)
         ctc_probs = ctc_probs.squeeze(0)
         # cur_hyps: (prefix, (blank_ending_score, none_blank_ending_score))
-        cur_hyps = [(tuple(), (0.0, -float('inf')))]
         # 2. CTC beam search step by step
-        for t in range(0, maxlen):
-            logp = ctc_probs[t]  # (vocab_size,)
-            # key: prefix, value (pb, pnb), default value(-inf, -inf)
-            next_hyps = defaultdict(lambda: (-float('inf'), -float('inf')))
-            # 2.1 First beam prune: select topk best
-            top_k_logp, top_k_index = logp.topk(beam_size)  # (beam_size,)
-            for s in top_k_index:
-                s = s.item()
-                ps = logp[s].item()
-                for prefix, (pb, pnb) in cur_hyps:
-                    last = prefix[-1] if len(prefix) > 0 else None
-                    if s == 0:  # blank
-                        n_pb, n_pnb = next_hyps[prefix]
-                        n_pb = log_add([n_pb, pb + ps, pnb + ps])
-                        next_hyps[prefix] = (n_pb, n_pnb)
-                    elif s == last:
-                        #  Update *ss -> *s;
-                        n_pb, n_pnb = next_hyps[prefix]
-                        n_pnb = log_add([n_pnb, pnb + ps])
-                        next_hyps[prefix] = (n_pb, n_pnb)
-                        # Update *s-s -> *ss, - is for blank
-                        n_prefix = prefix + (s, )
-                        n_pb, n_pnb = next_hyps[n_prefix]
-                        n_pnb = log_add([n_pnb, pb + ps])
-                        next_hyps[n_prefix] = (n_pb, n_pnb)
-                    else:
-                        n_prefix = prefix + (s, )
-                        n_pb, n_pnb = next_hyps[n_prefix]
-                        n_pnb = log_add([n_pnb, pb + ps, pnb + ps])
-                        next_hyps[n_prefix] = (n_pb, n_pnb)
+        if context_graph is None:
+            cur_hyps = [(tuple(), (0.0, -float('inf')))]
+            for t in range(0, maxlen):
+                logp = ctc_probs[t]  # (vocab_size,)
+                # key: prefix, value (pb, pnb), default value(-inf, -inf)
+                next_hyps = defaultdict(lambda: (-float('inf'), -float('inf')))
+                # 2.1 First beam prune: select topk best
+                top_k_logp, top_k_index = logp.topk(beam_size)  # (beam_size,)
+                for s in top_k_index:
+                    s = s.item()
+                    ps = logp[s].item()
+                    for prefix, (pb, pnb) in cur_hyps:
+                        last = prefix[-1] if len(prefix) > 0 else None
+                        if s == 0:  # blank
+                            n_pb, n_pnb = next_hyps[prefix]
+                            n_pb = log_add([n_pb, pb + ps, pnb + ps])
+                            next_hyps[prefix] = (n_pb, n_pnb)
+                        elif s == last:
+                            #  Update *ss -> *s;
+                            n_pb, n_pnb = next_hyps[prefix]
+                            n_pnb = log_add([n_pnb, pnb + ps])
+                            next_hyps[prefix] = (n_pb, n_pnb)
+                            # Update *s-s -> *ss, - is for blank
+                            n_prefix = prefix + (s, )
+                            n_pb, n_pnb = next_hyps[n_prefix]
+                            n_pnb = log_add([n_pnb, pb + ps])
+                            next_hyps[n_prefix] = (n_pb, n_pnb)
+                        else:
+                            n_prefix = prefix + (s, )
+                            n_pb, n_pnb = next_hyps[n_prefix]
+                            n_pnb = log_add([n_pnb, pb + ps, pnb + ps])
+                            next_hyps[n_prefix] = (n_pb, n_pnb)
 
-            # 2.2 Second beam prune
-            next_hyps = sorted(next_hyps.items(),
-                               key=lambda x: log_add(list(x[1])),
-                               reverse=True)
-            cur_hyps = next_hyps[:beam_size]
-        hyps = [(y[0], log_add([y[1][0], y[1][1]])) for y in cur_hyps]
-        return hyps, encoder_out
+                # 2.2 Second beam prune
+                next_hyps = sorted(next_hyps.items(),
+                                   key=lambda x: log_add(list(x[1])),
+                                   reverse=True)
+                cur_hyps = next_hyps[:beam_size]
+            hyps = [(y[0], log_add([y[1][0], y[1][1]])) for y in cur_hyps]
+        else:
+            cur_hyps = [(tuple(), (0.0, -float('inf'), 0, 0.0))]
+            # 2. CTC beam search step by step
+            for t in range(0, maxlen):
+                logp = ctc_probs[t]  # (vocab_size,)
+                # key: prefix, value (pb, pnb, context_state, context_score),
+                # default value(-inf, -inf, 0, 0.0)
+                next_hyps = defaultdict(lambda: (-float('inf'), -float('inf'), 0, 0.0))
+                # 2.1 First beam prune: select topk best
+                top_k_logp, top_k_index = logp.topk(beam_size)  # (beam_size,)
+                for s in top_k_index:
+                    s = s.item()
+                    ps = logp[s].item()
+                    for prefix, (pb, pnb, c_state, c_score) in cur_hyps:
+                        last = prefix[-1] if len(prefix) > 0 else None
+                        if s == 0:  # blank
+                            n_pb, n_pnb, _, _ = next_hyps[prefix]
+                            n_pb = log_add([n_pb, pb + ps, pnb + ps])
+                            next_hyps[prefix] = (n_pb, n_pnb, c_state, c_score)
+                        elif s == last:
+                            #  Update *ss -> *s;
+                            n_pb, n_pnb, _, _ = next_hyps[prefix]
+                            n_pnb = log_add([n_pnb, pnb + ps])
+                            next_hyps[prefix] = (n_pb, n_pnb, c_state, c_score)
+                            # Update *s-s -> *ss, - is for blank
+                            n_prefix = prefix + (s, )
+                            n_pb, n_pnb, _, _ = next_hyps[n_prefix]
+                            new_c_state, new_c_score = context_graph. \
+                                find_next_state(c_state, s)
+                            n_pnb = log_add([n_pnb, pb + ps])
+                            next_hyps[n_prefix] = (n_pb, n_pnb, new_c_state,
+                                                   c_score + new_c_score)
+                        else:
+                            n_prefix = prefix + (s, )
+                            n_pb, n_pnb, _, _ = next_hyps[n_prefix]
+                            new_c_state, new_c_score = context_graph. \
+                                find_next_state(c_state, s)
+                            n_pnb = log_add([n_pnb, pb + ps, pnb + ps])
+                            next_hyps[n_prefix] = (n_pb, n_pnb, new_c_state,
+                                                   c_score + new_c_score)
 
-    def _ctc_prefix_beam_search_with_bias(
-        self,
-        speech: torch.Tensor,
-        speech_lengths: torch.Tensor,
-        beam_size: int,
-        decoding_chunk_size: int = -1,
-        num_decoding_left_chunks: int = -1,
-        simulate_streaming: bool = False,
-        context_graph: ContextGraph = None,
-    ) -> Tuple[List[List[int]], torch.Tensor]:
-        """ CTC prefix beam search inner implementation, rescoring with
-            context graph
-
-        Args:
-            speech (torch.Tensor): (batch, max_len, feat_dim)
-            speech_length (torch.Tensor): (batch, )
-            beam_size (int): beam size for beam search
-            decoding_chunk_size (int): decoding chunk for dynamic chunk
-                trained model.
-                <0: for decoding, use full chunk.
-                >0: for decoding, use fixed chunk size as set.
-                0: used for training, it's prohibited here
-            simulate_streaming (bool): whether do encoder forward in a
-                streaming fashion
-
-        Returns:
-            List[List[int]]: nbest results
-            torch.Tensor: encoder output, (1, max_len, encoder_dim),
-                it will be used for rescoring in attention rescoring mode
-        """
-        assert speech.shape[0] == speech_lengths.shape[0]
-        assert decoding_chunk_size != 0
-        batch_size = speech.shape[0]
-        # For CTC prefix beam search, we only support batch_size=1
-        assert batch_size == 1
-        # Let's assume B = batch_size and N = beam_size
-        # 1. Encoder forward and get CTC score
-        encoder_out, encoder_mask = self._forward_encoder(
-            speech, speech_lengths, decoding_chunk_size,
-            num_decoding_left_chunks,
-            simulate_streaming)  # (B, maxlen, encoder_dim)
-        maxlen = encoder_out.size(1)
-        ctc_probs = self.ctc.log_softmax(
-            encoder_out)  # (1, maxlen, vocab_size)
-        ctc_probs = ctc_probs.squeeze(0)
-
-        # cur_hyps: (prefix, (blank_ending_score, none_blank_ending_score,
-        # context_graph_state, context_score))
-        cur_hyps = [(tuple(), (0.0, -float('inf'), 0, 0.0))]
-        # 2. CTC beam search step by step
-        for t in range(0, maxlen):
-            logp = ctc_probs[t]  # (vocab_size,)
-            # key: prefix, value (pb, pnb), default value(-inf, -inf)
-            next_hyps = defaultdict(lambda: (-float('inf'), -float('inf'), 0, 0.0))
-            # 2.1 First beam prune: select topk best
-            top_k_logp, top_k_index = logp.topk(beam_size)  # (beam_size,)
-            for s in top_k_index:
-                s = s.item()
-                ps = logp[s].item()
-                for prefix, (pb, pnb, c_state, c_score) in cur_hyps:
-                    last = prefix[-1] if len(prefix) > 0 else None
-                    if s == 0:  # blank
-                        n_pb, n_pnb, _, _ = next_hyps[prefix]
-                        n_pb = log_add([n_pb, pb + ps, pnb + ps])
-                        next_hyps[prefix] = (n_pb, n_pnb, c_state, c_score)
-                    elif s == last:
-                        #  Update *ss -> *s;
-                        n_pb, n_pnb, _, _ = next_hyps[prefix]
-                        n_pnb = log_add([n_pnb, pnb + ps])
-                        next_hyps[prefix] = (n_pb, n_pnb, c_state, c_score)
-                        # Update *s-s -> *ss, - is for blank
-                        n_prefix = prefix + (s, )
-                        n_pb, n_pnb, _, _ = next_hyps[n_prefix]
-                        new_c_state, new_c_score = context_graph. \
-                            find_next_state(c_state, s)
-                        n_pnb = log_add([n_pnb, pb + ps])
-                        next_hyps[n_prefix] = (n_pb, n_pnb, new_c_state,
-                                               c_score + new_c_score)
-                    else:
-                        n_prefix = prefix + (s, )
-                        n_pb, n_pnb, _, _ = next_hyps[n_prefix]
-                        new_c_state, new_c_score = context_graph. \
-                            find_next_state(c_state, s)
-                        n_pnb = log_add([n_pnb, pb + ps, pnb + ps])
-                        next_hyps[n_prefix] = (n_pb, n_pnb, new_c_state,
-                                               c_score + new_c_score)
-
-            # 2.2 Second beam prune
-            next_hyps = sorted(next_hyps.items(),
-                               key=lambda x: log_add([x[1][0], x[1][1]]) + x[1][3],
-                               reverse=True)
-            cur_hyps = next_hyps[:beam_size]
-        hyps = [(y[0], log_add([y[1][0], y[1][1]]) + y[1][3]) for y in cur_hyps]
+                # 2.2 Second beam prune
+                next_hyps = sorted(next_hyps.items(),
+                                   key=lambda x: log_add([x[1][0], x[1][1]]) + x[1][3],
+                                   reverse=True)
+                cur_hyps = next_hyps[:beam_size]
+            hyps = [(y[0], log_add([y[1][0], y[1][1]]) + y[1][3]) for y in cur_hyps]
         return hyps, encoder_out
 
     def ctc_prefix_beam_search(
@@ -556,19 +510,11 @@ class ASRModel(torch.nn.Module):
         Returns:
             List[int]: CTC prefix beam search nbest results
         """
-        if context_graph is None:
-            hyps, _ = self._ctc_prefix_beam_search(speech, speech_lengths,
-                                                   beam_size, decoding_chunk_size,
-                                                   num_decoding_left_chunks,
-                                                   simulate_streaming)
-        else:
-            hyps, _ = self._ctc_prefix_beam_search_with_bias(speech,
-                                                             speech_lengths,
-                                                             beam_size,
-                                                             decoding_chunk_size,
-                                                             num_decoding_left_chunks,
-                                                             simulate_streaming,
-                                                             context_graph)
+        hyps, _ = self._ctc_prefix_beam_search(speech, speech_lengths,
+                                               beam_size, decoding_chunk_size,
+                                               num_decoding_left_chunks,
+                                               simulate_streaming,
+                                               context_graph)
         return hyps[0]
 
     def attention_rescoring(
@@ -614,14 +560,9 @@ class ASRModel(torch.nn.Module):
         # For attention rescoring we only support batch_size=1
         assert batch_size == 1
         # encoder_out: (1, maxlen, encoder_dim), len(hyps) = beam_size
-        if context_graph is None:
-            hyps, encoder_out = self._ctc_prefix_beam_search(
-                speech, speech_lengths, beam_size, decoding_chunk_size,
-                num_decoding_left_chunks, simulate_streaming)
-        else:
-            hyps, encoder_out = self._ctc_prefix_beam_search_with_bias(
-                speech, speech_lengths, beam_size, decoding_chunk_size,
-                num_decoding_left_chunks, simulate_streaming, context_graph)
+        hyps, encoder_out = self._ctc_prefix_beam_search(
+            speech, speech_lengths, beam_size, decoding_chunk_size,
+            num_decoding_left_chunks, simulate_streaming, context_graph)
 
         assert len(hyps) == beam_size
         hyps_pad = pad_sequence([

--- a/wenet/utils/context_graph.py
+++ b/wenet/utils/context_graph.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 def tokenize(context_list_path,
              symbol_table,
              bpe_model=None):
-    """ Read biasing list from the biasing list address, tokenize and convert it 
+    """ Read biasing list from the biasing list address, tokenize and convert it
         into token id
     """
     if bpe_model is not None:
@@ -46,28 +46,28 @@ class ContextGraph:
             context_score(float): context score for each token
     """
     def __init__(self,
-                context_list_path: str,
-                symbol_table: Dict[str, int],
-                bpe_model: str = None,
-                context_score: float = 6):
-        self.context_score=context_score
+                 context_list_path: str,
+                 symbol_table: Dict[str, int],
+                 bpe_model: str = None,
+                 context_score: float = 6):
+        self.context_score = context_score
         self.context_list = tokenize(context_list_path, symbol_table, bpe_model)
-        self.graph = {0:{}}
+        self.graph = {0: {}}
         self.graph_size = 0
         self.state2token = {}
-        self.back_score = {0:0.0}
+        self.back_score = {0: 0.0}
         self.build_graph(self.context_list)
-    
+
     def build_graph(self, context_list: List[List[int]]):
-        """ Constructing the context decoding graph, add arcs with negative 
+        """ Constructing the context decoding graph, add arcs with negative
             scores returning to the starting state for each non-terminal tokens
-            of hotwords, and add arcs with scores of 0 returning to the starting 
+            of hotwords, and add arcs with scores of 0 returning to the starting
             state for terminal tokens.
         """
-        self.graph = {0:{}}
+        self.graph = {0: {}}
         self.graph_size = 0
         self.state2token = {}
-        self.back_score = {0:0.0}
+        self.back_score = {0: 0.0}
         for context_token in context_list:
             now_state = 0
             for i in range(len(context_token)):
@@ -86,12 +86,12 @@ class ContextGraph:
                         self.back_score[now_state] = 0
                     self.state2token[now_state] = context_token[i]
 
-    def find_next_state(self, 
-                        now_state: int, 
+    def find_next_state(self,
+                        now_state: int,
                         token: int):
-        """ Search for an arc with the input being a token from the current state, 
-            returning the score on the arc and the state it points to. If there is 
-            no match, return to the starting state and perform an additional search 
+        """ Search for an arc with the input being a token from the current state,
+            returning the score on the arc and the state it points to. If there is
+            no match, return to the starting state and perform an additional search
             from the starting state to avoid token consumption due to mismatches.
         """
         if token in self.graph[now_state]:

--- a/wenet/utils/context_graph.py
+++ b/wenet/utils/context_graph.py
@@ -1,0 +1,103 @@
+from wenet.dataset.processor import __tokenize_by_bpe_model
+from typing import Dict, List
+
+def tokenize(context_list_path,
+             symbol_table,
+             bpe_model=None):
+    """ Read biasing list from the biasing list address, tokenize and convert it 
+        into token id
+    """
+    if bpe_model is not None:
+        import sentencepiece as spm
+        sp = spm.SentencePieceProcessor()
+        sp.load(bpe_model)
+    else:
+        sp = None
+
+    with open(context_list_path, "r") as fin:
+        context_txts = fin.readlines()
+
+    context_list = []
+    for context_txt in context_txts:
+        context_txt = context_txt.strip()
+
+        labels = []
+        tokens = []
+        if bpe_model is not None:
+            tokens = __tokenize_by_bpe_model(sp, context_txt)
+        else:
+            for ch in context_txt:
+                if ch == ' ':
+                    ch = "▁"
+                tokens.append(ch)
+        for ch in tokens:
+            if ch in symbol_table:
+                labels.append(symbol_table[ch])
+            elif '<unk>' in symbol_table:
+                labels.append(symbol_table['<unk>'])
+        context_list.append(labels)
+    return context_list
+
+class ContextGraph:
+    """ Context decoding graph, constructing graph using dict instead of WFST
+        Args:
+            context_list_path(str): context list path
+            bpe_model(str): model for english bpe part
+            context_score(float): context score for each token
+    """
+    def __init__(self,
+                context_list_path: str,
+                symbol_table: Dict[str, int],
+                bpe_model: str = None,
+                context_score: float = 6):
+        self.context_score=context_score
+        self.context_list = tokenize(context_list_path, symbol_table, bpe_model)
+        self.graph = {0:{}}
+        self.graph_size = 0
+        self.state2token = {}
+        self.back_score = {0:0.0}
+        self.build_graph(self.context_list)
+    
+    def build_graph(self, context_list: List[List[int]]):
+        """ Constructing the context decoding graph, add arcs with negative 
+            scores returning to the starting state for each non-terminal tokens
+            of hotwords, and add arcs with scores of 0 returning to the starting 
+            state for terminal tokens.
+        """
+        self.graph = {0:{}}
+        self.graph_size = 0
+        self.state2token = {}
+        self.back_score = {0:0.0}
+        for context_token in context_list:
+            now_state = 0
+            for i in range(len(context_token)):
+                if context_token[i] in self.graph[now_state]:
+                    now_state = self.graph[now_state][context_token[i]]
+                    if i == len(context_token) - 1:
+                        self.back_score[now_state] = 0
+                else:
+                    self.graph_size += 1
+                    self.graph[self.graph_size] = {}
+                    self.graph[now_state][context_token[i]] = self.graph_size
+                    now_state = self.graph_size
+                    if i != len(context_token) - 1:
+                        self.back_score[now_state] = -(i + 1) * self.context_score
+                    else:
+                        self.back_score[now_state] = 0
+                    self.state2token[now_state] = context_token[i]
+
+    def find_next_state(self, 
+                        now_state: int, 
+                        token: int):
+        """ Search for an arc with the input being a token from the current state, 
+            returning the score on the arc and the state it points to. If there is 
+            no match, return to the starting state and perform an additional search 
+            from the starting state to avoid token consumption due to mismatches.
+        """
+        if token in self.graph[now_state]:
+            return self.graph[now_state][token], self.context_score
+        back_score = self.back_score[now_state]
+        now_state = 0
+        if token in self.graph[now_state]:
+            return self.graph[now_state][token], back_score + self.context_score
+        return 0, back_score


### PR DESCRIPTION
添加python版本的基于热词图的热词偏置代码，均使用wenet给出的预训练模型进行测试，U-WER和B-WER分别指热词之外单词的词错误率和在热词上的词错误率

WenetSpeech biasing子集organization-name测试集，使用attention rescoring解码应用热词图前后结果：
|  method   | CER  |  U-CER | B-CER |
|  ----  | ----  | ---- | ---- |
| baseline  | 1.62 | 1.55 | 1.83 |
| context graph  | 1.43 | 1.54 | 1.05 |

热词列表大小298，context score=2.0
数据集、热词列表路径：https://github.com/thuhcsi/Contextual-Biasing-Dataset/

Librispeech test-other测试集，使用attention rescoring解码应用热词图前后结果：
|  method   | WER  |  U-WER | B-WER |
|  ----  | ----  | ---- | ---- |
| baseline  | 8.77 | 5.58 | 36.84 |
| context graph  | 7.9 | 5.61 | 28.02 |

热词列表大小3838，合并了test-other每条数据包含的热词，context score=2.0
热词列表路径：https://github.com/facebookresearch/fbai-speech/tree/main/is21_deep_bias