### PR TITLE
[wenet] support context biasing in bin/recognize.py

### DIFF
--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -268,7 +268,8 @@ def main():
                 num_decoding_left_chunks=args.num_decoding_left_chunks,
                 ctc_weight=args.ctc_weight,
                 simulate_streaming=args.simulate_streaming,
-                reverse_weight=args.reverse_weight)
+                reverse_weight=args.reverse_weight,
+                context_graph=context_graph)
             for i, key in enumerate(keys):
                 for mode, hyps in results.items():
                     content = [char_dict[w] for w in hyps[i].tokens]

--- a/wenet/transformer/asr_model.py
+++ b/wenet/transformer/asr_model.py
@@ -27,6 +27,7 @@ from wenet.transformer.search import (ctc_greedy_search,
                                       attention_rescoring, DecodeResult)
 from wenet.utils.common import (IGNORE_ID, add_sos_eos, th_accuracy,
                                 reverse_pad_list)
+from wenet.utils.context_graph import ContextGraph
 
 
 class ASRModel(torch.nn.Module):
@@ -192,6 +193,7 @@ class ASRModel(torch.nn.Module):
         ctc_weight: float = 0.0,
         simulate_streaming: bool = False,
         reverse_weight: float = 0.0,
+        context_graph: ContextGraph = None,
     ) -> Dict[str, List[DecodeResult]]:
         """ Decode input speech
 
@@ -234,7 +236,7 @@ class ASRModel(torch.nn.Module):
                 ctc_probs, encoder_lens)
         if 'ctc_prefix_beam_search' in methods:
             ctc_prefix_result = ctc_prefix_beam_search(ctc_probs, encoder_lens,
-                                                       beam_size)
+                                                       beam_size, context_graph)
             results['ctc_prefix_beam_search'] = ctc_prefix_result
         if 'attention_rescoring' in methods:
             # attention_rescoring depends on ctc_prefix_beam_search nbest
@@ -242,7 +244,7 @@ class ASRModel(torch.nn.Module):
                 ctc_prefix_result = results['ctc_prefix_beam_search']
             else:
                 ctc_prefix_result = ctc_prefix_beam_search(
-                    ctc_probs, encoder_lens, beam_size)
+                    ctc_probs, encoder_lens, beam_size, context_graph)
             results['attention_rescoring'] = attention_rescoring(
                 self, ctc_prefix_result, encoder_out, encoder_lens, ctc_weight,
                 reverse_weight)


### PR DESCRIPTION
热词列表：
```
荣誉伟
北京
人名大会堂
```
```bash
# 不使用热词
python wenet/bin/recognize.py --modes "attention_rescoring" --config 20220506_u2pp_conformer_exp/train.yaml --data_type "raw" --test_data data.list --checkpoint 20220506_u2pp_conformer_exp/final.pt  --dict 20220506_u2pp_conformer_exp/units.txt --result_dir result
2023-11-12 22:28:37,392 INFO attention_rescoring 1000003_0f90da0d.wav 日本内阁官房长官荣誉为表示
# 使用热词
python wenet/bin/recognize.py --modes "attention_rescoring" --config 20220506_u2pp_conformer_exp/train.yaml --data_type "raw" --test_data data.list --checkpoint 20220506_u2pp_conformer_exp/final.pt  --dict 20220506_u2pp_conformer_exp/units.txt --result_dir result --context_graph_score 6.0 --context_list_path hotword.txt --context_bias_mode decoding-graph
2023-11-12 22:29:16,374 INFO attention_rescoring 1000003_0f90da0d.wav 日本内阁官房长官荣誉伟表示
```