### PR TITLE
[loss] set zero_infinity=True to ignore NaN or inf ctc_loss

### DIFF
--- a/wenet/transformer/ctc.py
+++ b/wenet/transformer/ctc.py
@@ -45,7 +45,8 @@ class CTC(torch.nn.Module):
 
         reduction_type = "sum" if reduce else "none"
         self.ctc_loss = torch.nn.CTCLoss(blank=blank_id,
-                                         reduction=reduction_type)
+                                         reduction=reduction_type,
+                                         zero_infinity=True)
 
     def forward(self, hs_pad: torch.Tensor, hlens: torch.Tensor,
                 ys_pad: torch.Tensor,


### PR DESCRIPTION
- https://pytorch.org/docs/stable/generated/torch.nn.CTCLoss.html
- zero_infinity (bool, optional) – Whether to zero infinite losses and the associated gradients. Default: False Infinite losses mainly occur when the inputs are too short to be aligned to the targets.

Setting `zero_infinity=True` can help us save a lot of time in data cleaning, as unclean data can be invalidated in the loss calculation through this flag.