### PR TITLE
[whisper] support arbitrary language and task

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ deepspeed<0.13.0
 librosa
 openai-whisper
 pre-commit==3.5.0
+langid

--- a/test/wenet/dataset/test_datapipes.py
+++ b/test/wenet/dataset/test_datapipes.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 from torch.utils.data import datapipes
 from torch.utils.data.datapipes.iter import IterableWrapper
+from functools import partial
 
 from wenet.dataset.datapipes import (SortDataPipe, WenetRawDatasetSource,
                                      WenetTarShardDatasetSource)
@@ -99,7 +100,7 @@ def test_dynamic_batch_datapipe(data_list):
     dataset = dataset.map(decode_wav)
     dataset = dataset.map(compute_fbank)
     dataset = dataset.map(fake_labels)
-    dataset = dataset.map(detect_language)
+    dataset = dataset.map(partial(detect_language, limited_langs=['zh', 'en']))
     dataset = dataset.map(detect_task)
     max_frames_in_batch = 10000
     dataset = dataset.dynamic_batch(

--- a/test/wenet/dataset/test_datapipes.py
+++ b/test/wenet/dataset/test_datapipes.py
@@ -6,7 +6,8 @@ from torch.utils.data.datapipes.iter import IterableWrapper
 from wenet.dataset.datapipes import (SortDataPipe, WenetRawDatasetSource,
                                      WenetTarShardDatasetSource)
 from wenet.dataset.processor import (DynamicBatchWindow, decode_wav, padding,
-                                     parse_json, compute_fbank)
+                                     parse_json, compute_fbank,
+                                     detect_language, detect_task)
 
 
 @pytest.mark.parametrize("data_list", [
@@ -98,6 +99,8 @@ def test_dynamic_batch_datapipe(data_list):
     dataset = dataset.map(decode_wav)
     dataset = dataset.map(compute_fbank)
     dataset = dataset.map(fake_labels)
+    dataset = dataset.map(detect_language)
+    dataset = dataset.map(detect_task)
     max_frames_in_batch = 10000
     dataset = dataset.dynamic_batch(
         window_class=DynamicBatchWindow(max_frames_in_batch),

--- a/test/wenet/whisper/test_whisper.py
+++ b/test/wenet/whisper/test_whisper.py
@@ -362,9 +362,9 @@ def test_model(model, audio_path):
             configs['tokenizer_conf']['special_tokens'],
             torch.tensor([dummy_tokens], dtype=torch.long),
             ignore_id=-1,
-            task=task,
+            tasks=[task],
             no_timestamp=True,
-            language=language,
+            langs=[language],
             use_prev=False)
         L = wenet_tokens.size(1)
         tgt_mask = ~make_pad_mask(torch.tensor([L], dtype=torch.long),

--- a/test/wenet/whisper/test_whisper.py
+++ b/test/wenet/whisper/test_whisper.py
@@ -94,8 +94,6 @@ def test_sinusoids(length, channels):
 @pytest.mark.parametrize("model,audio_path", [
     ("tiny", "test/resources/aishell-BAC009S0724W0121.wav"),
     ("base", "test/resources/librispeech-1995-1837-0001.wav"),
-    ("small", "test/resources/aishell-BAC009S0724W0121.wav"),
-    ("medium", "test/resources/librispeech-1995-1837-0001.wav"),
 ])
 def test_model(model, audio_path):
     default = os.path.join(os.path.expanduser("~"), ".cache")

--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -244,6 +244,7 @@ def main():
             target = batch["target"].to(device)
             feats_lengths = batch["feats_lengths"].to(device)
             target_lengths = batch["target_lengths"].to(device)
+            infos = {"tasks": batch["tasks"], "langs": batch["langs"]}
             results = model.decode(
                 args.modes,
                 feats,
@@ -257,7 +258,8 @@ def main():
                 context_graph=context_graph,
                 blank_id=blank_id,
                 blank_penalty=args.blank_penalty,
-                length_penalty=args.length_penalty)
+                length_penalty=args.length_penalty,
+                infos=infos)
             for i, key in enumerate(keys):
                 for mode, hyps in results.items():
                     tokens = hyps[i].tokens

--- a/wenet/dataset/dataset.py
+++ b/wenet/dataset/dataset.py
@@ -94,7 +94,8 @@ def Dataset(data_type,
         spec_trim_conf = conf.get('spec_trim_conf', {})
         dataset = dataset.map(partial(processor.spec_trim, **spec_trim_conf))
 
-    dataset = dataset.map(processor.detect_language)
+    language_conf = conf.get('language_conf', {"limited_langs": ['zh', 'en']})
+    dataset = dataset.map(partial(processor.detect_language, **language_conf))
     dataset = dataset.map(processor.detect_task)
 
     shuffle = conf.get('shuffle', True)

--- a/wenet/dataset/dataset.py
+++ b/wenet/dataset/dataset.py
@@ -94,6 +94,9 @@ def Dataset(data_type,
         spec_trim_conf = conf.get('spec_trim_conf', {})
         dataset = dataset.map(partial(processor.spec_trim, **spec_trim_conf))
 
+    dataset = dataset.map(processor.detect_language)
+    dataset = dataset.map(processor.detect_task)
+
     shuffle = conf.get('shuffle', True)
     if shuffle:
         shuffle_conf = conf.get('shuffle_conf', {})

--- a/wenet/dataset/processor.py
+++ b/wenet/dataset/processor.py
@@ -80,10 +80,17 @@ def parse_speaker(sample, speaker_dict):
     return sample
 
 
-def detect_language(sample):
+def detect_language(sample, limited_langs=('zh', 'en')):
     assert 'txt' in sample
     # i.e., ('zh', -90.74214363098145)
     sample['lang'] = langid.classify(sample['txt'])[0]
+    # NOTE(xcsong): Because language classification may not be very accurate
+    #   (for example, Chinese being classified as Japanese), our workaround,
+    #   given we know for certain that the training data only consists of
+    #   Chinese and English, is to limit the classification results to reduce
+    #   the impact of misclassification.
+    if sample['lang'] not in limited_langs:
+        sample['lang'] = 'zh'
     return sample
 
 

--- a/wenet/paraformer/paraformer.py
+++ b/wenet/paraformer/paraformer.py
@@ -218,9 +218,14 @@ class Paraformer(ASRModel):
         }
 
     def _calc_att_loss(
-            self, encoder_out: torch.Tensor, encoder_mask: torch.Tensor,
-            ys_pad: torch.Tensor, ys_pad_emb: torch.Tensor,
-            ys_pad_lens: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        self,
+        encoder_out: torch.Tensor,
+        encoder_mask: torch.Tensor,
+        ys_pad: torch.Tensor,
+        ys_pad_emb: torch.Tensor,
+        ys_pad_lens: torch.Tensor,
+        infos: Dict[str, List[str]] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         decoder_out, _, _ = self.decoder(encoder_out, encoder_mask, ys_pad_emb,
                                          ys_pad_lens)
         loss_att = self.criterion_att(decoder_out, ys_pad)

--- a/wenet/transformer/search.py
+++ b/wenet/transformer/search.py
@@ -14,13 +14,12 @@
 
 import math
 from collections import defaultdict
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 import torch
 from torch.nn.utils.rnn import pad_sequence
 
-from wenet.utils.common import (add_sos_eos, log_add, WHISPER_LANGS,
-                                add_whisper_tokens)
+from wenet.utils.common import (add_sos_eos, log_add, add_whisper_tokens)
 from wenet.utils.ctc_utils import remove_duplicates_and_blank
 from wenet.utils.mask import (make_pad_mask, mask_finished_preds,
                               mask_finished_scores, subsequent_mask)
@@ -253,6 +252,7 @@ def attention_beam_search(
     encoder_mask: torch.Tensor,
     beam_size: int = 10,
     length_penalty: float = 0.0,
+    infos: Dict[str, List[str]] = None,
 ) -> List[DecodeResult]:
     device = encoder_out.device
     batch_size = encoder_out.shape[0]
@@ -265,17 +265,21 @@ def attention_beam_search(
         running_size, maxlen, encoder_dim)  # (B*N, maxlen, encoder_dim)
     encoder_mask = encoder_mask.unsqueeze(1).repeat(1, beam_size, 1, 1).view(
         running_size, 1, maxlen)  # (B*N, 1, max_len)
+    tasks, langs = infos["tasks"], infos["langs"]
+    tasks = [t for t in tasks for _ in range(beam_size)]
+    langs = [l for l in langs for _ in range(beam_size)]
 
     if getattr(model, 'special_tokens', None) is not None \
             and "transcribe" in model.special_tokens:
-        hyps = torch.ones([running_size, 4], dtype=torch.long,
-                          device=device)  # (B*N, 4)
-        # TODO(xcsong): add args for language, task, etc
-        hyps[:, 0] = model.special_tokens["sot"]
-        hyps[:,
-             1] = model.special_tokens["sot"] + 1 + WHISPER_LANGS.index("zh")
-        hyps[:, 2] = model.special_tokens["transcribe"]
-        hyps[:, 3] = model.special_tokens["no_timestamps"]
+        hyps = torch.ones([running_size, 0], dtype=torch.long,
+                          device=device)  # (B*N, 0)
+        hyps, _ = add_whisper_tokens(model.special_tokens,
+                                     hyps,
+                                     model.ignore_id,
+                                     tasks=tasks,
+                                     no_timestamp=True,
+                                     langs=langs,
+                                     use_prev=False)
     else:
         hyps = torch.ones([running_size, 1], dtype=torch.long,
                           device=device).fill_(model.sos)  # (B*N, 1)
@@ -360,6 +364,7 @@ def attention_rescoring(
     encoder_lens: torch.Tensor,
     ctc_weight: float = 0.0,
     reverse_weight: float = 0.0,
+    infos: Dict[str, List[str]] = None,
 ) -> List[DecodeResult]:
     """
         Args:
@@ -370,6 +375,7 @@ def attention_rescoring(
     assert encoder_outs.shape[0] == len(ctc_prefix_results)
     batch_size = encoder_outs.shape[0]
     results = []
+    tasks, langs = infos["tasks"], infos["langs"]
     for b in range(batch_size):
         encoder_out = encoder_outs[b, :encoder_lens[b], :].unsqueeze(0)
         hyps = ctc_prefix_results[b].nbest
@@ -382,14 +388,13 @@ def attention_rescoring(
                                  dtype=torch.long)  # (beam_size,)
         if getattr(model, 'special_tokens', None) is not None \
                 and "transcribe" in model.special_tokens:
-            # TODO(xcsong): add args for language, task, etc
             prev_len = hyps_pad.size(1)
             hyps_pad, _ = add_whisper_tokens(model.special_tokens,
                                              hyps_pad,
                                              model.ignore_id,
-                                             task="transcribe",
+                                             tasks=[tasks[b]] * len(hyps),
                                              no_timestamp=True,
-                                             language="zh",
+                                             langs=[langs[b]] * len(hyps),
                                              use_prev=False)
             cur_len = hyps_pad.size(1)
             hyps_lens = hyps_lens + cur_len - prev_len

--- a/wenet/utils/common.py
+++ b/wenet/utils/common.py
@@ -156,7 +156,7 @@ def add_sos_eos(ys_pad: torch.Tensor, sos: int, eos: int,
 
 
 def add_whisper_tokens(special_tokens, ys_pad: torch.Tensor, ignore_id: int,
-                       task: str, no_timestamp: bool, language: str,
+                       tasks: List[str], no_timestamp: bool, langs: List[str],
                        use_prev: bool) -> Tuple[torch.Tensor, torch.Tensor]:
     """Add whisper-style tokens.
 
@@ -175,13 +175,16 @@ def add_whisper_tokens(special_tokens, ys_pad: torch.Tensor, ignore_id: int,
         special_tokens: get IDs of special tokens
         ignore_id (int): index of padding
         no_timestamp (bool): whether to add timestamps tokens
-        language (str): language tag
+        tasks (List[str]): list of task tags
+        langs (List[str]): list of language tags
 
     Returns:
         ys_in (torch.Tensor) : (B, Lmax + ?)
         ys_out (torch.Tensor) : (B, Lmax + ?)
 
     """
+    assert len(langs) == ys_pad.size(0)
+    assert len(tasks) == ys_pad.size(0)
     if use_prev:
         # i.e., hotword list
         _prev = [special_tokens["sot_prev"]]
@@ -191,41 +194,46 @@ def add_whisper_tokens(special_tokens, ys_pad: torch.Tensor, ignore_id: int,
     else:
         _prev = []
 
-    language_id = special_tokens["sot"] + 1 + WHISPER_LANGS.index(language)
-    if task == "transcribe":
-        task_id = special_tokens["transcribe"]
-    elif task == "translate":
-        task_id = special_tokens["translate"]
-    elif task == "vad":
-        task_id = special_tokens["no_speech"]
-    else:
-        raise NotImplementedError("unsupported task {}".format(task))
-    _sot = _prev + [special_tokens["sot"], language_id, task_id]
+    _sot = []
+    for task, lang in zip(tasks, langs):
+        if task == "transcribe":
+            task_id = special_tokens["transcribe"]
+        elif task == "translate":
+            task_id = special_tokens["translate"]
+        elif task == "vad":
+            task_id = special_tokens["no_speech"]
+        else:
+            raise NotImplementedError("unsupported task {}".format(task))
+        language_id = special_tokens["sot"] + 1 + WHISPER_LANGS.index(lang)
+        prefix = _prev + [special_tokens["sot"], language_id, task_id]
+        if task == "transcribe" or task == "translate":
+            if no_timestamp:
+                prefix.append(special_tokens["no_timestamps"])
+            else:
+                prefix.append(special_tokens["timestamp_begin"])
+                # add subsequent tokens
+                # ...
+                raise NotImplementedError
+        elif task == "vad":
+            prefix.append(special_tokens["no_speech"])
+        else:
+            raise NotImplementedError
+        prefix = torch.tensor(prefix,
+                              dtype=torch.long,
+                              requires_grad=False,
+                              device=ys_pad.device)
+        _sot.append(prefix)
+
     _eot = torch.tensor([special_tokens["eot"]],
                         dtype=torch.long,
                         requires_grad=False,
                         device=ys_pad.device)
     ys = [y[y != ignore_id] for y in ys_pad]  # parse padded ys
 
-    if task == "transcribe" or task == "translate":
-        if no_timestamp:
-            _sot.append(special_tokens["no_timestamps"])
-        else:
-            _sot.append(special_tokens["timestamp_begin"])
-            # add subsequent tokens
-            # ...
-            raise NotImplementedError
-    elif task == "vad":
-        _sot.append(special_tokens["no_speech"])
-    else:
-        raise NotImplementedError
-
-    _sot = torch.tensor(_sot,
-                        dtype=torch.long,
-                        requires_grad=False,
-                        device=ys_pad.device)
-    ys_in = [torch.cat([_sot, y], dim=0) for y in ys]
-    ys_out = [torch.cat([_sot[1:], y, _eot], dim=0) for y in ys]
+    ys_in = [torch.cat([prefix, y], dim=0) for prefix, y in zip(_sot, ys)]
+    ys_out = [
+        torch.cat([prefix[1:], y, _eot], dim=0) for prefix, y in zip(_sot, ys)
+    ]
     return pad_list(ys_in, special_tokens["eot"]), pad_list(ys_out, ignore_id)
 
 

--- a/wenet/whisper/whisper.py
+++ b/wenet/whisper/whisper.py
@@ -16,7 +16,7 @@
 
 import torch
 
-from typing import Tuple
+from typing import Tuple, Dict, List
 
 from wenet.transformer.asr_model import ASRModel
 from wenet.transformer.ctc import CTC
@@ -65,15 +65,15 @@ class Whisper(ASRModel):
         encoder_mask: torch.Tensor,
         ys_pad: torch.Tensor,
         ys_pad_lens: torch.Tensor,
+        infos: Dict[str, List[str]],
     ) -> Tuple[torch.Tensor, float]:
-        # TODO(xcsong): add args for no_timestamp, language, etc
         prev_len = ys_pad.size(1)
         ys_in_pad, ys_out_pad = add_whisper_tokens(self.special_tokens,
                                                    ys_pad,
                                                    self.ignore_id,
-                                                   task="transcribe",
+                                                   tasks=infos['tasks'],
                                                    no_timestamp=True,
-                                                   language="zh",
+                                                   langs=infos['langs'],
                                                    use_prev=False)
         cur_len = ys_in_pad.size(1)
         ys_in_lens = ys_pad_lens + cur_len - prev_len


### PR DESCRIPTION
use https://github.com/saffsd/langid.py to detect language on the fly.

results look good:

```py
import langid
print(langid.classify("Questo è un testo di prova."))
print(langid.classify("hello world"))
print(langid.classify("中国北京天安门"))
print(langid.classify("使用GPS进行定位"))
print(langid.classify("Hi, 你好"))
```

```sh
('it', -95.88065242767334)
('en', -23.719746112823486)                                                                                                                                                                                                          ('zh', -90.74214363098145)
('zh', -78.27495694160461)
('zh', -35.134679317474365)
```


langid could detect most of the common languages.
```py
from whisper.tokenizer import LANGUAGES as WhiserLanguages
WHISPER_LANGS = tuple(WhiserLanguages.keys())

all_langs = "af, am, an, ar, as, az, be, bg, bn, br, bs, ca, cs, cy, da, de, dz, el, en, eo, es, et, eu, fa, fi, fo, fr, ga, gl, gu, he, hi, hr, ht, hu, hy, id, is, it, ja, jv, ka, kk, km, kn, ko, ku, ky, la, lb, lo, lt, lv, mg, mk, ml, mn, mr, ms, mt, nb, ne, nl, nn, no, oc, or, pa, pl, ps, pt, qu, ro, ru, rw, se, si, sk, sl, sq, sr, sv, sw, ta, te, th, tl, tr, ug, uk, ur, vi, vo, wa, xh, zh, zu"
all_langs = all_langs.split()
all_langs = [i.replace(",", "") for i in all_langs]

l_in_whisper, l_not_in_whisper = [], []
for l in all_langs:
    if l not in WHISPER_LANGS:
        l_not_in_whisper.append(l)
    else:
        l_in_whisper.append(l)

print(l_not_in_whisper)
print(l_in_whisper)
```

```sh
l_not_in_whisper: ['an', 'dz', 'eo', 'ga', 'jv', 'ku', 'ky', 'nb', 'or', 'qu', 'rw', 'se', 'ug', 'vo', 'wa', 'xh', 'zu']
l_in_whisper: ['af', 'am', 'ar', 'as', 'az', 'be', 'bg', 'bn', 'br', 'bs', 'ca', 'cs', 'cy', 'da', 'de', 'el', 'en', 'es', 'et', 'eu', 'fa', 'fi', 'fo', 'fr', 'gl', 'gu', 'he', 'hi', 'hr', 'ht', 'hu', 'hy', 'id', 'is', 'it', 'ja', 'ka', 'kk', 'km', 'kn', 'ko', 'la', 'lb', 'lo', 'lt', 'lv', 'mg', 'mk', 'ml', 'mn', 'mr', 'ms', 'mt', 'ne', 'nl', 'nn', 'no', 'oc', 'pa', 'pl', 'ps', 'pt', 'ro', 'ru', 'si', 'sk', 'sl', 'sq', 'sr', 'sv', 'sw', 'ta', 'te', 'th', 'tl', 'tr', 'uk', 'ur', 'vi', 'zh']
```