### PR TITLE
[transformer] refactor cache

### DIFF
--- a/test/wenet/transformer/test_attention.py
+++ b/test/wenet/transformer/test_attention.py
@@ -64,7 +64,8 @@ def test_multi_head_attention_sdpa(args):
         output_with_sdpa * mask.transpose(1, 2),
         atol=9e-7,
     )
-    assert torch.allclose(cache, cache_with_sdpa)
+    assert torch.allclose(cache[0], cache_with_sdpa[0])
+    assert torch.allclose(cache[1], cache_with_sdpa[1])
 
     n_blocks = 12
     torch.manual_seed(777)
@@ -110,7 +111,8 @@ def test_multi_head_attention_sdpa(args):
             atol=9e-7,
             rtol=9e-4,
         )
-        assert torch.allclose(cache, cache_with_sdpa)
+        assert torch.allclose(cache[0], cache_with_sdpa[0])
+        assert torch.allclose(cache[1], cache_with_sdpa[1])
 
         q = output
 
@@ -170,7 +172,8 @@ def test_rel_position_multi_head_attention_sdpa(args):
         output_with_sdpa * mask.transpose(1, 2),
         atol=9e-7,
     )
-    assert torch.allclose(cache, cache_with_sdpa)
+    assert torch.allclose(cache[0], cache_with_sdpa[0])
+    assert torch.allclose(cache[1], cache_with_sdpa[1])
 
     n_blocks = 12
     torch.manual_seed(777)
@@ -220,7 +223,8 @@ def test_rel_position_multi_head_attention_sdpa(args):
             atol=9e-7,
             rtol=9e-4,
         )
-        assert torch.allclose(cache, cache_with_sdpa)
+        assert torch.allclose(cache[0], cache_with_sdpa[0])
+        assert torch.allclose(cache[1], cache_with_sdpa[1])
         q = output
 
 

--- a/test/wenet/whisper/test_whisper.py
+++ b/test/wenet/whisper/test_whisper.py
@@ -318,7 +318,8 @@ def test_model(model, audio_path):
                                        attn_ln_x,
                                        attn_ln_x,
                                        masks,
-                                       cache=torch.zeros((0, 0, 0, 0)))
+                                       cache=(torch.zeros((0, 0, 0, 0)),
+                                              torch.zeros(0, 0, 0, 0)))
             wenet_layers_output.append({
                 "name": "enc.layer{}.attn".format(i),
                 "value": x_att.clone()

--- a/wenet/branchformer/encoder_layer.py
+++ b/wenet/branchformer/encoder_layer.py
@@ -19,6 +19,8 @@ import torch
 import torch.nn as nn
 from typing import Optional, Tuple
 
+from wenet.transformer.attention import T_CACHE
+
 
 class BranchformerEncoderLayer(torch.nn.Module):
     """Branchformer encoder layer module.
@@ -112,10 +114,11 @@ class BranchformerEncoderLayer(torch.nn.Module):
         mask: torch.Tensor,
         pos_emb: torch.Tensor,
         mask_pad: torch.Tensor = torch.ones((0, 0, 0), dtype=torch.bool),
-        att_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
+        att_cache: T_CACHE = (torch.zeros(
+            (0, 0, 0, 0)), torch.zeros(0, 0, 0, 0)),
         cnn_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
         stoch_layer_coeff: float = 1.0
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor, T_CACHE, torch.Tensor]:
         # Two branches
         x1 = x
         x2 = x
@@ -207,9 +210,10 @@ class BranchformerEncoderLayer(torch.nn.Module):
         mask: torch.Tensor,
         pos_emb: torch.Tensor,
         mask_pad: torch.Tensor = torch.ones((0, 0, 0), dtype=torch.bool),
-        att_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
+        att_cache: T_CACHE = (torch.zeros(
+            (0, 0, 0, 0)), torch.zeros(0, 0, 0, 0)),
         cnn_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor, T_CACHE, torch.Tensor]:
         """Compute encoded features.
 
         Args:

--- a/wenet/e_branchformer/encoder_layer.py
+++ b/wenet/e_branchformer/encoder_layer.py
@@ -20,6 +20,8 @@ import torch
 import torch.nn as nn
 from typing import Optional, Tuple
 
+from wenet.transformer.attention import T_CACHE
+
 
 class EBranchformerEncoderLayer(torch.nn.Module):
     """E-Branchformer encoder layer module.
@@ -94,10 +96,11 @@ class EBranchformerEncoderLayer(torch.nn.Module):
         mask: torch.Tensor,
         pos_emb: torch.Tensor,
         mask_pad: torch.Tensor = torch.ones((0, 0, 0), dtype=torch.bool),
-        att_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
+        att_cache: T_CACHE = (torch.zeros(
+            (0, 0, 0, 0)), torch.zeros(0, 0, 0, 0)),
         cnn_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
         stoch_layer_coeff: float = 1.0
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor, T_CACHE, torch.Tensor]:
 
         if self.feed_forward_macaron is not None:
             residual = x
@@ -149,9 +152,10 @@ class EBranchformerEncoderLayer(torch.nn.Module):
         mask: torch.Tensor,
         pos_emb: torch.Tensor,
         mask_pad: torch.Tensor = torch.ones((0, 0, 0), dtype=torch.bool),
-        att_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
+        att_cache: T_CACHE = (torch.zeros(
+            (0, 0, 0, 0)), torch.zeros(0, 0, 0, 0)),
         cnn_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor, T_CACHE, torch.Tensor]:
         """Compute encoded features.
 
         Args:

--- a/wenet/transformer/attention.py
+++ b/wenet/transformer/attention.py
@@ -192,7 +192,6 @@ class MultiHeadedAttention(nn.Module):
             # >>> torch.equal(b, c)        # True
             # >>> d = torch.split(a, 2, dim=-1)
             # >>> torch.equal(d[0], d[1])  # True
-            print(cache)
             key_cache, value_cache = cache
             if key_cache.size(0) > 0:
                 k = torch.cat([key_cache, k], dim=2)

--- a/wenet/transformer/decoder.py
+++ b/wenet/transformer/decoder.py
@@ -18,6 +18,7 @@ from typing import Dict, Tuple, List, Optional
 import torch
 import torch.utils.checkpoint as ckpt
 import logging
+from wenet.transformer.attention import T_CACHE
 
 from wenet.transformer.decoder_layer import DecoderLayer
 from wenet.utils.class_utils import (
@@ -222,7 +223,7 @@ class TransformerDecoder(torch.nn.Module):
         memory_mask: torch.Tensor,
         tgt: torch.Tensor,
         tgt_mask: torch.Tensor,
-        cache: Dict[str, Dict[str, torch.Tensor]],
+        cache: Dict[str, Dict[str, T_CACHE]],
     ) -> torch.Tensor:
         """Forward one step.
             This is only used for decoding.

--- a/wenet/transformer/decoder_layer.py
+++ b/wenet/transformer/decoder_layer.py
@@ -17,6 +17,7 @@ from typing import Dict, Optional, Tuple
 
 import torch
 from torch import nn
+from wenet.transformer.attention import T_CACHE
 
 from wenet.utils.class_utils import WENET_NORM_CLASSES
 
@@ -70,7 +71,7 @@ class DecoderLayer(nn.Module):
         tgt_mask: torch.Tensor,
         memory: torch.Tensor,
         memory_mask: torch.Tensor,
-        cache: Optional[Dict[str, Optional[torch.Tensor]]] = None
+        cache: Optional[Dict[str, Optional[T_CACHE]]] = None
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Compute decoded features.
 
@@ -105,7 +106,7 @@ class DecoderLayer(nn.Module):
         if att_cache is None:
             tgt_q = tgt
             tgt_q_mask = tgt_mask
-            att_cache = torch.empty(0, 0, 0, 0)
+            att_cache = (torch.empty(0, 0, 0, 0), torch.empty(0, 0, 0, 0))
         else:
             tgt_q = tgt[:, -1:, :]
             residual = residual[:, -1:, :]
@@ -129,7 +130,8 @@ class DecoderLayer(nn.Module):
             if self.normalize_before:
                 x = self.norm2(x)
             if cross_att_cache is None:
-                cross_att_cache = torch.empty(0, 0, 0, 0)
+                cross_att_cache = (torch.empty(0, 0, 0,
+                                               0), torch.empty(0, 0, 0, 0))
             x, new_cross_cache = self.src_attn(x,
                                                memory,
                                                memory,

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -263,12 +263,20 @@ class BaseEncoder(torch.nn.Module):
             # NOTE(xcsong): Before layer.forward
             #   shape(att_cache[i:i + 1]) is (1, head, cache_t1, d_k * 2),
             #   shape(cnn_cache[i])       is (b=1, hidden-dim, cache_t2)
-            xs, _, new_att_cache, new_cnn_cache = layer(
+            if elayers == 0:
+                kv_cache = (att_cache, att_cache)
+            else:
+                i_kv_cache = att_cache[i:i + 1]
+                size = att_cache.size(-1) // 2
+                kv_cache = (i_kv_cache[:, :, :, :size], i_kv_cache[:, :, :,
+                                                                   size:])
+            xs, _, new_kv_cache, new_cnn_cache = layer(
                 xs,
                 att_mask,
                 pos_emb,
-                att_cache=att_cache[i:i + 1] if elayers > 0 else att_cache,
+                att_cache=kv_cache,
                 cnn_cache=cnn_cache[i] if cnn_cache.size(0) > 0 else cnn_cache)
+            new_att_cache = torch.cat(new_kv_cache, dim=-1)
             # NOTE(xcsong): After layer.forward
             #   shape(new_att_cache) is (1, head, attention_key_size, d_k * 2),
             #   shape(new_cnn_cache) is (b=1, hidden-dim, cache_t2)

--- a/wenet/transformer/encoder_layer.py
+++ b/wenet/transformer/encoder_layer.py
@@ -19,6 +19,7 @@ from typing import Optional, Tuple
 
 import torch
 from torch import nn
+from wenet.transformer.attention import T_CACHE
 
 from wenet.utils.class_utils import WENET_NORM_CLASSES
 
@@ -66,9 +67,10 @@ class TransformerEncoderLayer(nn.Module):
         mask: torch.Tensor,
         pos_emb: torch.Tensor,
         mask_pad: torch.Tensor = torch.ones((0, 0, 0), dtype=torch.bool),
-        att_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
+        att_cache: T_CACHE = (torch.zeros(
+            (0, 0, 0, 0)), torch.zeros((0, 0, 0, 0))),
         cnn_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor, T_CACHE, torch.Tensor]:
         """Compute encoded features.
 
         Args:
@@ -180,9 +182,10 @@ class ConformerEncoderLayer(nn.Module):
         mask: torch.Tensor,
         pos_emb: torch.Tensor,
         mask_pad: torch.Tensor = torch.ones((0, 0, 0), dtype=torch.bool),
-        att_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
+        att_cache: T_CACHE = (torch.zeros(
+            (0, 0, 0, 0)), torch.zeros((0, 0, 0, 0))),
         cnn_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor, T_CACHE, torch.Tensor]:
         """Compute encoded features.
 
         Args:


### PR DESCRIPTION
TODO:
- [x] fix xxx formers

QA:
#### 1  为什么要修改成 Tuple[torch.Tensor, torch.Tensor]
- torch.cat 和torch.split 在attention里边没有必要
- LLM 的实现， 会把 k v cache 先申请max_len的， 然后tuple（k_cache, v_cache）, 在attention 里边去写 copy （去写最一开始申请好的）
详细见：
   - https://github.com/google/gemma_pytorch/blob/main/gemma/model.py#L268-#L264
   - https://github.com/meta-llama/llama/blob/main/llama/model.py#L236-#L286

#### 2 该pr 封装函数 _update_kv_cache: 
  - 避免到处同样的代码，
  -  为将来支持LLM
  - jit /onnx 导出， forward_chunk 接口含义不变 (不影响jit 和onnx etc)