### PR TITLE
Introducing WeNet Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 | [**Runtime**](https://github.com/wenet-e2e/wenet/tree/main/runtime)
 | [**Pretrained Models**](docs/pretrained_models.md)
 | [**HuggingFace**](https://huggingface.co/spaces/wenet/wenet_demo)
+| [**Ask WeNet Guru**](https://gurubase.io/g/wenet)
 
 **We** share **Net** together.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [WeNet Guru](https://gurubase.io/g/wenet) to Gurubase. WeNet Guru uses the data from this repo and data from the [docs](https://wenet.org.cn/wenet/) to answer questions by leveraging the LLM.

In this PR, I showcased the "WeNet Guru", which highlights that WeNet now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable WeNet Guru in Gurubase, just let me know that's totally fine.