### PR TITLE
unuse forward when jit exporting transducer

### DIFF
--- a/wenet/transducer/transducer.py
+++ b/wenet/transducer/transducer.py
@@ -90,6 +90,7 @@ class Transducer(ASRModel):
                 normalize_length=length_normalized_loss,
             )
 
+    @torch.jit.unused
     def forward(
         self,
         batch: dict,


### PR DESCRIPTION
Error when jit exporting transducer with previous code
Found this forward func is not necessary for jit export (like transformer/asr_model.py, line 77 and 78)