### PR TITLE
[transformer] support multi query attention && multi goruped

### DIFF
--- a/wenet/transformer/attention.py
+++ b/wenet/transformer/attention.py
@@ -66,7 +66,7 @@ class MultiHeadedAttention(nn.Module):
         self.linear_q = nn.Linear(n_feat, self.inner_dim, bias=query_bias)
         self.linear_k = nn.Linear(n_feat, self.inner_kv_dim, bias=key_bias)
         self.linear_v = nn.Linear(n_feat, self.inner_kv_dim, bias=value_bias)
-        self.linear_out = nn.Linear(n_feat, n_feat)
+        self.linear_out = nn.Linear(self.inner_dim, n_feat, bias=query_bias)
         self.dropout = nn.Dropout(p=dropout_rate)
 
         self.use_sdpa = use_sdpa

--- a/wenet/transformer/attention.py
+++ b/wenet/transformer/attention.py
@@ -60,6 +60,7 @@ class MultiHeadedAttention(nn.Module):
             n_kv_head = n_head
         # We assume d_v always equals d_k
         self.d_k = n_feat // n_head
+        assert self.d_k == self.inner_kv_dim // n_kv_head
         self.h = n_head
         self.h_kv = n_head if n_kv_head is None else n_kv_head
 

--- a/wenet/transformer/decoder.py
+++ b/wenet/transformer/decoder.py
@@ -84,6 +84,8 @@ class TransformerDecoder(torch.nn.Module):
         mlp_type: str = 'position_wise_feed_forward',
         layer_norm_type: str = 'layer_norm',
         norm_eps: float = 1e-5,
+        n_kv_head: Optional[int] = None,
+        head_dim: Optional[int] = None,
     ):
         super().__init__()
         attention_dim = encoder_output_size
@@ -114,11 +116,11 @@ class TransformerDecoder(torch.nn.Module):
                 WENET_ATTENTION_CLASSES["selfattn"](
                     attention_heads, attention_dim,
                     self_attention_dropout_rate, query_bias, key_bias,
-                    value_bias, use_sdpa),
+                    value_bias, use_sdpa, n_kv_head, head_dim),
                 WENET_ATTENTION_CLASSES["crossattn"](
                     attention_heads, attention_dim, src_attention_dropout_rate,
-                    query_bias, key_bias, value_bias, use_sdpa)
-                if src_attention else None,
+                    query_bias, key_bias, value_bias, use_sdpa, n_kv_head,
+                    head_dim) if src_attention else None,
                 mlp_class(attention_dim, linear_units, dropout_rate,
                           activation, mlp_bias),
                 dropout_rate,
@@ -334,6 +336,8 @@ class BiTransformerDecoder(torch.nn.Module):
         use_sdpa: bool = False,
         layer_norm_type: str = 'layer_norm',
         norm_eps: float = 1e-5,
+        n_kv_head: Optional[int] = None,
+        head_dim: Optional[int] = None,
     ):
 
         super().__init__()
@@ -360,6 +364,8 @@ class BiTransformerDecoder(torch.nn.Module):
             use_sdpa=use_sdpa,
             layer_norm_type=layer_norm_type,
             norm_eps=norm_eps,
+            n_kv_head=n_kv_head,
+            head_dim=head_dim,
         )
 
         self.right_decoder = TransformerDecoder(
@@ -384,6 +390,8 @@ class BiTransformerDecoder(torch.nn.Module):
             use_sdpa=use_sdpa,
             layer_norm_type=layer_norm_type,
             norm_eps=norm_eps,
+            n_kv_head=n_kv_head,
+            head_dim=head_dim,
         )
 
     def forward(

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # Modified from ESPnet(https://github.com/espnet/espnet)
 """Encoder definition."""
-from typing import Tuple
+from typing import Optional, Tuple
 
 import torch
 import torch.utils.checkpoint as ckpt
@@ -375,6 +375,8 @@ class TransformerEncoder(BaseEncoder):
         mlp_type: str = 'position_wise_feed_forward',
         layer_norm_type: str = 'layer_norm',
         norm_eps: float = 1e-5,
+        n_kv_head: Optional[int] = None,
+        head_dim: Optional[int] = None,
     ):
         """ Construct TransformerEncoder
 
@@ -396,7 +398,8 @@ class TransformerEncoder(BaseEncoder):
                                                     output_size,
                                                     attention_dropout_rate,
                                                     query_bias, key_bias,
-                                                    value_bias, use_sdpa),
+                                                    value_bias, use_sdpa,
+                                                    n_kv_head, head_dim),
                 mlp_class(output_size, linear_units, dropout_rate, activation,
                           mlp_bias),
                 dropout_rate,
@@ -445,6 +448,8 @@ class ConformerEncoder(BaseEncoder):
         mlp_type: str = 'position_wise_feed_forward',
         layer_norm_type: str = 'layer_norm',
         norm_eps: float = 1e-5,
+        n_kv_head: Optional[int] = None,
+        head_dim: Optional[int] = None,
     ):
         """Construct ConformerEncoder
 
@@ -481,6 +486,8 @@ class ConformerEncoder(BaseEncoder):
             key_bias,
             value_bias,
             use_sdpa,
+            n_kv_head,
+            head_dim,
         )
         # feed-forward module definition
         positionwise_layer_args = (


### PR DESCRIPTION
muitl query 可以减少cache占用，加快解码速度， llm中slm中会用到 比如gemma等
并且根据paper https://github.com/wenet-e2e/wenet/pull/2363#issuecomment-1961189853， 我们可以在multihead 训练的模型基础上， 用MQA 继续训练 

ASR上 https://github.com/wenet-e2e/wenet/pull/2363#issuecomment-1961189853， 中显示 确实可以和multihead 达到一致的性能