### PR TITLE
[whisper] fix decoding maxlen

### DIFF
--- a/wenet/transformer/search.py
+++ b/wenet/transformer/search.py
@@ -292,6 +292,8 @@ def attention_beam_search(
     cache: Optional[List[torch.Tensor]] = None
     if model.decoder.use_sdpa:
         encoder_mask = mask_to_bias(encoder_mask, encoder_out.dtype)
+    if hasattr(model, 'decode_maxlen'):
+        maxlen = model.decode_maxlen
     # 2. Decoder forward step by step
     for i in range(prefix_len, maxlen + 1):
         # Stop if all batch and all beam produce eos

--- a/wenet/whisper/whisper.py
+++ b/wenet/whisper/whisper.py
@@ -46,6 +46,7 @@ class Whisper(ASRModel):
         assert reverse_weight == 0.0
         self.sos = special_tokens["sot"]
         self.eos = special_tokens["eot"]
+        self.decode_maxlen = self.decoder.embed[1].max_len
 
     # TODO(xcsong): time align
     def set_alignment_heads(self, dump: bytes):


### PR DESCRIPTION
原生whisper在wenet上解码时，有的不会停止， encoder_out 的size 作为maxlen 会超过 decoder embed的max len

<img width="931" alt="截屏2024-03-04 13 31 29" src="https://github.com/wenet-e2e/wenet/assets/4906435/fb4fa6ba-fcc5-4f8b-be98-12feb41dd38e">
wav/test/S0915/BAC009S0915W0303.wav

修改后正确解码：
 ```bash
2024-03-04 13:29:56,745 INFO attention wav/test/S0915/BAC009S0915W0303.wav 今后所有空调产品还将实现联机运行
```