### PR TITLE
[firered] support enctor speech enc from llm base model

### DIFF
--- a/wenet/firered/convert_FireRed_AED_L_to_wenet_config_and_ckpt.py
+++ b/wenet/firered/convert_FireRed_AED_L_to_wenet_config_and_ckpt.py
@@ -167,6 +167,8 @@ def convert_to_wenet_state_dict(firered_state_dict, wenet_state_dict_path):
         "===================== start CKPT Conversion ========================="
     )
     for name in firered_state_dict.keys():
+        if 'llm.base_model' in name:
+            continue
         original_name = copy.deepcopy(name)
         if 'input_preprocessor' in original_name:
             name = name.replace("input_preprocessor", "embed")


### PR DESCRIPTION
after： https://github.com/wenet-e2e/wenet/pull/2680

llm base的 https://huggingface.co/FireRedTeam/FireRedASR-LLM-L/tree/main 模型开源， 模型只是多了llm和projector部分， 该pr抽出enc， 可供west等项目使用

```bash
llm.base_model.model.model.layers.26.mlp.down_proj.lora_B.default.weight
llm.base_model.model.model.layers.27.self_attn.q_proj.lora_A.default.weight
llm.base_model.model.model.layers.27.self_attn.q_proj.lora_B.default.weight
llm.base_model.model.model.layers.27.self_attn.k_proj.lora_A.default.weight
llm.base_model.model.model.layers.27.self_attn.k_proj.lora_B.default.weight
llm.base_model.model.model.layers.27.self_attn.v_proj.lora_A.default.weight
llm.base_model.model.model.layers.27.self_attn.v_proj.lora_B.default.weight
llm.base_model.model.model.layers.27.self_attn.o_proj.lora_A.default.weight
llm.base_model.model.model.layers.27.self_attn.o_proj.lora_B.default.weight
llm.base_model.model.model.layers.27.mlp.gate_proj.lora_A.default.weight
llm.base_model.model.model.layers.27.mlp.gate_proj.lora_B.default.weight
llm.base_model.model.model.layers.27.mlp.up_proj.lora_A.default.weight
llm.base_model.model.model.layers.27.mlp.up_proj.lora_B.default.weight
llm.base_model.model.model.layers.27.mlp.down_proj.lora_A.default.weight
llm.base_model.model.model.layers.27.mlp.down_proj.lora_B.default.weight
encoder_projector.linear1.weight
encoder_projector.linear1.bias
encoder_projector.linear2.weight
encoder_projector.linear2.bias
```