### PR TITLE
Update whisper.py

### DIFF
--- a/wenet/whisper/whisper.py
+++ b/wenet/whisper/whisper.py
@@ -51,10 +51,6 @@ class Whisper(ASRModel):
         raise NotImplementedError
 
     @property
-    def device(self):
-        return next(self.parameters()).device
-
-    @property
     def is_multilingual(self):
         return self.vocab_size >= 51865
 


### PR DESCRIPTION
When exporting the Whisper model using wenet/bin/export_jit.py, I encountered TorchScript-related issues. Deleting the device function in whisper.py resolves the problem.