### PR TITLE
[Dataset] Resolving the 'Illegal seek' error

### DIFF
--- a/wenet/dataset/datapipes.py
+++ b/wenet/dataset/datapipes.py
@@ -337,7 +337,7 @@ class TarsDataPipe(IterDataPipe):
             assert 'stream' in sample
             try:
                 with tarfile.open(fileobj=sample['stream'],
-                                  mode="r:*") as stream:
+                                  mode="r|*") as stream:
                     prev_prefix = None
                     example = {
                         'file_name': sample['file_name'],


### PR DESCRIPTION
When handling network resources, it is necessary to open tar files using the mode 'r|' instead of 'r:', as the former does not attempt seek operations and is suitable for sequential reading.








