### PR TITLE
[whisper] fix convert_to_wenet_units

### DIFF
--- a/wenet/whisper/convert_whisper_to_wenet_config_and_ckpt.py
+++ b/wenet/whisper/convert_whisper_to_wenet_config_and_ckpt.py
@@ -211,7 +211,7 @@ def convert_to_wenet_units(tokenizer, units_txt_path):
     n_vocab = tokenizer.encoding.n_vocab
     with open(units_txt_path, "+w") as f:
         for i in range(n_vocab):
-            unit = str(tokenizer.encoding.decode_single_token_bytes((i))
+            unit = str(tokenizer.encoding.decode_single_token_bytes(i)
             if len(unit) == 0:
                 unit = str(i)
                 print("can not decode id {}, convert to str({})".format(i, i))

--- a/wenet/whisper/convert_whisper_to_wenet_config_and_ckpt.py
+++ b/wenet/whisper/convert_whisper_to_wenet_config_and_ckpt.py
@@ -211,7 +211,7 @@ def convert_to_wenet_units(tokenizer, units_txt_path):
     n_vocab = tokenizer.encoding.n_vocab
     with open(units_txt_path, "+w") as f:
         for i in range(n_vocab):
-            unit = str(tokenizer.encoding.decode_single_token_bytes(i)
+            unit = str(tokenizer.encoding.decode_single_token_bytes(i))
             if len(unit) == 0:
                 unit = str(i)
                 print("can not decode id {}, convert to str({})".format(i, i))

--- a/wenet/whisper/convert_whisper_to_wenet_config_and_ckpt.py
+++ b/wenet/whisper/convert_whisper_to_wenet_config_and_ckpt.py
@@ -216,8 +216,7 @@ def convert_to_wenet_units(tokenizer, units_txt_path):
                 unit = str(i)
                 print("can not decode id {}, convert to str({})".format(i, i))
             unit = unit.replace(" ", "<space>")
-            unit = bytes(unit, 'utf-8')
-            f.write("{} {}\n".format(str(unit), i))
+            f.write("{} {}\n".format(unit, i))
             f.flush()
 
 

--- a/wenet/whisper/convert_whisper_to_wenet_config_and_ckpt.py
+++ b/wenet/whisper/convert_whisper_to_wenet_config_and_ckpt.py
@@ -211,7 +211,7 @@ def convert_to_wenet_units(tokenizer, units_txt_path):
     n_vocab = tokenizer.encoding.n_vocab
     with open(units_txt_path, "+w") as f:
         for i in range(n_vocab):
-            unit = tokenizer.encoding.decode([i])
+            unit = str(tokenizer.encoding.decode_single_token_bytes((i))
             if len(unit) == 0:
                 unit = str(i)
                 print("can not decode id {}, convert to str({})".format(i, i))


### PR DESCRIPTION
使用decode的时 units.txt 会存在相同的前缀
<img width="610" alt="Screenshot 2023-11-25 at 20 16 52" src="https://github.com/wenet-e2e/wenet/assets/4906435/46eea89a-9225-4567-9d38-0b8439e377ab">

使用decode_single_token_bytes， 然后再转成字符串
<img width="661" alt="Screenshot 2023-11-25 at 20 20 14" src="https://github.com/wenet-e2e/wenet/assets/4906435/d0f2dafb-a970-4928-ae81-df7f4c5d0574">
<img width="388" alt="Screenshot 2023-11-25 at 20 20 35" src="https://github.com/wenet-e2e/wenet/assets/4906435/61f2c245-fc44-46d5-ae3e-9eecf320b2e7">
