### PR TITLE
[transformer] set use_reentrant=False for gradient ckpt

### DIFF
--- a/wenet/paraformer/layers.py
+++ b/wenet/paraformer/layers.py
@@ -291,7 +291,7 @@ class SanmEncoder(BaseEncoder):
             xs, _, _, _ = layer(xs, chunk_masks, pos_emb, mask_pad)
         for layer in self.encoders:
             xs, _, _, _ = ckpt.checkpoint(layer.__call__, xs, chunk_masks,
-                                          pos_emb, mask_pad)
+                                          pos_emb, mask_pad, use_reentrant=False)
         return xs
 
 
@@ -481,7 +481,7 @@ class SanmDecoder(TransformerDecoder):
                 x, _, _, _ = layer(x, tgt_mask, memory, memory_mask)
             else:
                 x, _, _, _ = ckpt.checkpoint(layer.__call__, x, tgt_mask,
-                                             memory, memory_mask)
+                                             memory, memory_mask, use_reentrant=False)
         for layer in self.decoders3:
             x = layer(x)
         return x

--- a/wenet/transformer/decoder.py
+++ b/wenet/transformer/decoder.py
@@ -214,7 +214,8 @@ class TransformerDecoder(torch.nn.Module):
                                     memory_mask: torch.Tensor) -> torch.Tensor:
         for layer in self.decoders:
             x, tgt_mask, memory, memory_mask = ckpt.checkpoint(
-                layer.__call__, x, tgt_mask, memory, memory_mask)
+                layer.__call__, x, tgt_mask, memory, memory_mask,
+                use_reentrant=False)
         return x
 
     def forward_one_step(

--- a/wenet/transformer/encoder.py
+++ b/wenet/transformer/encoder.py
@@ -192,7 +192,7 @@ class BaseEncoder(torch.nn.Module):
         for layer in self.encoders:
             xs, chunk_masks, _, _ = ckpt.checkpoint(layer.__call__, xs,
                                                     chunk_masks, pos_emb,
-                                                    mask_pad)
+                                                    mask_pad, use_reentrant=False)
         return xs
 
     def forward_chunk(


### PR DESCRIPTION
According to pytorch API: https://pytorch.org/docs/stable/checkpoint.html

It is recommended to use `use_reentrant=False`.

![image](https://github.com/wenet-e2e/wenet/assets/13466943/2bb4268e-4432-4fbd-aba1-405d95a1256a)
