### PR TITLE
[transformer] attention support shpae [B, ..., h, t, d]

### DIFF
--- a/wenet/bin/recognize.py
+++ b/wenet/bin/recognize.py
@@ -289,6 +289,8 @@ def main():
                         logging.info('{} {}'.format(mode.ljust(max_format_len),
                                                     line))
                         files[mode].write(line + '\n')
+                if use_cuda:
+                    torch.cuda.empty_cache()
         for mode, f in files.items():
             f.close()
 

--- a/wenet/transformer/attention.py
+++ b/wenet/transformer/attention.py
@@ -316,7 +316,7 @@ class RelPositionMultiHeadedAttention(MultiHeadedAttention):
         # (batch, ..., head, time1, d_k)
         q_with_bias_u = (q + self.pos_bias_u).transpose(-2, -3)
         # (batch, ..., head, time1, d_k)
-        q_with_bias_v = (q + self.pos_bias_v).transpose(-2, 3)
+        q_with_bias_v = (q + self.pos_bias_v).transpose(-2, -3)
 
         # compute matrix b and matrix d
         # (batch, head, time1, time2)


### PR DESCRIPTION
为什么要支持 [B, ..., h, t, d]：
- cross attention cache 在这个 https://github.com/wenet-e2e/wenet/pull/2377 中引入， 
  其中cross attention的cache 没必要用[B*Beams, ], 因为该beams的都是同一个cache， 所以attention需要支持： 
  q [B*Beams, h, t,d] ->  [B, Beams, h, t,d] 
   k [B, h, t,d] -> [B, 1, h, t,d] 
   v [B,h,td] ->     [B,1,h,td] 

BTW： sdpa的attention是支持 [B, ..., , t, d]这种纬度的

TODO:
- [ ] check onnx and jit work
  - [x] jit  
- [ ] asr test， 为什么不训练呢： test指标一致+输出精度一致就可以了（理论上没改写代码逻辑）