### PR TITLE
[torchaudio] Fix torchaudio interface error (#2352)

### DIFF
--- a/tools/compute_cmvn_stats.py
+++ b/tools/compute_cmvn_stats.py
@@ -12,8 +12,6 @@ import torchaudio
 import torchaudio.compliance.kaldi as kaldi
 from torch.utils.data import Dataset, DataLoader
 
-torchaudio.set_audio_backend("sox_io")
-
 
 class CollateFunc(object):
     ''' Collate function for AudioDataset
@@ -32,7 +30,7 @@ class CollateFunc(object):
             value = item[1].strip().split(",")
             assert len(value) == 3 or len(value) == 1
             wav_path = value[0]
-            sample_rate = torchaudio.backend.sox_io_backend.info(
+            sample_rate = torchaudio.info(
                 wav_path).sample_rate
             resample_rate = sample_rate
             # len(value) == 3 means segmented wav.scp,
@@ -40,7 +38,7 @@ class CollateFunc(object):
             if len(value) == 3:
                 start_frame = int(float(value[1]) * sample_rate)
                 end_frame = int(float(value[2]) * sample_rate)
-                waveform, sample_rate = torchaudio.backend.sox_io_backend.load(
+                waveform, sample_rate = torchaudio.load(
                     filepath=wav_path,
                     num_frames=end_frame - start_frame,
                     frame_offset=start_frame)

--- a/tools/compute_fbank_feats.py
+++ b/tools/compute_fbank_feats.py
@@ -20,10 +20,6 @@ import torchaudio.compliance.kaldi as kaldi
 
 import wenet.dataset.kaldi_io as kaldi_io
 
-# The "sox" backends are deprecated and will be removed in 0.9.0 release.
-# So here we use sox_io backend
-torchaudio.set_audio_backend("sox_io")
-
 
 def parse_opts():
     parser = argparse.ArgumentParser(description='training your network')
@@ -104,14 +100,14 @@ if __name__ == '__main__':
         for item in audio_list:
             if len(item) == 2:
                 key, wav_path = item
-                waveform, sample_rate = torchaudio.load_wav(wav_path)
+                waveform, sample_rate = torchaudio.load(wav_path)
             else:
                 assert len(item) == 4
                 key, wav_path, start, end = item
                 sample_rate = torchaudio.info(wav_path).sample_rate
                 frame_offset = int(start * sample_rate)
                 num_frames = int((end - start) * sample_rate)
-                waveform, sample_rate = torchaudio.load_wav(
+                waveform, sample_rate = torchaudio.load(
                     wav_path, frame_offset, num_frames)
 
             mat = kaldi.fbank(waveform,

--- a/tools/wav2dur.py
+++ b/tools/wav2dur.py
@@ -5,7 +5,6 @@ import sys
 
 import torchaudio
 
-torchaudio.set_audio_backend("sox_io")
 
 scp = sys.argv[1]
 dur_scp = sys.argv[2]


### PR DESCRIPTION
在torchaudio>2.0版本中移除了全局backend选项，采用在函数调用中backend参数指定后端，并将默认的backend设为ffmpeg

> In 2.0, audio I/O backend dispatcher was introduced. Users can opt-in to using dispatcher by setting the environment variable TORCHAUDIO_USE_BACKEND_DISPATCHER=1.
> 
> In 2.1, the disptcher became the default mechanism for I/O.
> 
> In 2.2, the legacy global backend mechanism is removed. Utility functions get_audio_backend() and set_audio_backend() became no-op.

参考：[TorchAudio Dispatcher Migration](https://github.com/pytorch/audio/issues/2950)