### PR TITLE
fix(train): Fix step & destroy group

### DIFF
--- a/wenet/bin/train.py
+++ b/wenet/bin/train.py
@@ -130,6 +130,7 @@ def main():
                                     timeout=datetime.timedelta(seconds=args.timeout))
         executor.train(model, optimizer, scheduler, train_data_loader,
                        writer, configs, scaler, group_join)
+        dist.destroy_process_group(group_join)
 
         dist.barrier()  # NOTE(xcsong): Ensure all ranks start CV at the same time.
         total_loss, num_seen_utts = executor.cv(model, cv_data_loader, configs)

--- a/wenet/utils/executor.py
+++ b/wenet/utils/executor.py
@@ -78,7 +78,7 @@ class Executor:
                     scaler, info_dict
                 )
                 log_per_step(writer, info_dict)
-                self.step += 1 if (batch_idx + 1) % accum_grad == 0 else 0
+                self.step += 1 if (batch_idx + 1) % info_dict["accum_grad"] == 0 else 0
 
     def cv(self, model, data_loader, configs):
         ''' Cross validation on

--- a/wenet/utils/executor.py
+++ b/wenet/utils/executor.py
@@ -78,7 +78,7 @@ class Executor:
                     scaler, info_dict
                 )
                 log_per_step(writer, info_dict)
-                self.step += 1
+                self.step += 1 if (batch_idx + 1) % accum_grad == 0 else 0
 
     def cv(self, model, data_loader, configs):
         ''' Cross validation on

--- a/wenet/utils/train_utils.py
+++ b/wenet/utils/train_utils.py
@@ -374,7 +374,7 @@ def init_optimizer_and_scheduler(args, configs, model):
             args=args, model=model, optimizer=optimizer,
             lr_scheduler=scheduler, model_parameters=model.parameters())
 
-    step = configs["init_infos"].get("step", 0)
+    step = configs["init_infos"].get("step", -1)
     scheduler.set_step(step)
     return model, optimizer, scheduler
 
@@ -599,7 +599,9 @@ def log_per_step(writer, info_dict):
 
     if (batch_idx + 1) % log_interval == 0:
         log_str = '{} Batch {}/{} loss {:.6f} '.format(
-            tag, epoch, batch_idx + 1, loss_dict['loss'].item() * accum_grad)
+            tag, epoch, batch_idx + 1,
+            loss_dict['loss'].item() * accum_grad if tag == "TRAIN"
+            else loss_dict['loss'].item())
         for name, value in loss_dict.items():
             if name != 'loss' and value is not None:
                 log_str += '{} {:.6f} '.format(name, value.item())

--- a/wenet/utils/train_utils.py
+++ b/wenet/utils/train_utils.py
@@ -599,9 +599,7 @@ def log_per_step(writer, info_dict):
 
     if (batch_idx + 1) % log_interval == 0:
         log_str = '{} Batch {}/{} loss {:.6f} '.format(
-            tag, epoch, batch_idx + 1,
-            loss_dict['loss'].item() * accum_grad if tag == "TRAIN"
-            else loss_dict['loss'].item())
+            tag, epoch, batch_idx + 1, loss_dict['loss'].item() * accum_grad)
         for name, value in loss_dict.items():
             if name != 'loss' and value is not None:
                 log_str += '{} {:.6f} '.format(name, value.item())


### PR DESCRIPTION
1. wenet 2.2.1 中 configs['step']从-1开始而不是0开始 https://github.com/wenet-e2e/wenet/blob/v2.2.1/wenet/bin/train.py#L223 
2. wenet 2.2.1 中 self.step只有在accum_grad处才+1 https://github.com/wenet-e2e/wenet/blob/v2.2.1/wenet/utils/executor.py#L109  (上述不同应该不影响训练结果（或者说影响不大）。configs['step'] 对学习率影响只有一步之差。 self.step纯用来打印log，不影响训练流程)
3. `dist.barrier()` 移动到 `new_group` 之前，强制同步，减少超时出现的频率
4. 增加 `destroy_process_group`，对已经完成使命的`group_join`进行析构，避免 超过 `ulimit -u` 中限制的 `max user processes` https://github.com/google/jax/issues/2685

```sh
Root Cause (first observed failure):
[0]:
  time      : 2023-11-28_05:28:31
  host      : hobot-job-10017872-task-1.hobot-job-10017872.project-2080ti-speech-smalltask.svc.cluster.local.
  rank      : 0 (local_rank: 0)
  exitcode  : 1 (pid: 1554)
  error_file: /tmp/torchelastic_qjva9q5p/2023_fzr5792e/attempt_0/0/error.json
  traceback : Traceback (most recent call last):
    File "/usr/local/lib/python3.8/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 346, in wrapper
      return f(*args, **kwargs)
    File "wenet/bin/train.py", line 129, in main
      group_join = dist.new_group(backend="gloo",
    File "/usr/local/lib/python3.8/site-packages/torch/distributed/distributed_c10d.py", line 3335, in new_group
      pg = _new_process_group_helper(
    File "/usr/local/lib/python3.8/site-packages/torch/distributed/distributed_c10d.py", line 862, in _new_process_group_helper
      pg = ProcessGroupGloo(prefix_store, group_rank, group_size, timeout=timeout)
  RuntimeError: Resource temporarily unavailable
```