### PR TITLE
[ssl/w2vbert] weight copy from meta w2vbert-2.0

### DIFF
--- a/test/wenet/transformer/test_attention.py
+++ b/test/wenet/transformer/test_attention.py
@@ -1,8 +1,8 @@
 import torch
 import pytest
-from wenet.transformer.attention import (
-    IndicesRelPositionMultiHeadedAttention, MultiHeadedAttention,
-    RelPositionMultiHeadedAttention)
+from wenet.transformer.attention import (MultiHeadedAttention,
+                                         RelPositionMultiHeadedAttention,
+                                         ShawRelPositionMultiHeadedAttention)
 from wenet.transformer.embedding import RelPositionalEncoding
 from wenet.transformer.encoder_layer import (ConformerEncoderLayer,
                                              TransformerEncoderLayer)
@@ -224,18 +224,15 @@ def test_rel_position_multi_head_attention_sdpa(args):
         q = output
 
 
-def test_indices_rel_position_multihead_attention():
+def test_shaw_rel_position_multihead_attention():
     torch.manual_seed(777)
-    module = IndicesRelPositionMultiHeadedAttention(8,
-                                                    256,
-                                                    0.0,
-                                                    use_sdpa=False)
+    module = ShawRelPositionMultiHeadedAttention(8, 256, 0.0, use_sdpa=False)
 
     torch.manual_seed(777)
-    module_sdpa = IndicesRelPositionMultiHeadedAttention(8,
-                                                         256,
-                                                         0.0,
-                                                         use_sdpa=True)
+    module_sdpa = ShawRelPositionMultiHeadedAttention(8,
+                                                      256,
+                                                      0.0,
+                                                      use_sdpa=True)
     q = torch.rand(2, 10, 256)
     k = torch.rand(2, 10, 256)
     v = torch.rand(2, 10, 256)

--- a/wenet/dataset/processor.py
+++ b/wenet/dataset/processor.py
@@ -29,7 +29,7 @@ import torchaudio.compliance.kaldi as kaldi
 import torch.nn.functional as F
 from wenet.text.base_tokenizer import BaseTokenizer
 
-torchaudio.utils.sox_utils.set_buffer_size(16500)
+# torchaudio.utils.sox_utils.set_buffer_size(16500)
 
 AUDIO_FORMAT_SETS = set(['flac', 'mp3', 'm4a', 'ogg', 'opus', 'wav', 'wma'])
 
@@ -218,6 +218,22 @@ def compute_fbank(sample,
                       dither=dither,
                       energy_floor=0.0,
                       sample_frequency=sample_rate)
+    sample['feat'] = mat
+    return sample
+
+
+def compute_w2vbert_fbank(sample,
+                          num_mel_bins=23,
+                          frame_length=25,
+                          frame_shift=10,
+                          dither=0.0):
+    """ Extract Pretrain w2vbert(4.5M hours) fbank
+    """
+    sample = compute_fbank(sample, num_mel_bins, frame_length, frame_shift,
+                           dither)
+    mat = sample['feat']
+    std, mean = torch.std_mean(mat, dim=0)
+    mat = mat.subtract(mean).divide(std)
     sample['feat'] = mat
     return sample
 

--- a/wenet/dataset/processor.py
+++ b/wenet/dataset/processor.py
@@ -222,22 +222,6 @@ def compute_fbank(sample,
     return sample
 
 
-def compute_w2vbert_fbank(sample,
-                          num_mel_bins=23,
-                          frame_length=25,
-                          frame_shift=10,
-                          dither=0.0):
-    """ Extract Pretrain w2vbert(4.5M hours) fbank
-    """
-    sample = compute_fbank(sample, num_mel_bins, frame_length, frame_shift,
-                           dither)
-    mat = sample['feat']
-    std, mean = torch.std_mean(mat, dim=0)
-    mat = mat.subtract(mean).divide(std)
-    sample['feat'] = mat
-    return sample
-
-
 def sort_by_feats(sample):
     assert 'feat' in sample
     assert isinstance(sample['feat'], torch.Tensor)

--- a/wenet/dataset/processor.py
+++ b/wenet/dataset/processor.py
@@ -29,7 +29,7 @@ import torchaudio.compliance.kaldi as kaldi
 import torch.nn.functional as F
 from wenet.text.base_tokenizer import BaseTokenizer
 
-# torchaudio.utils.sox_utils.set_buffer_size(16500)
+torchaudio.utils.sox_utils.set_buffer_size(16500)
 
 AUDIO_FORMAT_SETS = set(['flac', 'mp3', 'm4a', 'ogg', 'opus', 'wav', 'wma'])
 

--- a/wenet/ssl/w2vbert/convert_w2vbert_to_wenet_config_and_ckpt.py
+++ b/wenet/ssl/w2vbert/convert_w2vbert_to_wenet_config_and_ckpt.py
@@ -1,0 +1,173 @@
+import argparse
+import os
+import torch
+
+import yaml
+
+
+def convert_to_wenet_yaml(wenet_yaml_path: str):
+    configs = {}
+    configs['input_dim'] = 80
+    # whisper token nums
+    configs['output_dim'] = 51866
+
+    configs['encoder'] = 'conformer'
+    configs['encoder_conf'] = {}
+    configs['encoder_conf']['causal'] = True
+    configs['encoder_conf']['gradient_checkpointing'] = True
+    configs['encoder_conf']['input_layer'] = 'stack_n_frames'
+    configs['encoder_conf']['output_size'] = 1024
+    configs['encoder_conf']['attention_heads'] = 16
+    configs['encoder_conf']['linear_units'] = 4096
+    configs['encoder_conf']['num_blocks'] = 24
+    configs['encoder_conf']['dropout_rate'] = 0.1
+    configs['encoder_conf']['positional_dropout_rate'] = 0.0
+    configs['encoder_conf']['attention_dropout_rate'] = 0.0
+    configs['encoder_conf']['normalize_before'] = True
+    configs['encoder_conf']['use_dynamic_chunk'] = False
+    configs['encoder_conf']['use_dynamic_left_chunk'] = False
+    configs['encoder_conf']['pos_enc_layer_type'] = "no_pos"
+    configs['encoder_conf']['static_chunk_size'] = -1
+    configs['encoder_conf']['activation_type'] = "swish"
+    configs['encoder_conf']['conv_bias'] = False
+
+    configs['cmvn'] = None
+    configs['cmvn_conf'] = {}
+    configs['cmvn_conf']['cmvn_file'] = None
+    configs['cmvn_conf']['is_json_cmvn'] = None
+
+    configs['model'] = "asr_model"
+    configs['model_conf'] = {}
+    configs['model_conf']['ctc_weight'] = 0.3
+    configs['model_conf']['lsm_weight'] = 0.1
+    configs['model_conf']['length_normalized_loss'] = False
+
+    configs['dataset'] = "asr"
+    configs['dataset_conf'] = {}
+    configs['dataset_conf']['filter_conf'] = {}
+    configs['dataset_conf']['filter_conf'][
+        'max_length'] = 419000  # 1/2 subsample # noqa
+    configs['dataset_conf']['filter_conf']['min_length'] = 0
+    configs['dataset_conf']['filter_conf']['token_max_length'] = 400
+    configs['dataset_conf']['filter_conf']['token_min_length'] = 1
+    configs['dataset_conf']['resample_conf'] = {}
+    configs['dataset_conf']['resample_conf']['resample_rate'] = 16000
+    configs['dataset_conf']['speed_perturb'] = False
+    configs['dataset_conf']['spec_aug'] = True
+    configs['dataset_conf']['spec_aug_conf'] = {}
+    configs['dataset_conf']['spec_aug_conf']['num_t_mask'] = 2
+    configs['dataset_conf']['spec_aug_conf']['num_f_mask'] = 2
+    configs['dataset_conf']['spec_aug_conf']['max_t'] = 50
+    configs['dataset_conf']['spec_aug_conf']['max_f'] = 10
+    configs['dataset_conf']['spec_sub'] = True
+    configs['dataset_conf']['spec_sub_conf'] = {}
+    configs['dataset_conf']['spec_sub_conf']['num_t_sub'] = 3
+    configs['dataset_conf']['spec_sub_conf']['max_t'] = 30
+    configs['dataset_conf']['spec_trim'] = False
+    configs['dataset_conf']['shuffle'] = True
+    configs['dataset_conf']['shuffle_conf'] = {}
+    configs['dataset_conf']['shuffle_conf']['shuffle_size'] = 1500
+    configs['dataset_conf']['sort'] = True
+    configs['dataset_conf']['sort_conf'] = {}
+    configs['dataset_conf']['sort_conf']['sort_size'] = 500
+    configs['dataset_conf']['feats_type'] = "fbank"
+    configs['dataset_conf']['batch_conf'] = {}
+    configs['dataset_conf']['batch_conf']['batch_type'] = 'dynamic'
+    configs['dataset_conf']['batch_conf']['batch_size'] = 26
+    configs['dataset_conf']['batch_conf']['max_frames_in_batch'] = 12000
+
+    configs['grad_clip'] = 5
+    configs['accum_grad'] = 4
+    configs['max_epoch'] = 100
+    configs['log_interval'] = 100
+
+    configs['optim'] = "adam"
+    configs['optim_conf'] = {}
+    configs['optim_conf']['lr'] = 0.0005
+    configs['scheduler'] = "warmuplr"
+    configs['scheduler_conf'] = {}
+    configs['scheduler_conf']['warmup_steps'] = 12000
+
+    with open(wenet_yaml_path, '+w') as f:
+        f.write(yaml.dump(configs))
+        f.flush()
+
+    print(configs)
+
+
+def convert_to_wenet_state_dict(w2vbert_conformer_state_dict,
+                                wenet_state_dict_path):
+
+    wenet_state_dict = {}
+    print("==============start CKPT Conversion =========================")
+    conformer_state_dict = w2vbert_conformer_state_dict
+    wenet_state_dict = {}
+    for name in conformer_state_dict.keys():
+        old_name = name
+        name = name.replace("ffn1_layer_norm", "norm_ff_macaron")
+        name = name.replace("self_attn_layer_norm", "norm_mha")
+        name = name.replace("conv_layer_norm", "norm_conv")
+        name = name.replace("ffn2_layer_norm", "norm_ff")
+        name = name.replace("self_attn.q_proj", "self_attn.linear_q")
+        name = name.replace("self_attn.k_proj", "self_attn.linear_k")
+        name = name.replace("self_attn.v_proj", "self_attn_linear_v")
+        name = name.replace("self_attn.output_proj", "self_attn.linear_out")
+        name = name.replace("self_attn.sdpa.rel_k_embed",
+                            "self_attn.rel_k_embed")
+        name = name.replace("conv.pointwise_conv1",
+                            "conv_module.pointwise_conv1")
+        name = name.replace("conv.depthwise_conv",
+                            "conv_module.depthwise_conv")
+        name = name.replace("conv.pointwise_conv2",
+                            "conv_module.pointwise_conv2")
+        name = name.replace("conv.layer_norm", "conv_module.norm")
+        name = name.replace("ffn1.inner_proj", "feed_forward_macaron.w_1")
+        name = name.replace("ffn1.output_proj", "feed_forward_macaron.w_2")
+        name = name.replace("ffn2.inner_proj", "feed_forward.w_1")
+        name = name.replace("fn2.output_proj", "feed_forward.w_2")
+        name = name.replace("encoder_frontend.post_extract_layer_norm",
+                            "embed.layer_nrom")
+        name = name.replace("encoder_frontend.model_dim_proj", "embed.out")
+        name = name.replace(".layer_norm.", ".norm_final.")
+
+        wenet_state_dict[name] = conformer_state_dict[old_name]
+
+    print("Saving fp32 ckpt to {}...".format(wenet_state_dict_path))
+    torch.save(wenet_state_dict, wenet_state_dict_path)
+    print(
+        "DONE\n===================- End CKPT Conversion ====================\n"
+    )
+
+
+def get_args():
+    parser = argparse.ArgumentParser(
+        description='load and parse w2vbert2-conformer')
+    # yapf: disable
+    parser.add_argument(
+        '--w2vbert2_ckpt',
+        required=True,
+        help= 'https://huggingface.co/facebook/conformer-shaw/resolve/main/conformer_shaw.pt' # noqa
+    )
+    # yapf: enable
+    parser.add_argument('--output_dir',
+                        default='.',
+                        help='output file in wenet\'s style: ' +
+                        'units.txt, train.yaml, model.pt')
+    args = parser.parse_args()
+    return args
+
+
+def main():
+
+    args = get_args()
+    args.jit = True
+    checkpoint = torch.load(args.w2vbert2_ckpt, map_location="cpu")
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    convert_to_wenet_state_dict(
+        checkpoint["model"],
+        os.path.join(args.output_dir, 'wenet_w2vbert_conformer_600m.pt'))
+
+
+if __name__ == '__main__':
+    main()

--- a/wenet/ssl/w2vbert/convert_w2vbert_to_wenet_config_and_ckpt.py
+++ b/wenet/ssl/w2vbert/convert_w2vbert_to_wenet_config_and_ckpt.py
@@ -35,7 +35,7 @@ def convert_to_wenet_yaml(wenet_yaml_path: str):
     configs['encoder_conf']['static_chunk_size'] = -1
     configs['encoder_conf']['activation_type'] = "swish"
     configs['encoder_conf']['conv_bias'] = False
-    configs['encoder_conf']['selfattention_layer_type'] = 'rel_selfattn_v2'
+    configs['encoder_conf']['selfattention_layer_type'] = 'shaw_rel_selfattn'
     configs['encoder_conf']['cnn_module_kernel'] = 31
     configs['encoder_conf']['cnn_module_norm'] = 'layer_norm'
 

--- a/wenet/transformer/attention.py
+++ b/wenet/transformer/attention.py
@@ -454,6 +454,8 @@ class MultiHeadedCrossAttention(MultiHeadedAttention):
 
 
 class ShawRelPositionMultiHeadedAttention(MultiHeadedAttention):
+    """ https://arxiv.org/pdf/1803.02155.pdf
+    """
 
     def __init__(self,
                  n_head: int,

--- a/wenet/transformer/attention.py
+++ b/wenet/transformer/attention.py
@@ -443,3 +443,79 @@ class MultiHeadedCrossAttention(MultiHeadedAttention):
             output_shape = torch.Size([B * Beams]) + output.size()[2:]
             output = output.view(output_shape)
         return output, new_cache
+
+
+class IndicesRelPositionMultiHeadedAttention(MultiHeadedAttention):
+
+    def __init__(self,
+                 n_head: int,
+                 n_feat: int,
+                 dropout_rate: float,
+                 key_bias: bool = True,
+                 use_sdpa: bool = False):
+        super().__init__(n_head, n_feat, dropout_rate, key_bias, use_sdpa)
+        # TODO(Mddct): 64 8 1 as args
+        self.max_right_rel_pos = 64
+        self.max_left_rel_pos = 8
+        self.rel_k_embed = torch.nn.Embedding(
+            self.max_left_rel_pos + self.max_right_rel_pos + 1, self.d_k)
+
+    def _relative_indices(self, length: int, device: torch.device):
+        indices = torch.arange(length, device=device).unsqueeze(0)
+        rel_indices = indices - indices.transpose(0, 1)
+        rel_indices = torch.clamp(rel_indices, -self.max_left_rel_pos,
+                                  self.max_right_rel_pos)
+        return rel_indices + self.max_left_rel_pos
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        mask: torch.Tensor = torch.ones((0, 0, 0), dtype=torch.bool),
+        pos_emb: torch.Tensor = torch.empty(0),
+        cache: torch.Tensor = torch.zeros((0, 0, 0, 0))
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        del pos_emb
+        q, k, v = self.forward_qkv(query, key, value)
+        if cache.size(0) > 0:
+            key_cache, value_cache = torch.split(cache,
+                                                 cache.size(-1) // 2,
+                                                 dim=-1)
+            k = torch.cat([key_cache, k], dim=2)
+            v = torch.cat([value_cache, v], dim=2)
+        new_cache = torch.cat((k, v), dim=-1)
+
+        rel_k = self.rel_k_embed(
+            self._relative_indices(key.size(1), query.device))  # (t2, t2, d_k)
+        rel_k = rel_k[-q.size(2):]  # (t1, t2, d_k)
+        # b,h,t1,dk
+        rel_k = rel_k.unsqueeze(0).unsqueeze(0)  # (1, 1, t1, t2, d_k)
+        q_expand = q.unsqueeze(3)  # (batch, h, t1, 1, d_k)
+        rel_att_weights = (rel_k * q_expand).sum(-1).squeeze(
+            -1)  # (batch, h, t1, t2)
+        print(rel_att_weights.size())
+
+        if not self.use_sdpa:
+            scores = (torch.matmul(q, k.transpose(-2, -1)) +
+                      rel_att_weights) / math.sqrt(self.d_k)
+            return self.forward_attention(v, scores, mask), new_cache
+        else:
+            # NOTE(Mddct): we need mask bias, not boolean mask
+            assert mask.dtype != torch.bool
+            mask = mask.unsqueeze(1)
+            # matrix_bd as a mask bias
+            mask = torch.where(mask == get_dtype_min(mask.dtype), mask,
+                               rel_att_weights / math.sqrt(self.d_k))
+            output = torch.nn.functional.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=mask,
+                dropout_p=self.dropout_rate,
+                scale=1 / math.sqrt(self.d_k),
+            )
+            output = (output.transpose(1, 2).contiguous().view(
+                query.size(0), -1,
+                self.h * self.d_k))  # (batch, time1, d_model)
+            return self.linear_out(output), new_cache

--- a/wenet/transformer/subsampling.py
+++ b/wenet/transformer/subsampling.py
@@ -374,6 +374,11 @@ class StackNFramesSubsampling(BaseSubsampling):
             torch.Tensor: positional encoding
         """
         b, s, _ = x.size()
+        mat = sample['feat']
+        # assume x is fbank
+        std, mean = torch.std_mean(x, dim=0)
+        x = mat.subtract(mean).divide(std)
+
         seq_len = x_mask.sum(-1).view(b)
         r = s % self.stride
         s -= r

--- a/wenet/utils/class_utils.py
+++ b/wenet/utils/class_utils.py
@@ -16,6 +16,7 @@ from wenet.transformer.subsampling import (
     Conv2dSubsampling4,
     Conv2dSubsampling6,
     Conv2dSubsampling8,
+    StackNFramesSubsampling,
 )
 from wenet.efficient_conformer.subsampling import Conv2dSubsampling2
 from wenet.squeezeformer.subsampling import DepthwiseConv2dSubsampling4
@@ -54,7 +55,8 @@ WENET_SUBSAMPLE_CLASSES = {
     "dwconv2d4": DepthwiseConv2dSubsampling4,
     "conv2d6": Conv2dSubsampling6,
     "conv2d8": Conv2dSubsampling8,
-    'paraformer_dummy': torch.nn.Identity
+    'paraformer_dummy': torch.nn.Identity,
+    'stack_n_frames': StackNFramesSubsampling,
 }
 
 WENET_EMB_CLASSES = {

--- a/wenet/utils/class_utils.py
+++ b/wenet/utils/class_utils.py
@@ -75,7 +75,7 @@ WENET_ATTENTION_CLASSES = {
     "rel_selfattn": RelPositionMultiHeadedAttention,
     "grouped_rel_selfattn": GroupedRelPositionMultiHeadedAttention,
     "crossattn": MultiHeadedCrossAttention,
-    'rel_selfattn_v2': ShawRelPositionMultiHeadedAttention
+    'shaw_rel_selfattn': ShawRelPositionMultiHeadedAttention
 }
 
 WENET_MLP_CLASSES = {

--- a/wenet/utils/class_utils.py
+++ b/wenet/utils/class_utils.py
@@ -27,7 +27,8 @@ from wenet.transformer.embedding import (PositionalEncoding,
                                          NoPositionalEncoding)
 from wenet.transformer.attention import (MultiHeadedAttention,
                                          MultiHeadedCrossAttention,
-                                         RelPositionMultiHeadedAttention)
+                                         RelPositionMultiHeadedAttention,
+                                         ShawRelPositionMultiHeadedAttention)
 from wenet.efficient_conformer.attention import (
     GroupedRelPositionMultiHeadedAttention)
 
@@ -74,6 +75,7 @@ WENET_ATTENTION_CLASSES = {
     "rel_selfattn": RelPositionMultiHeadedAttention,
     "grouped_rel_selfattn": GroupedRelPositionMultiHeadedAttention,
     "crossattn": MultiHeadedCrossAttention,
+    'rel_selfattn_v2': ShawRelPositionMultiHeadedAttention
 }
 
 WENET_MLP_CLASSES = {


### PR DESCRIPTION
https://github.com/wenet-e2e/wenet/issues/2305

meta开源的w2vbert2.0 的权重是在4Mh的数据上pretrain训练（支持流式）， 模型是conformer，大小600M，  输入是fbank

diff 只有三处
- [x] fbank 归一化 https://github.com/wenet-e2e/wenet/pull/2346
- [x] 降采样 （拼帧 2-subsampling）
- [x] relative attention 

其他实现均一致， 

此次迁移，有潜在三大收益
- whisper 可做对比 以及嫁接模型等 多了fintune选择
-  目前speech+llm 大部分方案，采用了whisper encoder， 大小和该encoder 一致，  给未来speech+llm 提供其他选择
- wenet ssl/本身支持w2vbert的pretrain， 此次迁移相当于wenet 也有了预训练模型， 有了更多的可能性（比如使用基于wenet 快速构建情绪emb的预训练模型、continue pretrain on 业务数据 etc）

https://twitter.com/reach_vb/status/1750225679898071232
<img width="617" alt="截屏2024-03-08 01 21 28" src="https://github.com/wenet-e2e/wenet/assets/4906435/7f05ffd0-16ae-479b-9a8a-8f5f70b65f56">


该pr TODO：
- [x] convert (rename ckpt name)
- [x] unit test 

之后prTODO：
- [ ] asr fintune egs
- [ ] codebooks 迁移， support continue pretrain