### PR TITLE
fix segmentfault in (#2506)

### DIFF
--- a/wenet/dataset/processor.py
+++ b/wenet/dataset/processor.py
@@ -37,6 +37,21 @@ lid = LanguageIdentifier.from_modelstring(model, norm_probs=True)
 
 logging.getLogger('langid').setLevel(logging.INFO)
 
+import os
+try:
+    cpu_info = os.popen("lscpu | grep 'Vendor ID'").read()
+    # 0x48 --> HiSilicon
+    if (cpu_info.rstrip().split(" ")[-1] == "0x48"):
+        # NOTE (MengqingCao): set number of threads in the subprocesses to 1
+        # Why? There may be some operators ultilizing multi-threads in processor,
+        # causing possibly deadlock in Kunpeng.
+        # Similar issue in PyTorch: https://github.com/pytorch/pytorch/issues/45198
+        torch.set_num_threads(1)
+except Exception as ex:
+    logging.warning('Failed to set number of thread in Kunpeng, \
+        this may cause segmentfault while dataloading, \
+        ignore this warning if you are not using Kunpeng')
+
 
 class UrlOpenError(Exception):
 


### PR DESCRIPTION
解决Kunpeng cpu上 segmentfault 的同时，避免了 deepspeed 的重复初始化。
只粗略定位到是数据集处理模块 processor.py 中存在多线程处理的操作，造成了多进程读取数据时的死锁问题。因此在 processor 开始处设置线程数为1，来防止死锁和 segmentfault

为防止侵入式修改，在读取 cpu 硬件信息判断为 Kunpeng 后才进行此修改。

        # set number of threads in the subprocesses to 1
        # Why? There may be some operators ultilizing multi-threads in processor,
        # causing possibly deadlock in Kunpeng.
        # Similar issue in PyTorch: https://github.com/pytorch/pytorch/issues/45198
  - fix segmentfault in Kunpeng (#2506)
  - avoids the repeated initialization of deepspeed causing by (#2507)