### PR TITLE
[websocket] 8k and 16k support

### DIFF
--- a/runtime/core/bin/websocket_client_main.cc
+++ b/runtime/core/bin/websocket_client_main.cc
@@ -34,7 +34,7 @@ int main(int argc, char* argv[]) {
   client.SendStartSignal();
 
   wenet::WavReader wav_reader(FLAGS_wav_path);
-  int sample_rate = client.sample_rate_; 
+  int sample_rate = client.sample_rate_;
   CHECK_EQ(wav_reader.sample_rate(), sample_rate);
   const int num_samples = wav_reader.num_samples();
   // Send data every 0.5 second

--- a/runtime/core/bin/websocket_client_main.cc
+++ b/runtime/core/bin/websocket_client_main.cc
@@ -34,8 +34,7 @@ int main(int argc, char* argv[]) {
   client.SendStartSignal();
 
   wenet::WavReader wav_reader(FLAGS_wav_path);
-  int sample_rate = client.sample_rate_;
-  // 8K and 16K support 
+  int sample_rate = client.sample_rate_; 
   CHECK_EQ(wav_reader.sample_rate(), sample_rate);
   const int num_samples = wav_reader.num_samples();
   // Send data every 0.5 second

--- a/runtime/core/bin/websocket_client_main.cc
+++ b/runtime/core/bin/websocket_client_main.cc
@@ -22,18 +22,20 @@ DEFINE_int32(port, 10086, "port of websocket server");
 DEFINE_int32(nbest, 1, "n-best of decode result");
 DEFINE_string(wav_path, "", "test wav file path");
 DEFINE_bool(continuous_decoding, false, "continuous decoding mode");
+DEFINE_int32(sr, 16000, "audio sample rate");
 
 int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, false);
   google::InitGoogleLogging(argv[0]);
   wenet::WebSocketClient client(FLAGS_hostname, FLAGS_port);
   client.set_nbest(FLAGS_nbest);
+  client.set_sr(FLAGS_sr);
   client.set_continuous_decoding(FLAGS_continuous_decoding);
   client.SendStartSignal();
 
   wenet::WavReader wav_reader(FLAGS_wav_path);
-  const int sample_rate = 16000;
-  // Only support 16K
+  int sample_rate = client.sample_rate_;
+  // 8K and 16K support 
   CHECK_EQ(wav_reader.sample_rate(), sample_rate);
   const int num_samples = wav_reader.num_samples();
   // Send data every 0.5 second

--- a/runtime/core/websocket/websocket_client.h
+++ b/runtime/core/websocket/websocket_client.h
@@ -32,13 +32,13 @@ namespace wenet {
 namespace beast = boost::beast;          // from <boost/beast.hpp>
 namespace http = beast::http;            // from <boost/beast/http.hpp>
 namespace websocket = beast::websocket;  // from <boost/beast/websocket.hpp>
-namespace asio = boost::asio;            // from <boost/asio.hpp>
+namespace asio = boost::asio;            // from <boost/asio.hpp> or
 using tcp = boost::asio::ip::tcp;        // from <boost/asio/ip/tcp.hpp>
 
 class WebSocketClient {
  public:
   WebSocketClient(const std::string& host, int port);
-
+  int sample_rate_;
   void SendTextData(const std::string& data);
   void SendBinaryData(const void* data, size_t size);
   void ReadLoopFunc();
@@ -47,6 +47,7 @@ class WebSocketClient {
   void SendStartSignal();
   void SendEndSignal();
   void set_nbest(int nbest) { nbest_ = nbest; }
+  void set_sr(int sr) { sample_rate_ = sr; }
   void set_continuous_decoding(bool continuous_decoding) {
     continuous_decoding_ = continuous_decoding;
   }

--- a/runtime/core/websocket/websocket_client.h
+++ b/runtime/core/websocket/websocket_client.h
@@ -32,7 +32,7 @@ namespace wenet {
 namespace beast = boost::beast;          // from <boost/beast.hpp>
 namespace http = beast::http;            // from <boost/beast/http.hpp>
 namespace websocket = beast::websocket;  // from <boost/beast/websocket.hpp>
-namespace asio = boost::asio;            // from <boost/asio.hpp> or
+namespace asio = boost::asio;            // from <boost/asio.hpp>
 using tcp = boost::asio::ip::tcp;        // from <boost/asio/ip/tcp.hpp>
 
 class WebSocketClient {


### PR DESCRIPTION
Wenet previously only supported 16K.
I want to apply this to the call center and needed support for 8k.

I modified part of the code from websocket_client
The code was changed to allow 8k audio to be decoded using the --sr parameter.

You can decode 8k audio by modifying the code below.

./build/bin/websocket_client_main \
  --hostname x.x.x.x --port xxxxx \
  --sr 8000 \
  --wav_path $wav_path 2>&1 | tee client.log

@Mddct could you check this modification ? 