### PR TITLE
fix(example): correct symble table

### DIFF
--- a/examples/aishell/s0/run.sh
+++ b/examples/aishell/s0/run.sh
@@ -156,7 +156,7 @@ if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
       --train_engine ${train_engine} \
       --config $train_config \
       --data_type  $data_type \
-      --symbol_table  data/dict/lang_char.txt \
+      --symbol_table  ${dict} \
       --train_data data/$train_set/data.list \
       --cv_data data/dev/data.list \
       ${checkpoint:+--checkpoint $checkpoint} \


### PR DESCRIPTION
`run.sh` 中开头有dict=xxxxx, 如果这里没换成 `${dict}` ,则开头的设置实际上不会起作用