### PR TITLE
[dataset] add singal channel conf & processor

### DIFF
--- a/wenet/dataset/dataset.py
+++ b/wenet/dataset/dataset.py
@@ -65,6 +65,9 @@ def Dataset(data_type,
                                              cycle=cycle)
     dataset = dataset.map_ignore_error(processor.decode_wav)
 
+    singal_channel_conf = conf.get('singal_channel_conf', {})
+    dataset = dataset.map(partial(processor.singal_channel, **singal_channel_conf))
+
     speaker_conf = conf.get('speaker_conf', None)
     if speaker_conf is not None:
         assert 'speaker_table_path' in speaker_conf

--- a/wenet/dataset/processor.py
+++ b/wenet/dataset/processor.py
@@ -141,6 +141,26 @@ def decode_wav(sample):
     sample['sample_rate'] = sample_rate
     return sample
 
+def singal_channel(sample, channel=0):
+    """ Choose a channel of sample.
+        Inplace operation.
+
+        Args:
+            sample: {key, wav, label, sample_rate}
+            channel: target channel index
+
+        Returns:
+            {key, wav, label, sample_rate}
+    """
+    assert 'wav' in sample
+    waveform = sample['wav']
+    channel_nums = waveform.size(0)
+    assert channel < channel_nums
+    if channel_nums != 1:
+        waveform = waveform[channel, :].unsqueeze(0)
+    sample['wav'] = waveform
+    return sample
+
 
 def resample(sample, resample_rate=16000):
     """ Resample sample.


### PR DESCRIPTION
当shard/raw list中存在多通道数据，dataset会在padding部分报错，错误信息如下(or 类似)
```
    padded_wavs = pad_sequence(sorted_wavs, batch_first=True, padding_value=0)
  File "/opt/conda/lib/python3.10/site-packages/torch/nn/utils/rnn.py", line 399, in pad_sequence
    return torch._C._nn.pad_sequence(sequences, batch_first, padding_value)
RuntimeError: The size of tensor a (2) must match the size of tensor b (26645) at non-singleton dimension 1
```
This pr tries to fix the above problem
