### PR TITLE
fix firered/subsampling.py where x_mask shape may not be same as x shape

### DIFF
--- a/wenet/models/firered/subsampling.py
+++ b/wenet/models/firered/subsampling.py
@@ -64,8 +64,13 @@ class FireRedConv2dSubsampling4(Conv2dSubsampling4):
         x_lens = torch.sum(x_mask.squeeze(1), dim=1)
         x_lens = x_lens + self.right_context
         x_mask = make_non_pad_mask(x_lens).unsqueeze(1)
+        mask_seq = x_mask.size(2)
         x = torch.nn.functional.pad(x, (0, 0, 0, self.right_context),
                                     'constant', 0.0)
+        x_seq = x.size(1)
+        if x_seq > mask_seq:
+            x_mask = torch.nn.functional.pad(x_mask, (0, x_seq - mask_seq, 0,0,0,0),'constant', 0.0)
+
         x = x.unsqueeze(1)  # (b, c=1, t, f)
         x = self.conv(x)
         b, c, t, f = x.size()


### PR DESCRIPTION
当我使用wenet进行firered 的encoder部分导出时，我发现，
输入encoder的batch size==1， 如果事先手动给feat进行padding(例如从1013 padding到2000)，但是输入的feat_len为1013时，会产生错误。具体报错截图如下：
<img width="1533" height="507" alt="image" src="https://github.com/user-attachments/assets/00951973-2a66-4aeb-8618-f12283294baa" />
具体分析发现，在firered/subsampling文件中，没有保证在padding right_context后的x_mask和x的seq等长。
所以在该情况下，我在下面显示地将两者做了一个对齐