### PR TITLE
fix(decode): conformer without r_decoder

### DIFF
--- a/wenet/transformer/search.py
+++ b/wenet/transformer/search.py
@@ -376,7 +376,7 @@ def attention_rescoring(
                 tc.append(math.exp(s))
             score += decoder_out[i][len(hyp)][eos]
             # add right to left decoder score
-            if reverse_weight > 0:
+            if reverse_weight > 0 and r_decoder_out.dim() > 0:
                 r_score = 0.0
                 for j, w in enumerate(hyp):
                     s = r_decoder_out[i][len(hyp) - j - 1][w]


### PR DESCRIPTION
fix https://github.com/wenet-e2e/wenet/issues/2181

conformer 没有 r_decoder, 默认的 run,sh reverse_weight > 0, 所以触发2181的bug