### PR TITLE
[fix] fix runtime context graph

### DIFF
--- a/runtime/core/decoder/context_graph.cc
+++ b/runtime/core/decoder/context_graph.cc
@@ -169,7 +169,7 @@ bool ContextGraph::SplitUTF8StringToWords(
         beginning = false;
         break;
       }
-      
+
       if (end == start + 1) {
         ++start;
         no_oov = false;

--- a/runtime/core/decoder/context_graph.cc
+++ b/runtime/core/decoder/context_graph.cc
@@ -152,7 +152,7 @@ bool ContextGraph::SplitUTF8StringToWords(
         continue;
       }
       // Add '▁' at the beginning of English word.
-      if (IsAlpha(word) && beginning == true) {
+      if (IsAlpha(word) && beginning) {
         word = kSpaceSymbol + word;
       }
 
@@ -163,14 +163,13 @@ bool ContextGraph::SplitUTF8StringToWords(
         continue;
       }
 
-      // Matching using '▁' separately for English
-      if (end == start + 1 && word[0] == kSpaceSymbol[0]) {
-        words->emplace_back(string(kSpaceSymbol));
-        beginning = false;
-        break;
-      }
-
       if (end == start + 1) {
+        // Matching using '▁' separately for English
+        if (word[0] == kSpaceSymbol[0]) {
+          words->emplace_back(string(kSpaceSymbol));
+          beginning = false;
+          break;
+        }
         ++start;
         no_oov = false;
         LOG(WARNING) << word << " is oov.";


### PR DESCRIPTION
修复runtime context graph在使用英文热词时会给每个bpe字词添加“▁”的问题，并且为英文热词设置热词分数时不再乘以token长度。

修复解码过程中热词匹配到一半时失配需要消耗一个token的问题。该问题导致对于“唯品唯品会”无法匹配热词“唯品会”，对于大热词列表以及识别英语情况下影响会比较大，因为这两种情况中更容易进入热词匹配的过程，也就会产生更多的失配，影响正常的热词增强过程。

Librispeech test-other测试集，使用attention rescoring解码应用热词图前后结果，由于runtime context graph方案中是按照词表直接对热词进行bpe分词，所以效果会比python context graph差一些：

method | WER | U-WER | B-WER
-- | -- | -- | --
baseline | 8.77 | 5.58 | 36.84
python context graph | 7.9 | 5.61 | 28.02
old runtime context graph | 8.42 | 5.71 | 32.19
new runtime context graph | 8.14 | 5.63 | 30.19

热词列表大小3838，合并了test-other每条数据包含的热词，context score=2.0
热词列表路径：https://github.com/facebookresearch/fbai-speech/tree/main/is21_deep_bias
