### PR TITLE
[bugfix] firered conv2dsubsampling4 and transformer cmvn for padded inputs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ pycodestyle==2.6.0
 pyflakes==2.2.0
 clang-format==17.0.6
 cpplint==1.6.1
-torch>=2.1.2
-torchaudio>=2.1.2
+torch==2.6.0
+torchaudio>=2.6.0
 tqdm
 deepspeed>=0.14.0
 librosa

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,6 @@ torchaudio>=2.1.2
 tqdm
 deepspeed>=0.14.0
 librosa
-openai-whisper==20231117
+openai-whisper
 pre-commit==3.5.0
 langid

--- a/wenet/dataset/processor.py
+++ b/wenet/dataset/processor.py
@@ -41,7 +41,7 @@ import os
 try:
     cpu_info = os.popen("lscpu | grep 'Vendor ID'").read()
     # 0x48 --> HiSilicon
-    if (cpu_info.rstrip().split(" ")[-1] == "0x48"):
+    if (cpu_info.rstrip().split(" ")[-1] == "0x48") or (cpu_info.rstrip().split(" ")[-1].lower() == "hisilicon"):
         # NOTE (MengqingCao): set number of threads in the subprocesses to 1
         # Why? There may be some operators ultilizing multi-threads in processor,
         # causing possibly deadlock in Kunpeng.

--- a/wenet/models/firered/subsampling.py
+++ b/wenet/models/firered/subsampling.py
@@ -70,6 +70,6 @@ class FireRedConv2dSubsampling4(Conv2dSubsampling4):
         b, c, t, f = x.size()
         x = self.out(x.transpose(1, 2).contiguous().view(b, t, c * f))
         x, pos_emb = self.pos_enc(x, offset)
-        x_lens = torch.floor((torch.floor((x_lens - 1 ) / 2) - 1 ) / 2).to(x_lens.dtype)
+        x_lens = torch.floor((torch.floor((x_lens - 1) / 2) - 1) / 2).to(x_lens.dtype)
         mask = make_non_pad_mask(x_lens).unsqueeze(1)
         return x, pos_emb, mask

--- a/wenet/models/firered/subsampling.py
+++ b/wenet/models/firered/subsampling.py
@@ -63,7 +63,6 @@ class FireRedConv2dSubsampling4(Conv2dSubsampling4):
 
         x_lens = torch.sum(x_mask.squeeze(1), dim=1)
         x_lens = x_lens + self.right_context
-        x_mask = make_non_pad_mask(x_lens).unsqueeze(1)
         x = torch.nn.functional.pad(x, (0, 0, 0, self.right_context),
                                     'constant', 0.0)
         x = x.unsqueeze(1)  # (b, c=1, t, f)
@@ -71,5 +70,6 @@ class FireRedConv2dSubsampling4(Conv2dSubsampling4):
         b, c, t, f = x.size()
         x = self.out(x.transpose(1, 2).contiguous().view(b, t, c * f))
         x, pos_emb = self.pos_enc(x, offset)
-        mask = x_mask[:, :, :-2:2][:, :, :-2:2]
+        x_lens = torch.floor((torch.floor((x_lens - 1 ) / 2) - 1 ) / 2).to(x_lens.dtype)
+        mask = make_non_pad_mask(x_lens).unsqueeze(1)
         return x, pos_emb, mask

--- a/wenet/models/transformer/encoder.py
+++ b/wenet/models/transformer/encoder.py
@@ -153,6 +153,7 @@ class BaseEncoder(torch.nn.Module):
         masks = ~make_pad_mask(xs_lens, T).unsqueeze(1)  # (B, 1, T)
         if self.global_cmvn is not None:
             xs = self.global_cmvn(xs)
+        xs = xs * masks.transpose(1, 2)
         xs, pos_emb, masks = self.embed(xs, masks)
         mask_pad = masks  # (B, 1, T/subsample_rate)
         chunk_masks = add_optional_chunk_mask(


### PR DESCRIPTION
1. Incorrect mask computation in conv2dsubsampling4

Current implementation:
```
mask = x_mask[:, :, :-2:2][:, :, :-2:2]
```

This slicing-based mask downsampling is inaccurate and does not correctly reflect the actual output lengths of conv2d subsampling.

I propose to recompute the mask from sequence lengths instead:
```
x_lens = torch.floor((torch.floor((x_lens - 1) / 2) - 1) / 2).to(x_lens.dtype)
mask = make_non_pad_mask(x_lens).unsqueeze(1)
```

This matches the real length transformation of conv2dsubsampling4 and avoids accumulated alignment errors.

2. CMVN is applied to padded positions before convolution

Current code:
```
if self.global_cmvn is not None:
    xs = self.global_cmvn(xs)
xs, pos_emb, masks = self.embed(xs, masks)
```

Here CMVN is applied to padded frames. Since the embedding module contains convolution with right context, padded positions (after CMVN) will leak into valid frames, leading to incorrect features.

CMVN should ignore padded positions, or padded frames should be explicitly zeroed after CMVN before convolution.
```
if self.global_cmvn is not None:
    xs = self.global_cmvn(xs)
xs = xs * masks.transpose(1, 2)
xs, pos_emb, masks = self.embed(xs, masks)
```