### PR TITLE
[feat](ZeroPrompt): illustrative exp of zeroprompt, not production ready

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pyflakes==2.2.0
 torch==1.13.0
 torchaudio==0.13.0
 deepspeed
+Levenshtein

--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -77,6 +77,7 @@ def get_args():
                             'hlg_rescore',
                             'paraformer_greedy_search',
                             'paraformer_beam_search',
+                            'zeroprompt',
                         ],
                         default='attention',
                         help='decoding mode')
@@ -175,6 +176,14 @@ def get_args():
                         default=0.0,
                         help='''The higher the score, the greater the degree of
                                 bias using decoding-graph for biasing''')
+    parser.add_argument('--zeroprompt_len',
+                        type=int,
+                        default=0,
+                        help='length of zeroprompt (after subsample)')
+    parser.add_argument('--zeroprompt_layer',
+                        type=int,
+                        default=0,
+                        help='start layer to apply zeroprompt (after subsample)')
 
     args = parser.parse_args()
     print(args)
@@ -402,6 +411,15 @@ def main():
                     decoding_chunk_size=args.decoding_chunk_size,
                     num_decoding_left_chunks=args.num_decoding_left_chunks,
                     simulate_streaming=args.simulate_streaming)
+            elif args.mode == 'zeroprompt':
+                hyps, data = model.zeroprompt(
+                    feats,
+                    feats_lengths,
+                    decoding_chunk_size=args.decoding_chunk_size,
+                    num_decoding_left_chunks=args.num_decoding_left_chunks,
+                    key=keys[0], char_dict=char_dict,
+                    zeroprompt_len=args.zeroprompt_len,
+                    zeroprompt_layer=args.zeroprompt_layer)
             for i, key in enumerate(keys):
                 content = []
                 for w in hyps[i]:

--- a/wenet/transformer/asr_model.py
+++ b/wenet/transformer/asr_model.py
@@ -16,7 +16,6 @@
 from collections import defaultdict
 from typing import Dict, List, Optional, Tuple
 
-import copy
 import Levenshtein as L
 import torch
 

--- a/wenet/transformer/convolution.py
+++ b/wenet/transformer/convolution.py
@@ -118,7 +118,9 @@ class ConvolutionModule(nn.Module):
                 assert cache.size(1) == x.size(1)  # equal channel
                 x = torch.cat((cache, x), dim=2)
             assert (x.size(2) > self.lorder)
-            new_cache = x[:, :, -self.lorder:]
+            # NOTE(xcsong): We do cache slicing in encoder.forward_chunk to unify
+            #   zeroprompt_len > 0 & zeroprompt_len == 0.
+            new_cache = x
         else:
             # It's better we just return None if no cache is required,
             # However, for JIT export, here we just fake one tensor instead of


### PR DESCRIPTION
This PR is an illustrative example to showcase the efficiency of ZeroPrompt and calculate metrics used in the paper. Due to the addition of some input parameters and significant changes to the `forward_chunk` API, it's better not to merge this PR and leave it as a reference for others who are interested in ZeroPrompt.

- Paper link: https://arxiv.org/pdf/2305.10649.pdf

- Presentation (In Chinese): 【语音识别延迟优化三部曲之二：ZeroPrompt】 https://www.bilibili.com/video/BV1Cj411z73S/?share_source=copy_web&vd_source=fd63a2f5ad1c9bc6b6658d9a922e20aa

- example output (Aishell-1, 640ms chunksize + 640ms zeroprompt):
  -  We can see that using ZeroPrompt allows us to consistently gain extra words at almost every chunk, The First Token Display Time & Last Token Display Time have been advanced by 640ms (one chunk).
  -  It’s reasonable for the predictions from the first ZeroPrompt chunk to be inaccurate due to the lack of contextual information. However, this is not a significant issue since most of the errors are homophones of the correct counterparts.
  - Additionally, these errors will be quickly corrected by the Prompt-and-Refine strategy.
![4e80db4736e8cda1ae7ea3575dd0e25](https://github.com/wenet-e2e/wenet/assets/13466943/6b4ab0de-ebb3-4c80-a4ff-7335bd55dca9)
![image](https://github.com/wenet-e2e/wenet/assets/13466943/fd9d8192-b9f2-4601-828f-1c6aba6b29e4)



- example output (librispeech, 640ms chunksize + 640ms zeroprompt):
    - We can draw the same conclusion as in Aishell-1 results
![e02a0564f83689630a3d74213611a91](https://github.com/wenet-e2e/wenet/assets/13466943/6ec8049c-99f0-44d8-8e07-33f3d43ffbe2)


