### PR TITLE
fix bug

### DIFF
--- a/wenet/utils/train_utils.py
+++ b/wenet/utils/train_utils.py
@@ -587,7 +587,7 @@ def log_per_step(writer, info_dict):
 
     if (batch_idx + 1) % log_interval == 0:
         log_str = '{} Batch {}/{} loss {:.6f} '.format(
-            tag, epoch, batch_idx + 1, loss_dict['loss'].item())
+            tag, epoch, batch_idx + 1, loss_dict['loss'].item() * accum_grad)
         for name, value in loss_dict.items():
             if name != 'loss' and value is not None:
                 log_str += '{} {:.6f} '.format(name, value.item())


### PR DESCRIPTION
When printing the train loss without multiplying it by accum_grad, it results in the printed output of loss, loss_att, and loss_ctc being in different orders of magnitude.