### PR TITLE
[runtime] Configurable blank token idx

### DIFF
--- a/runtime/core/decoder/ctc_wfst_beam_search.cc
+++ b/runtime/core/decoder/ctc_wfst_beam_search.cc
@@ -88,7 +88,7 @@ void CtcWfstBeamSearch::Search(const std::vector<std::vector<float>>& logp) {
           std::max_element(logp[i].begin(), logp[i].end()) - logp[i].begin();
       // Optional, adding one blank frame if we has skipped it in two same
       // symbols
-      if (cur_best != opts_.blank_scale && is_last_frame_blank_ &&
+      if (cur_best != opts_.blank && is_last_frame_blank_ &&
           cur_best == last_best_) {
         decodable_.AcceptLoglikes(last_frame_prob_);
         decoder_.AdvanceDecoding(&decodable_, 1);

--- a/runtime/core/decoder/ctc_wfst_beam_search.cc
+++ b/runtime/core/decoder/ctc_wfst_beam_search.cc
@@ -77,7 +77,7 @@ void CtcWfstBeamSearch::Search(const std::vector<std::vector<float>>& logp) {
   }
   // Every time we get the log posterior, we decode it all before return
   for (int i = 0; i < logp.size(); i++) {
-    float blank_score = std::exp(logp[i][0]);
+    float blank_score = std::exp(logp[i][opts_.blank]);
     if (blank_score > opts_.blank_skip_thresh * opts_.blank_scale) {
       VLOG(3) << "skipping frame " << num_frames_ << " score " << blank_score;
       is_last_frame_blank_ = true;
@@ -88,7 +88,8 @@ void CtcWfstBeamSearch::Search(const std::vector<std::vector<float>>& logp) {
           std::max_element(logp[i].begin(), logp[i].end()) - logp[i].begin();
       // Optional, adding one blank frame if we has skipped it in two same
       // symbols
-      if (cur_best != 0 && is_last_frame_blank_ && cur_best == last_best_) {
+      if (cur_best != opts_.blank_scale && is_last_frame_blank_ &&
+          cur_best == last_best_) {
         decodable_.AcceptLoglikes(last_frame_prob_);
         decoder_.AdvanceDecoding(&decodable_, 1);
         decoded_frames_mapping_.push_back(num_frames_ - 1);
@@ -168,7 +169,7 @@ void CtcWfstBeamSearch::ConvertToInputs(const std::vector<int>& alignment,
   if (time != nullptr) time->clear();
   for (int cur = 0; cur < alignment.size(); ++cur) {
     // ignore blank
-    if (alignment[cur] - 1 == 0) continue;
+    if (alignment[cur] - 1 == opts_.blank) continue;
     // merge continuous same label
     if (cur > 0 && alignment[cur] == alignment[cur - 1]) continue;
 

--- a/runtime/core/decoder/ctc_wfst_beam_search.h
+++ b/runtime/core/decoder/ctc_wfst_beam_search.h
@@ -55,6 +55,7 @@ struct CtcWfstBeamSearchOptions : public kaldi::LatticeFasterDecoderConfig {
   // search
   float blank_skip_thresh = 0.98;
   float blank_scale = 1.0;
+  int blank = 0;
 };
 
 class CtcWfstBeamSearch : public SearchInterface {

--- a/runtime/core/decoder/params.h
+++ b/runtime/core/decoder/params.h
@@ -88,7 +88,7 @@ DEFINE_int32(min_active, 200, "min active states in ctc wfst search");
 DEFINE_double(beam, 16.0, "beam in ctc wfst search");
 DEFINE_double(lattice_beam, 10.0, "lattice beam in ctc wfst search");
 DEFINE_double(acoustic_scale, 1.0, "acoustic scale for ctc wfst search");
-DEFINE_int32(blank_id, 1.0,
+DEFINE_int32(blank_id, 0.0,
              "blank token idx for ctc wfst search and ctc prefix beam search");
 DEFINE_double(blank_skip_thresh, 1.0,
               "blank skip thresh for ctc wfst search, 1.0 means no skip");

--- a/runtime/core/decoder/params.h
+++ b/runtime/core/decoder/params.h
@@ -88,6 +88,8 @@ DEFINE_int32(min_active, 200, "min active states in ctc wfst search");
 DEFINE_double(beam, 16.0, "beam in ctc wfst search");
 DEFINE_double(lattice_beam, 10.0, "lattice beam in ctc wfst search");
 DEFINE_double(acoustic_scale, 1.0, "acoustic scale for ctc wfst search");
+DEFINE_int32(blank_id, 1.0,
+             "blank token idx for ctc wfst search and ctc prefix beam search");
 DEFINE_double(blank_skip_thresh, 1.0,
               "blank skip thresh for ctc wfst search, 1.0 means no skip");
 DEFINE_double(blank_scale, 1.0, "blank scale for ctc wfst search");
@@ -145,6 +147,7 @@ std::shared_ptr<DecodeOptions> InitDecodeOptionsFromFlags() {
   decode_config->ctc_wfst_search_opts.beam = FLAGS_beam;
   decode_config->ctc_wfst_search_opts.lattice_beam = FLAGS_lattice_beam;
   decode_config->ctc_wfst_search_opts.acoustic_scale = FLAGS_acoustic_scale;
+  decode_config->ctc_wfst_search_opts.blank = FLAGS_blank_id;
   decode_config->ctc_wfst_search_opts.blank_skip_thresh =
       FLAGS_blank_skip_thresh;
   decode_config->ctc_wfst_search_opts.blank_scale = FLAGS_blank_scale;
@@ -152,6 +155,7 @@ std::shared_ptr<DecodeOptions> InitDecodeOptionsFromFlags() {
   decode_config->ctc_wfst_search_opts.nbest = FLAGS_nbest;
   decode_config->ctc_prefix_search_opts.first_beam_size = FLAGS_nbest;
   decode_config->ctc_prefix_search_opts.second_beam_size = FLAGS_nbest;
+  decode_config->ctc_prefix_search_opts.blank = FLAGS_blank_id;
   return decode_config;
 }
 

--- a/runtime/core/decoder/params.h
+++ b/runtime/core/decoder/params.h
@@ -88,7 +88,7 @@ DEFINE_int32(min_active, 200, "min active states in ctc wfst search");
 DEFINE_double(beam, 16.0, "beam in ctc wfst search");
 DEFINE_double(lattice_beam, 10.0, "lattice beam in ctc wfst search");
 DEFINE_double(acoustic_scale, 1.0, "acoustic scale for ctc wfst search");
-DEFINE_int32(blank_id, 0.0,
+DEFINE_int32(blank_id, 0,
              "blank token idx for ctc wfst search and ctc prefix beam search");
 DEFINE_double(blank_skip_thresh, 1.0,
               "blank skip thresh for ctc wfst search, 1.0 means no skip");
@@ -156,6 +156,7 @@ std::shared_ptr<DecodeOptions> InitDecodeOptionsFromFlags() {
   decode_config->ctc_prefix_search_opts.first_beam_size = FLAGS_nbest;
   decode_config->ctc_prefix_search_opts.second_beam_size = FLAGS_nbest;
   decode_config->ctc_prefix_search_opts.blank = FLAGS_blank_id;
+  decode_config->ctc_endpoint_config.blank = FLAGS_blank_id;
   return decode_config;
 }
 

--- a/runtime/core/utils/string.cc
+++ b/runtime/core/utils/string.cc
@@ -153,7 +153,7 @@ std::string ProcessBlank(const std::string& str, bool lowercase) {
       std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
       std::wstring wsresult = converter.from_bytes(result);
       for (auto& c : wsresult) {
-        c = lowercase ? tolower(c, loc) : toupper(c, loc);
+        c = lowercase ? tolower(c, loc) : c;
       }
       result = converter.to_bytes(wsresult);
     } catch (std::exception& e) {


### PR DESCRIPTION
Following https://github.com/wenet-e2e/wenet/pull/2320 which makes feature extraction pipeline compatible with whisper. We realized blank token idx is hard coded https://github.com/wenet-e2e/wenet/issues/2329, resulting in weird decoding results in the previous PR.

This PR is aiming at fixing that. **There might be some places that i missed, can you folks help me do another pass?**

![Screenshot 2024-02-22 at 2 19 12 PM](https://github.com/wenet-e2e/wenet/assets/22871821/3d94a650-f50f-4141-9ce7-12233957df12)

Current RTF is 2.xx after warming up,  using one core with beam size of 8, on my local macbook. I think the model is probably capable of running at real time with avx512 on multiple cores, even with whisper large. so let's get it to work!

However, there is still some loose ends. Maybe you guys already know the answer and can share some insights.

- decoder main result **still slightly differs from transcribe.py** imitating streaming inference using attention masks. I don't know exactly why, maybe some default params are different?
- In order to create the decoding **TLG graph, some tools might needs to be updated to support flexible blank token id**. I haven't checked this one, but now this is not a high priority for us.

