### PR TITLE
Using hamming window for Paraformer frontend.

### DIFF
--- a/wenet/cli/paraformer_model.py
+++ b/wenet/cli/paraformer_model.py
@@ -40,7 +40,8 @@ class Paraformer:
                             frame_length=25,
                             frame_shift=10,
                             energy_floor=0.0,
-                            sample_frequency=self.resample_rate)
+                            sample_frequency=self.resample_rate,
+                            window_type="hamming")
         feats = feats.unsqueeze(0)
         feats_lens = torch.tensor([feats.size(1)],
                                   dtype=torch.int64,

--- a/wenet/dataset/processor.py
+++ b/wenet/dataset/processor.py
@@ -231,7 +231,8 @@ def compute_fbank(sample,
                   num_mel_bins=23,
                   frame_length=25,
                   frame_shift=10,
-                  dither=0.0):
+                  dither=0.0,
+                  window_type="povey"):
     """ Extract fbank
 
         Args:
@@ -253,7 +254,8 @@ def compute_fbank(sample,
                       frame_shift=frame_shift,
                       dither=dither,
                       energy_floor=0.0,
-                      sample_frequency=sample_rate)
+                      sample_frequency=sample_rate,
+                      window_type=window_type)
     sample['feat'] = mat
     return sample
 

--- a/wenet/paraformer/convert_paraformer_to_wenet_config_and_ckpt.py
+++ b/wenet/paraformer/convert_paraformer_to_wenet_config_and_ckpt.py
@@ -140,6 +140,7 @@ def convert_to_wenet_yaml(configs, wenet_yaml_path: str,
     configs['dataset_conf']['fbank_conf']['frame_shift'] = 10
     configs['dataset_conf']['fbank_conf']['frame_length'] = 25
     configs['dataset_conf']['fbank_conf']['dither'] = 0.1
+    configs['dataset_conf']['fbank_conf']['window_type'] = 'hamming'
     configs['dataset_conf']['spec_sub'] = False
     configs['dataset_conf']['spec_trim'] = False
     configs['dataset_conf']['shuffle'] = True


### PR DESCRIPTION
The default window in the `Paraformer` frontend is `hamming`. We can find more details [here](https://github.com/modelscope/FunASR/blob/42479a68cb3b2a95338d6c27a3ac9a5e66c60405/funasr/frontends/wav_frontend.py#L134). However, the default window in `kaldi.fbank` is `povey`, as specified [here](https://pytorch.org/audio/stable/generated/torchaudio.compliance.kaldi.fbank.html#torchaudio.compliance.kaldi.fbank). This different window maybe a little mismatch. As mentioned in line 44 of [this document](https://kaldi-asr.org/doc/feature-window_8h_source.html):

> "povey" is a window I made to be similar to Hamming but to go to zero at the edges, it's pow((0.5 - 0.5cos(n/N2*pi)), 0.85) I just don't think the Hamming window makes sense as a windowing function.