### PR TITLE
[train] fix bug of timeout and step

### DIFF
--- a/wenet/bin/train.py
+++ b/wenet/bin/train.py
@@ -113,8 +113,9 @@ def main():
                })
 
     # Get executor
+    tag = configs["init_infos"].get("tag", "init")
     executor = Executor()
-    executor.step = configs["init_infos"].get('step', -1)
+    executor.step = configs["init_infos"].get('step', -1) + int("step_" in tag)
 
     # Init scaler, used for pytorch amp mixed precision training
     scaler = None
@@ -122,8 +123,7 @@ def main():
         scaler = torch.cuda.amp.GradScaler()
 
     # Start training loop
-    tag = configs["init_infos"].get("tag", "init")
-    start_epoch = configs["init_infos"].get('epoch', -1) + int("epoch_" in tag)
+    start_epoch = configs["init_infos"].get('epoch', 0) + int("epoch_" in tag)
     configs.pop("init_infos", None)
     final_epoch = None
     for epoch in range(start_epoch, configs.get('max_epoch', 100)):

--- a/wenet/utils/train_utils.py
+++ b/wenet/utils/train_utils.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import copy
-import datetime
 import deepspeed
 import json
 import logging
@@ -426,8 +425,7 @@ def wenet_join(group_join, info_dict):
         #   operations are executed. If we add a communication operation that is not
         #   managed by Deepspeed in this group, it's highly likely to cause
         #   communication chaos, resulting in hard-to-troubleshoot hangs.
-        dist.monitored_barrier(group=group_join,
-                               timeout=datetime.timedelta(seconds=30))
+        dist.monitored_barrier(group=group_join)
     except RuntimeError as e:
         logging.info("Detected uneven workload distribution: {}\n".format(e) +
                      "Break current worker to manually join all workers, " +


### PR DESCRIPTION
1. finetune load previous ckpt时，如果检查点是step_xxx则step+1，如果检查点是epoch_xxx则epcoh + 1

![image](https://github.com/wenet-e2e/wenet/assets/13466943/631b0899-0419-41bc-9e72-32515fb65170)

2. `wenet/bin/train.py` 中 已经对 group 设定了timeout，这里无需再设

![image](https://github.com/wenet-e2e/wenet/assets/13466943/b45c9305-7743-48a5-987c-c7bc58ef02e8)
