### PR TITLE
[ssl/w2vbert]  support part of w2vbert training

### DIFF
--- a/wenet/ssl/w2vbert/w2vbert_model.py
+++ b/wenet/ssl/w2vbert/w2vbert_model.py
@@ -244,7 +244,7 @@ class W2VBERTModel(torch.nn.Module):
             "features_l2": features_pen,
             "codes_acc": codes_acc.detach(),
             "loss": loss,
-            "losss_constrastive": loss_contrastive / sample_size,
+            "loss_contrastive": loss_contrastive / sample_size,
             "loss_diversity": loss_diversity,
             "loss_mlm": loss_mlm,
         }

--- a/wenet/ssl/w2vbert/w2vbert_model.py
+++ b/wenet/ssl/w2vbert/w2vbert_model.py
@@ -224,7 +224,6 @@ class W2VBERTModel(torch.nn.Module):
                            top_n_out)  # [B, num_codebooks, T', num_embeddings]
         if self.bias:
             out = out + self.encoder_top_n_out_bias.unsqueeze(0).unsqueeze(2)
-        out = out + self.encoder_top_n_out_bias.unsqueeze(0).unsqueeze(2)
 
         num_codes = masked_masks.sum() * self.num_codebooks
         loss_mlm = self._compute_mlm_loss(out,

--- a/wenet/ssl/w2vbert/w2vbert_model.py
+++ b/wenet/ssl/w2vbert/w2vbert_model.py
@@ -2,9 +2,10 @@ import math
 from typing import Optional, Tuple, Union
 import torch
 
-import torch.nn.functional as F
 from wenet.ssl.bestrq.mask import compute_mask_indices_v2
 from wenet.ssl.wav2vec2.quantizer import Wav2vecGumbelVectorQuantizer
+from wenet.ssl.wav2vec2.wav2vec2_model import (_compute_contrastive_loss,
+                                               _sample_negative_indices)
 from wenet.transformer.attention import RelPositionMultiHeadedAttention
 
 from wenet.transformer.encoder import ConformerEncoder, TransformerEncoder
@@ -12,97 +13,7 @@ from wenet.transformer.encoder_layer import ConformerEncoderLayer
 from wenet.utils.mask import make_non_pad_mask
 
 
-def _sample_negative_indices(features_shape: Tuple,
-                             num_negatives: int,
-                             device: torch.device,
-                             mask_time_indices: Optional[torch.Tensor] = None):
-    """
-    Sample `num_negatives` vectors from feature vectors.
-    """
-    batch_size, sequence_length = features_shape
-
-    sequence_length_range = torch.arange(sequence_length, device=device)
-
-    # get `num_negatives` random vector indices from the same utterance
-    sampled_negative_indices = torch.zeros(
-        (batch_size, sequence_length, num_negatives),
-        dtype=sequence_length_range.dtype,
-        device=device)
-
-    mask_time_indices = (mask_time_indices.bool()
-                         if mask_time_indices is not None else torch.ones(
-                             features_shape, dtype=torch.bool, device=device))
-
-    for batch_idx in range(batch_size):
-        high = mask_time_indices[batch_idx].sum() - 1
-        mapped_masked_indices = sequence_length_range[
-            mask_time_indices[batch_idx]]
-
-        feature_indices = torch.arange(high + 1).unsqueeze(1).expand(
-            high + 1, num_negatives)
-        sampled_indices = torch.randint(0,
-                                        high,
-                                        size=(high + 1, num_negatives))
-        sampled_indices[sampled_indices >= feature_indices] += 1
-
-        # remap to actual indices
-        sampled_negative_indices[batch_idx][mask_time_indices[
-            batch_idx]] = mapped_masked_indices[sampled_indices]
-
-        # correct for batch size
-        sampled_negative_indices[batch_idx] += batch_idx * sequence_length
-
-    return sampled_negative_indices.reshape(batch_size, -1)
-
-
-def _compute_contrastive_loss(quantized_features: torch.Tensor,
-                              features: torch.Tensor,
-                              negative_indices: torch.Tensor,
-                              mask_time_indices: torch.Tensor,
-                              logits_temp: float,
-                              num_negatives: int = 1):
-    batch_size, sequence_length, hidden_size = quantized_features.shape
-
-    # take negative vectors from sampled indices
-    quantized_negatives = quantized_features.view(
-        -1, hidden_size)[negative_indices.view(-1)]
-    quantized_negatives = quantized_negatives.view(batch_size, sequence_length,
-                                                   num_negatives,
-                                                   hidden_size).permute(
-                                                       2, 0, 1, 3)
-
-    target_features = torch.cat(
-        [quantized_features.unsqueeze(0), quantized_negatives], dim=0)
-    loss_logits = F.cosine_similarity(features, target_features, dim=-1)
-    loss_logits = loss_logits / logits_temp
-
-    neg_is_pos = (quantized_features == quantized_negatives).all(-1)
-    neg_is_pos = torch.cat(
-        [
-            torch.full(
-                (1, ) + loss_logits.shape[1:], False,
-                device=neg_is_pos.device), neg_is_pos
-        ],
-        dim=0,
-    )
-
-    # make sure incorrectly sampled vectors don't contribute to loss
-    loss_logits = torch.where(neg_is_pos, -1e9, loss_logits)
-
-    predictions = loss_logits.permute(2, 1, 0).reshape(-1,
-                                                       loss_logits.shape[0])
-    targets = ((1 - mask_time_indices.long()) * -100).transpose(1, 0).flatten()
-
-    target_mask = torch.where(targets >= 0, 1.0, 0.0)
-    contrastive_loss = F.cross_entropy(
-        predictions, targets.long(), reduction='none') * target_mask
-
-    contrastive_loss = contrastive_loss.sum()
-
-    return contrastive_loss
-
-
-class Wav2vec2Model(torch.nn.Module):
+class W2VBERTModel(torch.nn.Module):
 
     def __init__(
         self,
@@ -120,8 +31,16 @@ class Wav2vec2Model(torch.nn.Module):
         gumbel_temperature_decay: float = 0.999995,
         contrastive_logits_temperature: float = 0.1,
         diversity_weight: float = 0.0,
+        bias: bool = True,
+        contrastive_blocks: int = 6,
+        masked_blocks: int = 6,
+        contrastive_weight: float = 1.0,
+        mlm_weight: float = 1.0,
     ) -> None:
-        """ Wrap encoder to train using wav2vec2's style
+        """ Wrap encoder to train using W2V-BERT's style
+
+        Described in:
+        https://arxiv.org/pdf/2108.06209v2.pdf
 
         Args:
             encoder: wenet's encoder,
@@ -143,6 +62,11 @@ class Wav2vec2Model(torch.nn.Module):
         """
         super().__init__()
         assert mask_prob > 0.0
+        assert (contrastive_blocks > 0 and masked_blocks > 0 and
+                contrastive_blocks + masked_blocks == len(encoder.encoders))
+        self.contrastive_blocks = contrastive_blocks
+        self.masked_blocks = masked_blocks
+
         self.mask_prob = mask_prob
         self.mask_length = mask_length
         self.min_masks = min_masks
@@ -151,10 +75,13 @@ class Wav2vec2Model(torch.nn.Module):
         self.features_regularization_weight = features_regularization_weight
         self.diversity_weight = diversity_weight
 
+        self.contrastive_weight = contrastive_weight
+        self.mlm_weight = mlm_weight
         # encoder
         self.encoder = encoder
 
         # quantizer
+        self.num_codebooks = num_codebooks
         self.quantizer = Wav2vecGumbelVectorQuantizer(
             self.encoder.output_size(),
             num_codebooks=num_codebooks,
@@ -171,12 +98,24 @@ class Wav2vec2Model(torch.nn.Module):
 
         self.contrastive_logits_temp = contrastive_logits_temperature
 
-        self.mask_emb = torch.nn.parameter.Parameter(
-            torch.empty(self.encoder.output_size()).uniform_(),
-            requires_grad=True,
-        )
+        # NOET(Mddct): mask_em is replaced by random value in Wav-BERT
+        # self.mask_emb = torch.nn.parameter.Parameter(
+        #     torch.empty(self.encoder.output_size()).uniform_(),
+        #     requires_grad=True,
+        # )
         # TODO(Mddct): support causal or lookahead mask or keep consistent with
         # wenet dynamic chunk training
+
+        # # n softmax
+        self.encoder_top_n_out = torch.nn.parameter.Parameter(
+            torch.empty(num_codebooks, self.encoder.output_size(),
+                        num_embeddings))
+        torch.nn.init.trunc_normal_(self.encoder_top_n_out, std=0.02)
+        self.bias = bias
+        if bias:
+            self.encoder_top_n_out_bias = torch.nn.parameter.Parameter(
+                torch.empty(num_codebooks, num_embeddings))
+            torch.nn.init.zeros_(self.encoder_top_n_out_bias)
 
         # reset parameter
         self.reset_encoder_parameter()
@@ -237,13 +176,15 @@ class Wav2vec2Model(torch.nn.Module):
         # 2 mask features
         masked_xs, masked_masks = self._apply_mask(xs, masks.squeeze(1))
         # 3 forward encoder blocks
-        out, _ = self._forward_encoder_blocks(masked_xs, masks, pos_emb, masks)
+        contrastive_vec, mlm_vec, out_mask = self._forward_encoder_blocks(
+            masked_xs, masks, pos_emb, masks)
 
+        # 4 constrastive branch
         gumbel_temperature = max(
             self.max_gumbel_temp * self.gumbel_temp_decay**steps,
             self.min_gumbel_temp)
 
-        quantized_features, codevector_perplexity, _ = self.quantizer(
+        quantized_features, codevector_perplexity, targets_ids = self.quantizer(
             unmasked_xs, masks.squeeze(1), gumbel_temperature)
 
         sampled_negative_indices = _sample_negative_indices(
@@ -251,8 +192,8 @@ class Wav2vec2Model(torch.nn.Module):
             masked_masks)
 
         loss_contrastive = _compute_contrastive_loss(
-            quantized_features, out, sampled_negative_indices, masked_masks,
-            self.contrastive_logits_temp, self.num_negatives)
+            quantized_features, contrastive_vec, sampled_negative_indices,
+            masked_masks, self.contrastive_logits_temp, self.num_negatives)
         loss = loss_contrastive
 
         # scale by sample size
@@ -275,12 +216,37 @@ class Wav2vec2Model(torch.nn.Module):
             features_pen = xs.pow(2).mean()
             loss = loss + self.features_regularization_weight * features_pen
 
+        # 5 maked lm branch
+        out = mlm_vec.unsqueeze(1)
+        top_n_out = self.encoder_top_n_out.unsqueeze(
+            0)  # [1, num_codebooks, dim, num_embeddings]
+        out = torch.matmul(out,
+                           top_n_out)  # [B, num_codebooks, T', num_embeddings]
+        if self.bias:
+            out = out + self.encoder_top_n_out_bias.unsqueeze(0).unsqueeze(2)
+        out = out + self.encoder_top_n_out_bias.unsqueeze(0).unsqueeze(2)
+
+        num_codes = masked_masks.sum() * self.num_codebooks
+        loss_mlm = self._compute_mlm_loss(out,
+                                          targets_ids,
+                                          mask=out_mask.squeeze(1) *
+                                          masked_masks)
+        ids_corr = out.argmax(dim=-1,
+                              keepdim=False).transpose(1, 2) == targets_ids
+        codes_acc = (ids_corr * masked_masks.unsqueeze(2)).sum() / num_codes
+        # TODO(Mddct): support num codes used in batch, unique num codes
+        # used in batch like bestrq
+
+        # 6 final loss
+        loss = self.contrastive_weight * loss + self.mlm_weight * loss_mlm
         return {
             "code_ppl": codevector_perplexity.detach(),
             "features_l2": features_pen,
+            "codes_acc": codes_acc.detach(),
             "loss": loss,
             "losss_constrastive": loss_contrastive / sample_size,
             "loss_diversity": loss_diversity,
+            "loss_mlm": loss_mlm,
         }
 
     def _apply_mask(
@@ -295,10 +261,26 @@ class Wav2vec2Model(torch.nn.Module):
                                         device=xs.device)
         masks_expand = masks.unsqueeze(-1)  # [B, T, 1]
 
-        mask_emb = self.mask_emb.to(xs.device).view(1, 1, -1)
+        mask_emb = torch.normal(mean=0,
+                                std=0.1,
+                                size=xs.size(),
+                                device=xs.device)
         xs = torch.where(masks_expand, mask_emb, xs)
 
         return xs, masks
+
+    def _compute_mlm_loss(self, input: torch.Tensor, target: torch.Tensor,
+                          mask: torch.Tensor) -> torch.Tensor:
+        log_probs = torch.log_softmax(input, dim=-1).transpose(
+            1, 2)  # [B, T', num_codebooks, num_embeddings]
+
+        per_example_n_loss = -log_probs.gather(3, target.unsqueeze(3)).squeeze(
+            3)  # [B, T', num_codebooks]
+
+        numerator = torch.sum(per_example_n_loss * mask.unsqueeze(2))
+        denominator = torch.sum(mask) + 1e-5
+        loss = numerator / (denominator * self.num_codebooks)
+        return loss
 
     def _forward_subsampling(
         self, xs: torch.Tensor, xs_lens: torch.Tensor
@@ -310,16 +292,27 @@ class Wav2vec2Model(torch.nn.Module):
         xs, pos_emb, masks = self.encoder.embed(xs, masks)
         return xs, pos_emb, masks
 
-    def _forward_encoder_blocks(self, xs: torch.Tensor, xs_masks: torch.Tensor,
-                                pos_emb: torch.Tensor, mask_pad: torch.Tensor):
+    def _forward_encoder_blocks(
+        self, xs: torch.Tensor, xs_masks: torch.Tensor, pos_emb: torch.Tensor,
+        mask_pad: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
 
         masks = xs_masks
 
-        for layer in self.encoder.encoders:
+        xs: torch.Tensor
+        # forward contrastive layers get context vector for Contrastive Loss
+        for layer in self.encoder.encoders[:self.contrastive_blocks]:
             xs, masks, _, _ = layer(xs, xs_masks, pos_emb, mask_pad)
+        contrastive_vec = xs
+
+        for layer in self.encoder.encoders[self.contrastive_blocks:]:
+            xs, masks, _, _ = layer(xs, xs_masks, pos_emb, mask_pad)
+        masked_vec = xs
+
         if self.encoder.normalize_before:
             xs = self.encoder.after_norm(xs)
+            masked_vec = xs
         # Here we assume the mask is not changed in encoder layers, so just
         # return the masks before encoder layers, and the masks will be used
         # for cross attention with decoder later
-        return xs, masks
+        return contrastive_vec, masked_vec, masks

--- a/wenet/ssl/w2vbert/w2vbert_model.py
+++ b/wenet/ssl/w2vbert/w2vbert_model.py
@@ -51,7 +51,7 @@ class W2VBERTModel(torch.nn.Module):
             num_codebooks: numbers of codebooks i.e groups of codebook
             mask_prob: probs of mask
             mask_length: spans of masks
-            min_maks: min masks for each audio
+            min_masks: min masks for each audio
             num_negatives: numbers of negatives of each masks
             features_regularization_weight: l2 regularization weight
             max_gumbel_temperature: maximum temperature for gumbel softmax

--- a/wenet/ssl/wav2vec2/wav2vec2_model.py
+++ b/wenet/ssl/wav2vec2/wav2vec2_model.py
@@ -279,7 +279,7 @@ class Wav2vec2Model(torch.nn.Module):
             "code_ppl": codevector_perplexity.detach(),
             "features_l2": features_pen,
             "loss": loss,
-            "losss_constrastive": loss_contrastive / sample_size,
+            "loss_contrastive": loss_contrastive / sample_size,
             "loss_diversity": loss_diversity,
         }
 


### PR DESCRIPTION
ref: https://arxiv.org/pdf/2108.06209v2.pdf
note: bestrq >= w2vbert >= hubert >= wav2vec2 from some public information，

btw：  HuBERT, which relies on an iterative re-clustering and re-training process， so no plan to implement hubert for now

<img width="1292" alt="Screenshot 2023-10-09 at 17 07 53" src="https://github.com/wenet-e2e/wenet/assets/4906435/35874b45-fedc-45e6-8bc5-790a4fb23409">
