### PR TITLE
[paraformer] support chunk mask

### DIFF
--- a/test/wenet/paraformer/test_paraformer.py
+++ b/test/wenet/paraformer/test_paraformer.py
@@ -1,0 +1,54 @@
+import torch
+
+from wenet.transformer.embedding import ParaformerPositinoalEncoding
+
+
+class SinusoidalPositionEncoder(torch.nn.Module):
+    """https://github.com/alibaba-damo-academy/FunASR/blob/main/funasr/modules/embedding.py#L387
+    """
+
+    def __int__(self):
+        pass
+
+    def encode(self,
+               positions: torch.Tensor,
+               depth: int,
+               dtype: torch.dtype = torch.float32) -> torch.Tensor:
+        batch_size = positions.size(0)
+        positions = positions.type(dtype)
+        device = positions.device
+        log_timescale_increment = torch.log(
+            torch.tensor([10000], dtype=dtype,
+                         device=device)) / (depth / 2 - 1)
+        inv_timescales = torch.exp(
+            torch.arange(depth / 2, device=device).type(dtype) *
+            (-log_timescale_increment))
+        inv_timescales = torch.reshape(inv_timescales, [batch_size, -1])
+        scaled_time = torch.reshape(positions, [1, -1, 1]) * torch.reshape(
+            inv_timescales, [1, 1, -1])
+        encoding = torch.cat([torch.sin(scaled_time),
+                              torch.cos(scaled_time)],
+                             dim=2)
+        return encoding.to(dtype)
+
+    def forward(self, x):
+        _, timesteps, input_dim = x.size()
+        positions = torch.arange(1, timesteps + 1, device=x.device)[None, :]
+        position_encoding = self.encode(positions, input_dim,
+                                        x.dtype).to(x.device)
+        return x + position_encoding
+
+
+def test_pe():
+    torch.manual_seed(777)
+    Paraformer_pe = SinusoidalPositionEncoder()
+    Wenet_paraformer_pe = ParaformerPositinoalEncoding(d_model=560,
+                                                       dropout_rate=0.0,
+                                                       max_len=5000)
+    Paraformer_pe.eval()
+    Wenet_paraformer_pe.eval()
+
+    input = torch.rand(1, 70, 560)
+    paraformer_pe_out = Paraformer_pe(input)
+    wenet_paraformer_pe_out, _ = Wenet_paraformer_pe(input, offset=1)
+    assert torch.allclose(paraformer_pe_out, wenet_paraformer_pe_out)

--- a/test/wenet/paraformer/test_paraformer.py
+++ b/test/wenet/paraformer/test_paraformer.py
@@ -1,6 +1,6 @@
 import torch
 
-from wenet.transformer.embedding import ParaformerPositinoalEncoding
+from wenet.paraformer.embedding import ParaformerPositinoalEncoding
 
 
 class SinusoidalPositionEncoder(torch.nn.Module):
@@ -36,19 +36,24 @@ class SinusoidalPositionEncoder(torch.nn.Module):
         positions = torch.arange(1, timesteps + 1, device=x.device)[None, :]
         position_encoding = self.encode(positions, input_dim,
                                         x.dtype).to(x.device)
-        return x + position_encoding
+        return x + position_encoding, position_encoding
 
 
 def test_pe():
     torch.manual_seed(777)
     Paraformer_pe = SinusoidalPositionEncoder()
-    Wenet_paraformer_pe = ParaformerPositinoalEncoding(d_model=560,
+    d_model = 512
+    depth = 560
+    Wenet_paraformer_pe = ParaformerPositinoalEncoding(d_model=d_model,
+                                                       depth=560,
                                                        dropout_rate=0.0,
                                                        max_len=5000)
     Paraformer_pe.eval()
     Wenet_paraformer_pe.eval()
 
-    input = torch.rand(1, 70, 560)
-    paraformer_pe_out = Paraformer_pe(input)
-    wenet_paraformer_pe_out, _ = Wenet_paraformer_pe(input, offset=1)
+    input = torch.rand(1, 70, depth)
+    paraformer_x_out, paraformer_pe_out = Paraformer_pe(input * d_model**0.5)
+    wenet_paraformer_x_out, wenet_paraformer_pe_out = Wenet_paraformer_pe(
+        input, offset=1)
     assert torch.allclose(paraformer_pe_out, wenet_paraformer_pe_out)
+    assert torch.allclose(paraformer_x_out, wenet_paraformer_x_out)

--- a/wenet/paraformer/convert_paraformer_to_wenet_config_and_ckpt.py
+++ b/wenet/paraformer/convert_paraformer_to_wenet_config_and_ckpt.py
@@ -100,7 +100,7 @@ def convert_to_wenet_yaml(configs, wenet_yaml_path: str,
                           fields_to_keep: List[str]) -> Dict:
     configs = _filter_dict_fields(configs, fields_to_keep)
     configs['encoder'] = 'sanm_encoder'
-    configs['encoder_conf']['input_layer'] = 'conv2d'
+    configs['encoder_conf']['input_layer'] = 'paraformer_dummy'
     configs['decoder'] = 'sanm_decoder'
     configs['lfr_conf'] = {'lfr_m': 7, 'lfr_n': 6}
 
@@ -113,6 +113,7 @@ def convert_to_wenet_yaml(configs, wenet_yaml_path: str,
     # This type not use
     del configs['encoder_conf']['selfattention_layer_type'], configs[
         'encoder_conf']['pos_enc_class']
+    configs['encoder_conf']['pos_enc_layer_type'] = 'abs_pos_paraformer'
 
     configs['ctc_conf'] = {}
     configs['ctc_conf']['ctc_blank_id'] = 0

--- a/wenet/paraformer/convert_paraformer_to_wenet_config_and_ckpt.py
+++ b/wenet/paraformer/convert_paraformer_to_wenet_config_and_ckpt.py
@@ -156,6 +156,8 @@ def convert_to_wenet_yaml(configs, wenet_yaml_path: str,
     configs['max_epoch'] = 100
     configs['log_interval'] = 100
 
+    configs['model_conf']['length_normalized_loss'] = False
+
     with open(wenet_yaml_path, '+w') as f:
         f.write(yaml.dump(configs))
         f.flush()

--- a/wenet/paraformer/embedding.py
+++ b/wenet/paraformer/embedding.py
@@ -1,0 +1,14 @@
+from wenet.transformer.embedding import WhisperPositionalEncoding
+
+
+class ParaformerPositinoalEncoding(WhisperPositionalEncoding):
+    """ Sinusoids position encoding used in paraformer.encoder
+    """
+
+    def __init__(self,
+                 depth: int,
+                 d_model: int,
+                 dropout_rate: float = 0.1,
+                 max_len: int = 1500):
+        super().__init__(depth, dropout_rate, max_len)
+        self.xscale = d_model**0.5

--- a/wenet/paraformer/layers.py
+++ b/wenet/paraformer/layers.py
@@ -7,6 +7,8 @@ import torch
 from wenet.paraformer.attention import (DummyMultiHeadSANM,
                                         MultiHeadAttentionCross,
                                         MultiHeadedAttentionSANM)
+from wenet.paraformer.embedding import ParaformerPositinoalEncoding
+from wenet.paraformer.subsampling import IdentitySubsampling
 from wenet.transformer.encoder import BaseEncoder
 from wenet.transformer.decoder import TransformerDecoder
 from wenet.transformer.decoder_layer import DecoderLayer
@@ -117,43 +119,6 @@ class PositionwiseFeedForwardDecoderSANM(torch.nn.Module):
         return self.w_2(self.norm(self.dropout(self.activation(self.w_1(x)))))
 
 
-class SinusoidalPositionEncoder(torch.nn.Module):
-    """https://github.com/alibaba-damo-academy/FunASR/blob/main/funasr/modules/embedding.py#L387
-    """
-
-    def __int__(self):
-        pass
-
-    def encode(self,
-               positions: torch.Tensor,
-               depth: int,
-               dtype: torch.dtype = torch.float32) -> torch.Tensor:
-        batch_size = positions.size(0)
-        positions = positions.type(dtype)
-        device = positions.device
-        log_timescale_increment = torch.log(
-            torch.tensor([10000], dtype=dtype,
-                         device=device)) / (depth / 2 - 1)
-        inv_timescales = torch.exp(
-            torch.arange(depth / 2, device=device).type(dtype) *
-            (-log_timescale_increment))
-        inv_timescales = torch.reshape(inv_timescales, [batch_size, -1])
-        scaled_time = torch.reshape(positions, [1, -1, 1]) * torch.reshape(
-            inv_timescales, [1, 1, -1])
-        encoding = torch.cat([torch.sin(scaled_time),
-                              torch.cos(scaled_time)],
-                             dim=2)
-        return encoding.to(dtype)
-
-    def forward(self, x):
-        _, timesteps, input_dim = x.size()
-        positions = torch.arange(1, timesteps + 1, device=x.device)[None, :]
-        position_encoding = self.encode(positions, input_dim,
-                                        x.dtype).to(x.device)
-
-        return x + position_encoding
-
-
 class AliParaformerEncoderLayer(TransformerEncoderLayer):
 
     def __init__(self,
@@ -184,7 +149,14 @@ class AliParaformerEncoderLayer(TransformerEncoderLayer):
         residual = x
         if self.normalize_before:
             x = self.norm1(x)
-        x_att, new_att_cache = self.self_attn(x, x, x, mask, cache=att_cache)
+        x_att, new_att_cache = self.self_attn(
+            x,
+            x,
+            x,
+            mask,
+            cache=att_cache,
+            mask_pad=mask_pad,
+        )
         if self.in_size == self.size:
             x = residual + self.dropout(x_att)
         else:
@@ -206,24 +178,26 @@ class AliParaformerEncoderLayer(TransformerEncoderLayer):
 
 class SanmEncoder(BaseEncoder):
 
-    def __init__(self,
-                 input_size: int,
-                 output_size: int = 256,
-                 attention_heads: int = 4,
-                 linear_units: int = 2048,
-                 num_blocks: int = 6,
-                 dropout_rate: float = 0.1,
-                 positional_dropout_rate: float = 0.1,
-                 attention_dropout_rate: float = 0,
-                 input_layer: str = "conv2d",
-                 pos_enc_layer_type: str = "abs_pos",
-                 normalize_before: bool = True,
-                 static_chunk_size: int = 0,
-                 use_dynamic_chunk: bool = False,
-                 global_cmvn: torch.nn.Module = None,
-                 use_dynamic_left_chunk: bool = False,
-                 kernel_size: int = 11,
-                 sanm_shfit: int = 0):
+    def __init__(
+        self,
+        input_size: int,
+        output_size: int = 256,
+        attention_heads: int = 4,
+        linear_units: int = 2048,
+        num_blocks: int = 6,
+        dropout_rate: float = 0.1,
+        positional_dropout_rate: float = 0.1,
+        attention_dropout_rate: float = 0,
+        input_layer: str = "conv2d",
+        pos_enc_layer_type: str = "abs_pos",
+        normalize_before: bool = True,
+        static_chunk_size: int = 0,
+        use_dynamic_chunk: bool = False,
+        global_cmvn: torch.nn.Module = None,
+        use_dynamic_left_chunk: bool = False,
+        kernel_size: int = 11,
+        sanm_shfit: int = 0,
+    ):
         super().__init__(input_size, output_size, attention_heads,
                          linear_units, num_blocks, dropout_rate,
                          positional_dropout_rate, attention_dropout_rate,
@@ -231,7 +205,15 @@ class SanmEncoder(BaseEncoder):
                          static_chunk_size, use_dynamic_chunk, global_cmvn,
                          use_dynamic_left_chunk)
         del self.embed
-        self.embed = SinusoidalPositionEncoder()
+        self.embed = IdentitySubsampling(
+            input_size,
+            output_size,
+            dropout_rate,
+            ParaformerPositinoalEncoding(input_size,
+                                         output_size,
+                                         positional_dropout_rate,
+                                         max_len=5000),
+        )
 
         encoder_selfattn_layer = MultiHeadedAttentionSANM
         encoder_selfattn_layer_args0 = (
@@ -277,25 +259,29 @@ class SanmEncoder(BaseEncoder):
         if self.normalize_before:
             self.after_norm = torch.nn.LayerNorm(output_size)
 
-    def forward(
-        self,
-        xs: torch.Tensor,
-        xs_lens: torch.Tensor,
-        decoding_chunk_size: int = 0,
-        num_decoding_left_chunks: int = -1
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        if self.global_cmvn is not None:
-            xs = self.global_cmvn(xs)
-        masks_pad = make_non_pad_mask(xs_lens).unsqueeze(1)  # [B,1,T]
-        xs = xs * self.output_size()**0.5
-        xs = self.embed(xs)
+    def forward_layers(self, xs: torch.Tensor, chunk_masks: torch.Tensor,
+                       pos_emb: torch.Tensor,
+                       mask_pad: torch.Tensor) -> torch.Tensor:
         for layer in self.encoders0:
-            xs, _, _, _ = layer(xs, masks_pad, None)
+            xs, _, _, _ = layer(xs, chunk_masks, pos_emb, mask_pad)
         for layer in self.encoders:
-            xs, _, _, _ = layer(xs, masks_pad, None)
-        if self.normalize_before:
-            xs = self.after_norm(xs)
-        return xs, masks_pad
+            xs, _, _, _ = layer(xs, chunk_masks, pos_emb, mask_pad)
+        return xs
+
+    @torch.jit.ignore(drop=True)
+    def forward_layers_checkpointed(self, xs: torch.Tensor,
+                                    chunk_masks: torch.Tensor,
+                                    pos_emb: torch.Tensor,
+                                    mask_pad: torch.Tensor) -> torch.Tensor:
+        for layer in self.encoders0:
+            xs, _, _, _, _ = torch.utils.checkpoint(layer.__call__, xs,
+                                                    chunk_masks, mask_pad,
+                                                    pos_emb)
+        for layer in self.encoders:
+            xs, _, _, _, _ = torch.utils.checkpoint(layer.__call__, xs,
+                                                    chunk_masks, mask_pad,
+                                                    pos_emb)
+        return xs
 
 
 class _Decoders3(torch.nn.Module):
@@ -358,7 +344,11 @@ class SanmDecoderLayer(DecoderLayer):
             if self.normalize_before:
                 tgt = self.norm2(tgt)
             tgt_q = tgt
-            x = self.self_attn(tgt_q, tgt, tgt, tgt_q_mask)[0]
+            x = self.self_attn(tgt_q,
+                               tgt,
+                               tgt,
+                               tgt_q_mask,
+                               mask_pad=tgt_q_mask)[0]
             x = residual + self.dropout(x)
 
         if self.src_attn is not None:
@@ -367,7 +357,8 @@ class SanmDecoderLayer(DecoderLayer):
                 x = self.norm3(x)
 
             x = residual + self.dropout(
-                self.src_attn(x, memory, memory, memory_mask)[0])
+                self.src_attn(
+                    x, memory, memory, memory_mask, mask_pad=memory_mask)[0])
 
         return x, tgt_mask, memory, memory_mask
 
@@ -439,10 +430,8 @@ class SanmDecoder(TransformerDecoder):
         r_ys_in_pad: torch.Tensor = torch.empty(0),
         reverse_weight: float = 0.0,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """ only for inference now
-        """
-        ys_pad_mask = make_non_pad_mask(ys_pad_lens).unsqueeze(1)
 
+        ys_pad_mask = make_non_pad_mask(ys_pad_lens).unsqueeze(1)
         x = sematic_embeds
         for layer in self.decoders:
             x, _, _, _ = layer(x, ys_pad_mask, encoder_out, encoder_out_mask)

--- a/wenet/paraformer/paraformer.py
+++ b/wenet/paraformer/paraformer.py
@@ -99,7 +99,6 @@ class Predictor(torch.nn.Module):
         tp_alphas = tp_alphas.squeeze(-1)
         tp_token_num = tp_alphas.sum(-1)
 
-        # print(tp_alphas, tp_token_num)
         return acoustic_embeds, token_num, alphas, cif_peak, tp_alphas, tp_token_num
 
 
@@ -300,8 +299,8 @@ class Paraformer(torch.nn.Module):
         # cif predictor
         acoustic_embed, token_num, _, _, tp_alphas, _ = self.predictor(
             encoder_out, mask=encoder_out_mask)
-        # token_num = token_num.floor().to(speech_lengths.dtype)
-        token_num = token_num.round().to(speech_lengths.dtype)
+        token_num = token_num.floor().to(speech_lengths.dtype)
+        # token_num = token_num.round().to(speech_lengths.dtype)
 
         # decoder
         decoder_out, _, _ = self.decoder(encoder_out, encoder_out_mask,

--- a/wenet/paraformer/subsampling.py
+++ b/wenet/paraformer/subsampling.py
@@ -1,0 +1,48 @@
+from typing import Tuple, Union
+import torch
+from wenet.transformer.subsampling import BaseSubsampling
+
+
+class IdentitySubsampling(BaseSubsampling):
+    """ Paraformer subsampling
+    """
+
+    def __init__(self, idim: int, odim: int, dropout_rate: float,
+                 pos_enc_class: torch.nn.Module):
+        super().__init__()
+        _, _ = idim, odim
+        self.right_context = 6
+        self.subsampling_rate = 6
+        self.pos_enc = pos_enc_class
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        x_mask: torch.Tensor,
+        offset: Union[torch.Tensor, int] = 0
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Subsample x.
+
+        Args:
+            x (torch.Tensor): Input tensor (#batch, time, idim).
+            x_mask (torch.Tensor): Input mask (#batch, 1, time).
+
+        Returns:
+            torch.Tensor: Subsampled tensor (#batch, time', odim),
+                where time' = time.
+            torch.Tensor: Subsampled mask (#batch, 1, time'),
+                where time' = time
+            torch.Tensor: positional encoding
+
+        """
+        # NOTE(Mddct): Paraformer starts from 1
+        if isinstance(offset, torch.Tensor):
+            offset = torch.add(offset, 1)
+        else:
+            offset = offset + 1
+        x, pos_emb = self.pos_enc(x, offset)
+        return x, pos_emb, x_mask
+
+    def position_encoding(self, offset: Union[int, torch.Tensor],
+                          size: int) -> torch.Tensor:
+        return self.pos_enc.position_encoding(offset + 1, size)

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -89,6 +89,7 @@ class BaseEncoder(torch.nn.Module):
         self._output_size = output_size
 
         self.global_cmvn = global_cmvn
+        print(input_layer)
         self.embed = WENET_SUBSAMPLE_CLASSES[input_layer](
             input_size,
             output_size,

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -89,7 +89,6 @@ class BaseEncoder(torch.nn.Module):
         self._output_size = output_size
 
         self.global_cmvn = global_cmvn
-        print(input_layer)
         self.embed = WENET_SUBSAMPLE_CLASSES[input_layer](
             input_size,
             output_size,

--- a/wenet/utils/class_utils.py
+++ b/wenet/utils/class_utils.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright [2023-11-28] <sxc19@mails.tsinghua.edu.cn, Xingchen Song>
 import torch
+from wenet.paraformer.embedding import ParaformerPositinoalEncoding
 
 from wenet.transformer.swish import Swish
 from wenet.transformer.subsampling import (
@@ -47,6 +48,7 @@ WENET_SUBSAMPLE_CLASSES = {
     "dwconv2d4": DepthwiseConv2dSubsampling4,
     "conv2d6": Conv2dSubsampling6,
     "conv2d8": Conv2dSubsampling8,
+    'paraformer_dummy': torch.nn.Identity
 }
 
 WENET_EMB_CLASSES = {
@@ -56,6 +58,7 @@ WENET_EMB_CLASSES = {
     "no_pos": NoPositionalEncoding,
     "abs_pos_whisper": WhisperPositionalEncoding,
     "embed_learnable_pe": LearnablePositionalEncoding,
+    "abs_pos_paraformer": ParaformerPositinoalEncoding,
 }
 
 WENET_ATTENTION_CLASSES = {

--- a/wenet/utils/train_utils.py
+++ b/wenet/utils/train_utils.py
@@ -209,6 +209,8 @@ def check_modify_and_save_config(args, configs, symbol_table):
                 'num_mel_bins']
         else:
             input_dim = configs['dataset_conf']['mfcc_conf']['num_mel_bins']
+    else:
+        input_dim = configs['input_dim']
 
     configs, _ = get_blank_id(configs, symbol_table)
 

--- a/wenet/utils/train_utils.py
+++ b/wenet/utils/train_utils.py
@@ -201,13 +201,14 @@ def check_modify_and_save_config(args, configs, symbol_table):
         assert ds_configs["gradient_clipping"] == configs['grad_clip']
         assert ds_configs["steps_per_print"] == configs['log_interval']
 
-    if 'fbank_conf' in configs['dataset_conf']:
-        input_dim = configs['dataset_conf']['fbank_conf']['num_mel_bins']
-    elif 'log_mel_spectrogram_conf' in configs['dataset_conf']:
-        input_dim = configs['dataset_conf']['log_mel_spectrogram_conf'][
-            'num_mel_bins']
-    else:
-        input_dim = configs['dataset_conf']['mfcc_conf']['num_mel_bins']
+    if 'input_dim' not in configs:
+        if 'fbank_conf' in configs['dataset_conf']:
+            input_dim = configs['dataset_conf']['fbank_conf']['num_mel_bins']
+        elif 'log_mel_spectrogram_conf' in configs['dataset_conf']:
+            input_dim = configs['dataset_conf']['log_mel_spectrogram_conf'][
+                'num_mel_bins']
+        else:
+            input_dim = configs['dataset_conf']['mfcc_conf']['num_mel_bins']
 
     configs, _ = get_blank_id(configs, symbol_table)
 


### PR DESCRIPTION
重构encoder 支持wenet/transformer/encoder's dynamic chunk training



## QA 
0 为什么要支持paraformer mask training？

尝试使用pretrain的非流paraformer，fintune训练u2++ like的流式模型，看是否可以得到好的效果
- ctc for streaming
- cif + paraformer decoder for two-pass rescoring


1 为什么要有：IdentitySubsampling？ 

因为wenet顺序是： cmvn->subsampling->pos emb
paraformer 顺序是： lfr(subsampling) ->cmvn -> pos_emb
所以这里实现了个IdentitySubsampling， 什么也不做,只是调用了pos emb class，保持接口不变

2 paraformer fsm block中有padding， 可能对流式训练有影响（训练和推理chunk不一致）
TODO 
- [ ] @xingchensong 


example: 
ctc_weight: 0.3
use_dynamic_chunk: true

<img width="1667" alt="Screenshot 2024-01-08 at 17 03 27" src="https://github.com/wenet-e2e/wenet/assets/4906435/83b78887-e979-466c-b38b-d15c79a08e99">


## Next PR
- [ ] paraformer recipe
- [ ] paraformer chunk(先不管上述padding) recipe


