### PR TITLE
feat(train): make timeout of wenet_join configurable

### DIFF
--- a/wenet/bin/train.py
+++ b/wenet/bin/train.py
@@ -126,7 +126,7 @@ def main():
 
         # NOTE(xcsong): Why we need a new group? see `train_utils.py::wenet_join`
         group_join = dist.new_group(backend="gloo",
-                                    timeout=datetime.timedelta(seconds=30))
+                                    timeout=datetime.timedelta(seconds=args.timeout))
 
         dist.barrier()  # NOTE(xcsong): Ensure all ranks start Train at the same time.
         executor.train(model, optimizer, scheduler, train_data_loader,

--- a/wenet/utils/train_utils.py
+++ b/wenet/utils/train_utils.py
@@ -131,6 +131,9 @@ def add_ddp_args(parser):
 
 
 def add_deepspeed_args(parser):
+    parser.add_argument('--timeout', default=30, type=int,
+                        help='timeout (in seconds) of wenet_join. ' +
+                             '30s for aishell & 300s for wenetspeech')
     parser.add_argument('--local_rank', type=int, default=-1,
                         help='local rank passed from distributed launcher')
     parser.add_argument('--deepspeed.save_states',


### PR DESCRIPTION
在某些共享存储系统（jfs/hdfs）中，prefetch大数据集可能会花很多时间，此时30s timeout可能会造成模型还没处理完第一批次的数据就退出了epoch，所以大数据集相对来说要能设置更长的timeout