### PR TITLE
[fix]fix the type error in make_shard_list.py when resample(#2125)

### DIFF
--- a/tools/make_shard_list.py
+++ b/tools/make_shard_list.py
@@ -55,7 +55,8 @@ def write_tar_file(data_list,
                 audio, sample_rate = sox.load(wav, normalize=False)
                 if sample_rate != resample:
                     audio = torchaudio.transforms.Resample(
-                        sample_rate, resample)(audio)
+                        sample_rate, resample)(audio.float())
+                    audio = audio.to(torch.int16)
                 read_time += (time.time() - ts)
                 # change format to wav
                 ts = time.time()


### PR DESCRIPTION
在tool/make_shard_list.py中
原始代码：
                if sample_rate != resample:
                    audio = torchaudio.transforms.Resample(
                        sample_rate, resample)(audio)

修改后代码：
                if sample_rate != resample:
                    audio = torchaudio.transforms.Resample(
                        sample_rate, resample)(audio.float())
                    audio = audio.to(torch.int16)
     