### PR TITLE
[wenet] export_jit.py

### DIFF
--- a/wenet/bin/export_jit.py
+++ b/wenet/bin/export_jit.py
@@ -46,6 +46,7 @@ def main():
     with open(args.config, 'r') as fin:
         configs = yaml.load(fin, Loader=yaml.FullLoader)
     model, configs = init_model(args, configs)
+    model.eval()
     print(model)
     # Export jit torch script model
 


### PR DESCRIPTION
missing eval

https://github.com/wenet-e2e/wenet/pull/2127 这里导出加了的话， cli model里边不用eval应该就可以了

https://github.com/wenet-e2e/wenet/blob/main/wenet/paraformer/export_jit.py#L59 paraformer导出用了这个 infer没有这个问题