### PR TITLE
[runtime] Fixed failed compilation without ITN. Now, compiling ITN is mandatory.

### DIFF
--- a/runtime/core/post_processor/CMakeLists.txt
+++ b/runtime/core/post_processor/CMakeLists.txt
@@ -1,9 +1,5 @@
 add_library(post_processor STATIC
   post_processor.cc
 )
-if(ITN)
-  target_link_libraries(post_processor PUBLIC utils wetext_processor wetext_utils)
-else()
-  target_link_libraries(post_processor PUBLIC utils)
-endif()
+target_link_libraries(post_processor PUBLIC utils wetext_processor wetext_utils)
 

--- a/runtime/ipex/CMakeLists.txt
+++ b/runtime/ipex/CMakeLists.txt
@@ -10,7 +10,6 @@ option(GRPC "whether to build with gRPC" OFF)
 option(WEBSOCKET "whether to build with websocket" OFF)
 option(HTTP "whether to build with http" OFF)
 option(TORCH "whether to build with Torch" ON)
-option(ITN "whether to use WeTextProcessing" ON)
 option(IPEX "whether to build with Torch+IPEX" ON)
 
 set(CMAKE_VERBOSE_MAKEFILE OFF)
@@ -31,9 +30,7 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/kaldi
 )
-if(ITN)
-  include(wetextprocessing)
-endif()
+ include(wetextprocessing)
 
 # Build all libraries
 add_subdirectory(utils)

--- a/runtime/libtorch/CMakeLists.txt
+++ b/runtime/libtorch/CMakeLists.txt
@@ -14,7 +14,6 @@ option(HTTP "whether to build with http" OFF)
 option(TORCH "whether to build with Torch" ON)
 option(ONNX "whether to build with ONNX" OFF)
 option(GPU "whether to build with GPU" OFF)
-option(ITN "whether to use WeTextProcessing" ON)
 
 set(CMAKE_CXX_FLAGS_DEBUG "$ENV{CXXFLAGS} -g")
 set(CMAKE_VERBOSE_MAKEFILE OFF)
@@ -48,9 +47,7 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/kaldi
 )
 
-if(ITN)
-  include(wetextprocessing)
-endif()
+include(wetextprocessing)
 
 # Build all libraries
 add_subdirectory(utils)


### PR DESCRIPTION
In the original version, it didn't work without itn.  but now a further separation of references 'wetext' can ensure that it works without itn.