### PR TITLE
Update subsampling.py

### DIFF
--- a/wenet/transformer/subsampling.py
+++ b/wenet/transformer/subsampling.py
@@ -388,3 +388,7 @@ class StackNFramesSubsampling(BaseSubsampling):
         x = self.norm(x)
         x = self.out(x)
         return x, pos_emb, new_mask.unsqueeze(1)
+
+    def position_encoding(self, offset: Union[int, torch.Tensor],
+                          size: int) -> torch.Tensor:
+        return self.pos_enc_class.position_encoding(offset, size)


### PR DESCRIPTION
The StackNFramesSubsampling module was missing the pos_enc attribute, which caused an AttributeError when pos_enc.position_encoding was called in the forward_chunk.