### PR TITLE
[examples] fix bug for bpe decoding

### DIFF
--- a/examples/librispeech/s0/run.sh
+++ b/examples/librispeech/s0/run.sh
@@ -199,7 +199,7 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
       --test_data $wave_data/$test/data.list \
       --checkpoint $decode_checkpoint \
       --beam_size 10 \
-      --batch_size 1 \
+      --batch_size 16 \
       --penalty 0.0 \
       --result_dir $result_dir \
       --ctc_weight $ctc_weight \
@@ -207,13 +207,6 @@ if [ ${stage} -le 5 ] && [ ${stop_stage} -ge 5 ]; then
 
     for mode in $decode_modes; do
       test_dir=$result_dir/$mode
-      mkdir -p $test_dir
-      cp $test_dir/text $test_dir/text_bpe
-      cut -f2- -d " " $test_dir/text_bpe > $test_dir/text_bpe_value_tmp
-      cut -f1 -d " " $test_dir/text_bpe > $test_dir/text_bpe_key_tmp
-      tools/spm_decode --model=${bpemodel}.model --input_format=piece \
-        < $test_dir/text_bpe_value_tmp | sed -e "s/▁/ /g" > $test_dir/text_value_tmp
-      paste -d " " $test_dir/text_bpe_key_tmp $test_dir/text_value_tmp > $test_dir/text
       python tools/compute-wer.py --char=1 --v=1 \
         $wave_data/$test/text $test_dir/text > $test_dir/wer
     done


### PR DESCRIPTION

![image](https://github.com/wenet-e2e/wenet/assets/13466943/7cc1550b-0422-4029-94ac-2cb9b903846d)


替换下划线的操作 在新的 `bpe_tokenizer.py` 中实现了，https://github.com/wenet-e2e/wenet/blob/main/wenet/text/bpe_tokenizer.py#L51  ， 所以这里run.sh 不需要这个后处理，否则最终结果所有单词全都连到一块了