### PR TITLE
[cli] missing 'requests' and 'numpy'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 from setuptools import setup, find_packages
 
 requirements = [
+    "requests",
+    "requests",
     "tqdm",
     "torch>=1.13.0",
     "torchaudio>=0.13.0"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 requirements = [
-    "requests",
+    "numpy",
     "requests",
     "tqdm",
     "torch>=1.13.0",


### PR DESCRIPTION
'numpy'  in ctc_utils.py
'requests' in  hub

<img width="709" alt="Screenshot 2023-11-06 at 19 07 51" src="https://github.com/wenet-e2e/wenet/assets/4906435/cdaacec4-cbdb-49c6-8c3b-56f5bafdd709">

<img width="720" alt="Screenshot 2023-11-06 at 19 07 41" src="https://github.com/wenet-e2e/wenet/assets/4906435/f981f90b-1925-4db7-8761-e52bcb37fc95">
