### PR TITLE
[firered] fix after_nrom

### DIFF
--- a/wenet/models/firered/encoder.py
+++ b/wenet/models/firered/encoder.py
@@ -126,3 +126,4 @@ class FireRedConformerEncoder(BaseEncoder):
                 norm_eps=norm_eps,
             ) for _ in range(num_blocks)
         ])
+        self.after_norm = torch.nn.Identity()


### PR DESCRIPTION
model does not use `after_nrom`. Without this line, training will result in an error, indicating that `find_unused_parameters=True` is required.