### PR TITLE
Fix WeTextProcessing build and add ITN (Inverse Text Normalization) support for iOS runtime

### DIFF
--- a/runtime/core/cmake/glog.cmake
+++ b/runtime/core/cmake/glog.cmake
@@ -1,6 +1,25 @@
+# Disable dbghelp (Windows only) for non-Windows platforms
+set(WITH_DBGHELP OFF CACHE BOOL "Disable dbghelp on non-Windows platforms" FORCE)
+
 FetchContent_Declare(glog
   URL      https://github.com/google/glog/archive/v0.4.0.zip
   URL_HASH SHA256=9e1b54eb2782f53cd8af107ecf08d2ab64b8d0dc2b7f5594472f3bd63ca85cdc
 )
 FetchContent_MakeAvailable(glog)
 include_directories(${glog_SOURCE_DIR}/src ${glog_BINARY_DIR})
+
+# Remove dbghelp from glog interface link libraries on non-Windows platforms
+# glog incorrectly adds dbghelp as a link dependency even on non-Windows
+if(NOT WIN32)
+  get_target_property(glog_interface_libs glog INTERFACE_LINK_LIBRARIES)
+  if(glog_interface_libs)
+    set(new_libs "")
+    foreach(lib ${glog_interface_libs})
+      string(FIND "${lib}" "dbghelp" dbghelp_pos)
+      if(dbghelp_pos EQUAL -1)
+        list(APPEND new_libs "${lib}")
+      endif()
+    endforeach()
+    set_target_properties(glog PROPERTIES INTERFACE_LINK_LIBRARIES "${new_libs}")
+  endif()
+endif()

--- a/runtime/core/cmake/wetextprocessing.cmake
+++ b/runtime/core/cmake/wetextprocessing.cmake
@@ -7,6 +7,14 @@ if(NOT ANDROID)
   include_directories(${wetextprocessing_SOURCE_DIR}/runtime)
   add_subdirectory(${wetextprocessing_SOURCE_DIR}/runtime/utils)
   add_subdirectory(${wetextprocessing_SOURCE_DIR}/runtime/processor)
+
+  # Disable code signing for wetext_processor_c shared library on iOS
+  if(IOS)
+    set_target_properties(wetext_processor_c PROPERTIES
+      XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO"
+      XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
+    )
+  endif()
 else()
   include(ExternalProject)
   set(ANDROID_CMAKE_ARGS
@@ -32,4 +40,3 @@ else()
   link_directories(${BINARY_DIR}/processor ${BINARY_DIR}/utils)
   link_libraries(wetext_utils)
 endif()
-

--- a/runtime/core/patch/openfst/src/include/fst/bi-table.h
+++ b/runtime/core/patch/openfst/src/include/fst/bi-table.h
@@ -1,0 +1,480 @@
+// See www.openfst.org for extensive documentation on this weighted
+// finite-state transducer library.
+//
+// Classes for representing a bijective mapping between an arbitrary entry
+// of type T and a signed integral ID.
+
+#ifndef FST_BI_TABLE_H_
+#define FST_BI_TABLE_H_
+
+#include <deque>
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <fst/log.h>
+#include <fst/memory.h>
+#include <unordered_set>
+
+namespace fst {
+
+// Bitables model bijective mappings between entries of an arbitrary type T and
+// an signed integral ID of type I. The IDs are allocated starting from 0 in
+// order.
+//
+// template <class I, class T>
+// class BiTable {
+//  public:
+//
+//   // Required constructors.
+//   BiTable();
+//
+//   // Looks up integer ID from entry. If it doesn't exist and insert
+//   / is true, adds it; otherwise, returns -1.
+//   I FindId(const T &entry, bool insert = true);
+//
+//   // Looks up entry from integer ID.
+//   const T &FindEntry(I) const;
+//
+//   // Returns number of stored entries.
+//   I Size() const;
+// };
+
+// An implementation using a hash map for the entry to ID mapping. H is the
+// hash function and E is the equality function. If passed to the constructor,
+// ownership is given to this class.
+template <class I, class T, class H, class E = std::equal_to<T>>
+class HashBiTable {
+ public:
+  // Reserves space for table_size elements. If passing H and E to the
+  // constructor, this class owns them.
+  explicit HashBiTable(size_t table_size = 0, H *h = nullptr, E *e = nullptr) :
+      hash_func_(h ? h : new H()), hash_equal_(e ? e : new E()),
+      entry2id_(table_size, *hash_func_, *hash_equal_) {
+    if (table_size) id2entry_.reserve(table_size);
+  }
+
+  HashBiTable(const HashBiTable<I, T, H, E> &table)
+      : hash_func_(new H(*table.hash_func_)),
+        hash_equal_(new E(*table.hash_equal_)),
+        entry2id_(table.entry2id_.begin(), table.entry2id_.end(),
+                  table.entry2id_.size(), *hash_func_, *hash_equal_),
+        id2entry_(table.id2entry_) {}
+
+  I FindId(const T &entry, bool insert = true) {
+    if (!insert) {
+      const auto it = entry2id_.find(entry);
+      return it == entry2id_.end() ? -1 : it->second - 1;
+    }
+    I &id_ref = entry2id_[entry];
+    if (id_ref == 0) {  // T not found; stores and assigns a new ID.
+      id2entry_.push_back(entry);
+      id_ref = id2entry_.size();
+    }
+    return id_ref - 1;  // NB: id_ref = ID + 1.
+  }
+
+  const T &FindEntry(I s) const { return id2entry_[s]; }
+
+  I Size() const { return id2entry_.size(); }
+
+  // TODO(riley): Add fancy clear-to-size, as in CompactHashBiTable.
+  void Clear() {
+    entry2id_.clear();
+    id2entry_.clear();
+  }
+
+ private:
+  std::unique_ptr<H> hash_func_;
+  std::unique_ptr<E> hash_equal_;
+  std::unordered_map<T, I, H, E> entry2id_;
+  std::vector<T> id2entry_;
+};
+
+// Enables alternative hash set representations below.
+enum HSType { HS_STL = 0, HS_DENSE = 1, HS_SPARSE = 2, HS_FLAT = 3 };
+
+// Default hash set is STL hash_set.
+template <class K, class H, class E, HSType HS>
+struct HashSet : public std::unordered_set<K, H, E, PoolAllocator<K>> {
+  explicit HashSet(size_t n = 0, const H &h = H(), const E &e = E())
+      : std::unordered_set<K, H, E, PoolAllocator<K>>(n, h, e) {}
+
+  void rehash(size_t n) {}
+};
+
+// An implementation using a hash set for the entry to ID mapping. The hash set
+// holds keys which are either the ID or kCurrentKey. These keys can be mapped
+// to entries either by looking up in the entry vector or, if kCurrentKey, in
+// current_entry_. The hash and key equality functions map to entries first. H
+// is the hash function and E is the equality function. If passed to the
+// constructor, ownership is given to this class.
+// TODO(rybach): remove support for (deprecated and unused) HS_DENSE, HS_SPARSE.
+template <class I, class T, class H, class E = std::equal_to<T>,
+          HSType HS = HS_FLAT>
+class CompactHashBiTable {
+ public:
+  friend class HashFunc;
+  friend class HashEqual;
+
+  // Reserves space for table_size elements. If passing H and E to the
+  // constructor, this class owns them.
+  explicit CompactHashBiTable(size_t table_size = 0, H *h = nullptr,
+                              E *e = nullptr) :
+        hash_func_(h ? h : new H()), hash_equal_(e ? e : new E()),
+        compact_hash_func_(*this), compact_hash_equal_(*this),
+        keys_(table_size, compact_hash_func_, compact_hash_equal_) {
+    if (table_size) id2entry_.reserve(table_size);
+  }
+
+  CompactHashBiTable(const CompactHashBiTable<I, T, H, E, HS> &table)
+      : hash_func_(new H(*table.hash_func_)),
+        hash_equal_(new E(*table.hash_equal_)),
+        compact_hash_func_(*this), compact_hash_equal_(*this),
+        keys_(table.keys_.size(), compact_hash_func_, compact_hash_equal_),
+        id2entry_(table.id2entry_) {
+    keys_.insert(table.keys_.begin(), table.keys_.end());
+  }
+
+  I FindId(const T &entry, bool insert = true) {
+    current_entry_ = &entry;
+    if (insert) {
+      auto result = keys_.insert(kCurrentKey);
+      if (!result.second) return *result.first;  // Already exists.
+      // Overwrites kCurrentKey with a new key value; this is safe because it
+      // doesn't affect hashing or equality testing.
+      I key = id2entry_.size();
+      const_cast<I &>(*result.first) = key;
+      id2entry_.push_back(entry);
+      return key;
+    }
+    const auto it = keys_.find(kCurrentKey);
+    return it == keys_.end() ? -1 : *it;
+  }
+
+  const T &FindEntry(I s) const { return id2entry_[s]; }
+
+  I Size() const { return id2entry_.size(); }
+
+  // Clears content; with argument, erases last n IDs.
+  void Clear(ssize_t n = -1) {
+    if (n < 0 || n >= id2entry_.size()) {  // Clears completely.
+      keys_.clear();
+      id2entry_.clear();
+    } else if (n == id2entry_.size() - 1) {  // Leaves only key 0.
+      const T entry = FindEntry(0);
+      keys_.clear();
+      id2entry_.clear();
+      FindId(entry, true);
+    } else {
+      while (n-- > 0) {
+        I key = id2entry_.size() - 1;
+        keys_.erase(key);
+        id2entry_.pop_back();
+      }
+      keys_.rehash(0);
+    }
+  }
+
+ private:
+  static_assert(std::is_signed<I>::value, "I must be a signed type");
+  // ... otherwise >= kCurrentKey comparisons as used below don't work.
+  // TODO(rybach): (1) remove kEmptyKey, kDeletedKey, (2) don't use >= for key
+  // comparison, (3) allow unsigned key types.
+  static constexpr I kCurrentKey = -1;
+  static constexpr I kEmptyKey = -2;
+  static constexpr I kDeletedKey = -3;
+
+  class HashFunc {
+   public:
+    explicit HashFunc(const CompactHashBiTable &ht) : ht_(&ht) {}
+
+    size_t operator()(I k) const {
+      if (k >= kCurrentKey) {
+        return (*ht_->hash_func_)(ht_->Key2Entry(k));
+      } else {
+        return 0;
+      }
+    }
+
+   private:
+    const CompactHashBiTable *ht_;
+  };
+
+  class HashEqual {
+   public:
+    explicit HashEqual(const CompactHashBiTable &ht) : ht_(&ht) {}
+
+    bool operator()(I k1, I k2) const {
+      if (k1 == k2) {
+        return true;
+      } else if (k1 >= kCurrentKey && k2 >= kCurrentKey) {
+        return (*ht_->hash_equal_)(ht_->Key2Entry(k1), ht_->Key2Entry(k2));
+      } else {
+        return false;
+      }
+    }
+
+   private:
+    const CompactHashBiTable *ht_;
+  };
+
+  using KeyHashSet = HashSet<I, HashFunc, HashEqual, HS>;
+
+  const T &Key2Entry(I k) const {
+    if (k == kCurrentKey) {
+      return *current_entry_;
+    } else {
+      return id2entry_[k];
+    }
+  }
+
+  std::unique_ptr<H> hash_func_;
+  std::unique_ptr<E> hash_equal_;
+  HashFunc compact_hash_func_;
+  HashEqual compact_hash_equal_;
+  KeyHashSet keys_;
+  std::vector<T> id2entry_;
+  const T *current_entry_;
+};
+
+template <class I, class T, class H, class E, HSType HS>
+constexpr I CompactHashBiTable<I, T, H, E, HS>::kCurrentKey;
+
+template <class I, class T, class H, class E, HSType HS>
+constexpr I CompactHashBiTable<I, T, H, E, HS>::kEmptyKey;
+
+template <class I, class T, class H, class E, HSType HS>
+constexpr I CompactHashBiTable<I, T, H, E, HS>::kDeletedKey;
+
+// An implementation using a vector for the entry to ID mapping. It is passed a
+// function object FP that should fingerprint entries uniquely to an integer
+// that can used as a vector index. Normally, VectorBiTable constructs the FP
+// object. The user can instead pass in this object; in that case, VectorBiTable
+// takes its ownership.
+template <class I, class T, class FP>
+class VectorBiTable {
+ public:
+  // Reserves table_size cells of space. If passing FP argument to the
+  // constructor, this class owns it.
+  explicit VectorBiTable(FP *fp = nullptr, size_t table_size = 0) :
+      fp_(fp ? fp : new FP()) {
+    if (table_size) id2entry_.reserve(table_size);
+  }
+
+  VectorBiTable(const VectorBiTable<I, T, FP> &table)
+      : fp_(new FP(*table.fp_)), fp2id_(table.fp2id_),
+        id2entry_(table.id2entry_) {}
+
+  I FindId(const T &entry, bool insert = true) {
+    ssize_t fp = (*fp_)(entry);
+    if (fp >= fp2id_.size()) fp2id_.resize(fp + 1);
+    I &id_ref = fp2id_[fp];
+    if (id_ref == 0) {  // T not found.
+      if (insert) {     // Stores and assigns a new ID.
+        id2entry_.push_back(entry);
+        id_ref = id2entry_.size();
+      } else {
+        return -1;
+      }
+    }
+    return id_ref - 1;  // NB: id_ref = ID + 1.
+  }
+
+  const T &FindEntry(I s) const { return id2entry_[s]; }
+
+  I Size() const { return id2entry_.size(); }
+
+  const FP &Fingerprint() const { return *fp_; }
+
+ private:
+  std::unique_ptr<FP> fp_;
+  std::vector<I> fp2id_;
+  std::vector<T> id2entry_;
+};
+
+// An implementation using a vector and a compact hash table. The selecting
+// functor S returns true for entries to be hashed in the vector. The
+// fingerprinting functor FP returns a unique fingerprint for each entry to be
+// hashed in the vector (these need to be suitable for indexing in a vector).
+// The hash functor H is used when hashing entry into the compact hash table.
+// If passed to the constructor, ownership is given to this class.
+template <class I, class T, class S, class FP, class H, HSType HS = HS_DENSE>
+class VectorHashBiTable {
+ public:
+  friend class HashFunc;
+  friend class HashEqual;
+
+  explicit VectorHashBiTable(S *s, FP *fp, H *h, size_t vector_size = 0,
+                             size_t entry_size = 0)
+      : selector_(s), fp_(fp), h_(h), hash_func_(*this), hash_equal_(*this),
+        keys_(0, hash_func_, hash_equal_) {
+    if (vector_size) fp2id_.reserve(vector_size);
+    if (entry_size) id2entry_.reserve(entry_size);
+  }
+
+  VectorHashBiTable(const VectorHashBiTable<I, T, S, FP, H, HS> &table)
+      : selector_(new S(*table.selector_)), fp_(new FP(*table.fp_)),
+        h_(new H(*table.h_)), id2entry_(table.id2entry_),
+        fp2id_(table.fp2id_), hash_func_(*this), hash_equal_(*this),
+        keys_(table.keys_.size(), hash_func_, hash_equal_) {
+    keys_.insert(table.keys_.begin(), table.keys_.end());
+  }
+
+  I FindId(const T &entry, bool insert = true) {
+    if ((*selector_)(entry)) {  // Uses the vector if selector_(entry) == true.
+      uint64 fp = (*fp_)(entry);
+      if (fp2id_.size() <= fp) fp2id_.resize(fp + 1, 0);
+      if (fp2id_[fp] == 0) {  // T not found.
+        if (insert) {         // Stores and assigns a new ID.
+          id2entry_.push_back(entry);
+          fp2id_[fp] = id2entry_.size();
+        } else {
+          return -1;
+        }
+      }
+      return fp2id_[fp] - 1;  // NB: assoc_value = ID + 1.
+    } else {                  // Uses the hash table otherwise.
+      current_entry_ = &entry;
+      const auto it = keys_.find(kCurrentKey);
+      if (it == keys_.end()) {
+        if (insert) {
+          I key = id2entry_.size();
+          id2entry_.push_back(entry);
+          keys_.insert(key);
+          return key;
+        } else {
+          return -1;
+        }
+      } else {
+        return *it;
+      }
+    }
+  }
+
+  const T &FindEntry(I s) const { return id2entry_[s]; }
+
+  I Size() const { return id2entry_.size(); }
+
+  const S &Selector() const { return *selector_; }
+
+  const FP &Fingerprint() const { return *fp_; }
+
+  const H &Hash() const { return *h_; }
+
+ private:
+  static constexpr I kCurrentKey = -1;
+  static constexpr I kEmptyKey = -2;
+
+  class HashFunc {
+   public:
+    explicit HashFunc(const VectorHashBiTable &ht) : ht_(&ht) {}
+
+    size_t operator()(I k) const {
+      if (k >= kCurrentKey) {
+        return (*(ht_->h_))(ht_->Key2Entry(k));
+      } else {
+        return 0;
+      }
+    }
+
+   private:
+    const VectorHashBiTable *ht_;
+  };
+
+  class HashEqual {
+   public:
+    explicit HashEqual(const VectorHashBiTable &ht) : ht_(&ht) {}
+
+    bool operator()(I k1, I k2) const {
+      if (k1 >= kCurrentKey && k2 >= kCurrentKey) {
+        return ht_->Key2Entry(k1) == ht_->Key2Entry(k2);
+      } else {
+        return k1 == k2;
+      }
+    }
+
+   private:
+    const VectorHashBiTable *ht_;
+  };
+
+  using KeyHashSet = HashSet<I, HashFunc, HashEqual, HS>;
+
+  const T &Key2Entry(I k) const {
+    if (k == kCurrentKey) {
+      return *current_entry_;
+    } else {
+      return id2entry_[k];
+    }
+  }
+
+  std::unique_ptr<S> selector_;  // True if entry hashed into vector.
+  std::unique_ptr<FP> fp_;       // Fingerprint used for hashing into vector.
+  std::unique_ptr<H> h_;         // Hash funcion used for hashing into hash_set.
+
+  std::vector<T> id2entry_;  // Maps state IDs to entry.
+  std::vector<I> fp2id_;     // Maps entry fingerprints to IDs.
+
+  // Compact implementation of the hash table mapping entries to state IDs
+  // using the hash function h_.
+  HashFunc hash_func_;
+  HashEqual hash_equal_;
+  KeyHashSet keys_;
+  const T *current_entry_;
+};
+
+template <class I, class T, class S, class FP, class H, HSType HS>
+constexpr I VectorHashBiTable<I, T, S, FP, H, HS>::kCurrentKey;
+
+template <class I, class T, class S, class FP, class H, HSType HS>
+constexpr I VectorHashBiTable<I, T, S, FP, H, HS>::kEmptyKey;
+
+// An implementation using a hash map for the entry to ID mapping. This version
+// permits erasing of arbitrary states. The entry T must have == defined and
+// its default constructor must produce a entry that will never be seen. F is
+// the hash function.
+template <class I, class T, class F>
+class ErasableBiTable {
+ public:
+  ErasableBiTable() : first_(0) {}
+
+  I FindId(const T &entry, bool insert = true) {
+    I &id_ref = entry2id_[entry];
+    if (id_ref == 0) {  // T not found.
+      if (insert) {     // Stores and assigns a new ID.
+        id2entry_.push_back(entry);
+        id_ref = id2entry_.size() + first_;
+      } else {
+        return -1;
+      }
+    }
+    return id_ref - 1;  // NB: id_ref = ID + 1.
+  }
+
+  const T &FindEntry(I s) const { return id2entry_[s - first_]; }
+
+  I Size() const { return id2entry_.size(); }
+
+  void Erase(I s) {
+    auto &ref = id2entry_[s - first_];
+    entry2id_.erase(ref);
+    ref = empty_entry_;
+    while (!id2entry_.empty() && id2entry_.front() == empty_entry_) {
+      id2entry_.pop_front();
+      ++first_;
+    }
+  }
+
+ private:
+  std::unordered_map<T, I, F> entry2id_;
+  std::deque<T> id2entry_;
+  const T empty_entry_;
+  I first_;  // I of first element in the deque.
+};
+
+}  // namespace fst
+
+#endif  // FST_BI_TABLE_H_

--- a/runtime/core/toolchains/ios.toolchain.cmake
+++ b/runtime/core/toolchains/ios.toolchain.cmake
@@ -262,8 +262,8 @@ if(NOT DEFINED DEPLOYMENT_TARGET)
     # Unless specified, SDK version 13.0 is used by default as minimum target version (mac catalyst minimum requirement).
     set(DEPLOYMENT_TARGET "13.1")
   else()
-    # Unless specified, SDK version 11.0 is used by default as minimum target version (iOS, tvOS).
-    set(DEPLOYMENT_TARGET "11.0")
+    # Unless specified, SDK version 12.0 is used by default as minimum target version (iOS, tvOS).
+    set(DEPLOYMENT_TARGET "12.0")
   endif()
   message(STATUS "[DEFAULTS] Using the default min-version since DEPLOYMENT_TARGET not provided!")
 elseif(DEFINED DEPLOYMENT_TARGET AND PLATFORM MATCHES "^MAC_CATALYST" AND ${DEPLOYMENT_TARGET} VERSION_LESS "13.1")

--- a/runtime/ios/CMakeLists.txt
+++ b/runtime/ios/CMakeLists.txt
@@ -39,6 +39,7 @@ if(ONNX)
   include(onnx)
 endif()
 include(openfst)
+include(wetextprocessing)
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/kaldi

--- a/runtime/ios/README.md
+++ b/runtime/ios/README.md
@@ -6,7 +6,7 @@
 
 ```
 cd runtime/ios/build
-cmake .. -G Xcode -DTORCH=ON -DONNX=OFF -DIOS=ON -DGRAPH_TOOLS=OFF -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE=../toolchains/ios.toolchain.cmake -DPLATFORM=OS64 -DENABLE_BITCODE=FALSE
+cmake .. -G Xcode -DTORCH=ON -DONNX=OFF -DIOS=ON -DGRAPH_TOOLS=OFF -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE=../toolchains/ios.toolchain.cmake -DPLATFORM=OS64 -DENABLE_BITCODE=FALSE -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 pod install
 
 # Build debug version

--- a/runtime/ios/WenetDemo/WenetDemo.xcodeproj/project.pbxproj
+++ b/runtime/ios/WenetDemo/WenetDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		372EA5222F72CB1D00A9B8A7 /* zh_itn_verbalizer.fst in Resources */ = {isa = PBXBuildFile; fileRef = 372EA5212F72CB1D00A9B8A7 /* zh_itn_verbalizer.fst */; };
+		372EA5232F72CB1D00A9B8A7 /* zh_itn_tagger.fst in Resources */ = {isa = PBXBuildFile; fileRef = 372EA5202F72CB1D00A9B8A7 /* zh_itn_tagger.fst */; };
 		374FEB34291019EE00513F88 /* libeigen_blas.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E1E2910198A00853C23 /* libeigen_blas.a */; };
 		37C64C892912A94B00BFCE0B /* final.zip in Resources */ = {isa = PBXBuildFile; fileRef = 37C64C882912A94A00BFCE0B /* final.zip */; };
 		37C64C8B2912ABE900BFCE0B /* units.txt in Resources */ = {isa = PBXBuildFile; fileRef = 37C64C8A2912ABE900BFCE0B /* units.txt */; };
@@ -34,6 +36,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		372EA5202F72CB1D00A9B8A7 /* zh_itn_tagger.fst */ = {isa = PBXFileReference; lastKnownFileType = file; path = zh_itn_tagger.fst; sourceTree = "<group>"; };
+		372EA5212F72CB1D00A9B8A7 /* zh_itn_verbalizer.fst */ = {isa = PBXFileReference; lastKnownFileType = file; path = zh_itn_verbalizer.fst; sourceTree = "<group>"; };
 		373FDD93291BE53D00DF4BEA /* libglog.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libglog.a; path = "../fc_base/glog-build/Release-iphoneos/libglog.a"; sourceTree = "<group>"; };
 		373FDD95291BE5A800DF4BEA /* libgflags_nothreads.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgflags_nothreads.a; path = "../fc_base/gflags-build/Release-iphoneos/libgflags_nothreads.a"; sourceTree = "<group>"; };
 		37C64C882912A94A00BFCE0B /* final.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = final.zip; sourceTree = "<group>"; };
@@ -97,6 +101,8 @@
 		37C64C812912A21300BFCE0B /* model */ = {
 			isa = PBXGroup;
 			children = (
+				372EA5202F72CB1D00A9B8A7 /* zh_itn_tagger.fst */,
+				372EA5212F72CB1D00A9B8A7 /* zh_itn_verbalizer.fst */,
 				37C64C8A2912ABE900BFCE0B /* units.txt */,
 				37C64C882912A94A00BFCE0B /* final.zip */,
 			);
@@ -231,6 +237,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				372EA5222F72CB1D00A9B8A7 /* zh_itn_verbalizer.fst in Resources */,
+				372EA5232F72CB1D00A9B8A7 /* zh_itn_tagger.fst in Resources */,
 				37C64C8B2912ABE900BFCE0B /* units.txt in Resources */,
 				37FD7E0F2910094500853C23 /* LaunchScreen.storyboard in Resources */,
 				37FD7E0C2910094500853C23 /* Assets.xcassets in Resources */,

--- a/runtime/ios/WenetDemo/WenetDemo.xcodeproj/project.pbxproj
+++ b/runtime/ios/WenetDemo/WenetDemo.xcodeproj/project.pbxproj
@@ -1,563 +1,575 @@
 // !$*UTF8*$!
 {
-    archiveVersion = 1;
-    classes = {
-    };
-    objectVersion = 56;
-    objects = {
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
 
 /* Begin PBXBuildFile section */
-        374FEB34291019EE00513F88 /* libeigen_blas.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E1E2910198A00853C23 /* libeigen_blas.a */; };
-        37C64C892912A94B00BFCE0B /* final.zip in Resources */ = {isa = PBXBuildFile; fileRef = 37C64C882912A94A00BFCE0B /* final.zip */; };
-        37C64C8B2912ABE900BFCE0B /* units.txt in Resources */ = {isa = PBXBuildFile; fileRef = 37C64C8A2912ABE900BFCE0B /* units.txt */; };
-        37C64C8F2912ADDD00BFCE0B /* libfst.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37C64C8E2912ADDD00BFCE0B /* libfst.a */; };
-        37C64C942912AF7F00BFCE0B /* libkaldi-decoder.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37C64C8C2912AD3300BFCE0B /* libkaldi-decoder.a */; };
-        37C64C962912AFC900BFCE0B /* libpost_processor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37C64C952912AFC900BFCE0B /* libpost_processor.a */; };
-        37C64C982912B06800BFCE0B /* libutils.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37C64C972912B06800BFCE0B /* libutils.a */; };
-        37C64C9A2912B0A000BFCE0B /* libfrontend.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37C64C992912B0A000BFCE0B /* libfrontend.a */; };
-        37FD7E032910094300853C23 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD7E022910094300853C23 /* AppDelegate.swift */; };
-        37FD7E052910094300853C23 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD7E042910094300853C23 /* SceneDelegate.swift */; };
-        37FD7E072910094300853C23 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD7E062910094300853C23 /* ViewController.swift */; };
-        37FD7E0A2910094300853C23 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 37FD7E082910094300853C23 /* Main.storyboard */; };
-        37FD7E0C2910094500853C23 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 37FD7E0B2910094500853C23 /* Assets.xcassets */; };
-        37FD7E0F2910094500853C23 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 37FD7E0D2910094500853C23 /* LaunchScreen.storyboard */; };
-        37FD7E1A291009EC00853C23 /* wenet.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37FD7E18291009EC00853C23 /* wenet.mm */; };
-        37FD7E1D2910195900853C23 /* libdecoder.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E1C2910195900853C23 /* libdecoder.a */; };
-        37FD7E282910198B00853C23 /* libpthreadpool.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E1F2910198B00853C23 /* libpthreadpool.a */; };
-        37FD7E292910198B00853C23 /* libc10.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E202910198B00853C23 /* libc10.a */; };
-        37FD7E2A2910198B00853C23 /* libtorch_cpu.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E212910198B00853C23 /* libtorch_cpu.a */; };
-        37FD7E2B2910198B00853C23 /* libtorch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E222910198B00853C23 /* libtorch.a */; };
-        37FD7E2C2910198B00853C23 /* libclog.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E232910198B00853C23 /* libclog.a */; };
-        37FD7E2D2910198B00853C23 /* libcpuinfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E242910198B00853C23 /* libcpuinfo.a */; };
-        37FD7E2E2910198C00853C23 /* libXNNPACK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E252910198B00853C23 /* libXNNPACK.a */; };
-        37FD7E2F2910198C00853C23 /* libpytorch_qnnpack.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E262910198B00853C23 /* libpytorch_qnnpack.a */; };
+		374FEB34291019EE00513F88 /* libeigen_blas.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E1E2910198A00853C23 /* libeigen_blas.a */; };
+		37C64C892912A94B00BFCE0B /* final.zip in Resources */ = {isa = PBXBuildFile; fileRef = 37C64C882912A94A00BFCE0B /* final.zip */; };
+		37C64C8B2912ABE900BFCE0B /* units.txt in Resources */ = {isa = PBXBuildFile; fileRef = 37C64C8A2912ABE900BFCE0B /* units.txt */; };
+		37C64C8F2912ADDD00BFCE0B /* libfst.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37C64C8E2912ADDD00BFCE0B /* libfst.a */; };
+		37C64C942912AF7F00BFCE0B /* libkaldi-decoder.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37C64C8C2912AD3300BFCE0B /* libkaldi-decoder.a */; };
+		37C64C962912AFC900BFCE0B /* libpost_processor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37C64C952912AFC900BFCE0B /* libpost_processor.a */; };
+		37C64C982912B06800BFCE0B /* libutils.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37C64C972912B06800BFCE0B /* libutils.a */; };
+		37C64C9A2912B0A000BFCE0B /* libfrontend.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37C64C992912B0A000BFCE0B /* libfrontend.a */; };
+		37FD7E032910094300853C23 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD7E022910094300853C23 /* AppDelegate.swift */; };
+		37FD7E052910094300853C23 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD7E042910094300853C23 /* SceneDelegate.swift */; };
+		37FD7E072910094300853C23 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD7E062910094300853C23 /* ViewController.swift */; };
+		37FD7E0A2910094300853C23 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 37FD7E082910094300853C23 /* Main.storyboard */; };
+		37FD7E0C2910094500853C23 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 37FD7E0B2910094500853C23 /* Assets.xcassets */; };
+		37FD7E0F2910094500853C23 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 37FD7E0D2910094500853C23 /* LaunchScreen.storyboard */; };
+		37FD7E1A291009EC00853C23 /* wenet.mm in Sources */ = {isa = PBXBuildFile; fileRef = 37FD7E18291009EC00853C23 /* wenet.mm */; };
+		37FD7E1D2910195900853C23 /* libdecoder.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E1C2910195900853C23 /* libdecoder.a */; };
+		37FD7E282910198B00853C23 /* libpthreadpool.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E1F2910198B00853C23 /* libpthreadpool.a */; };
+		37FD7E292910198B00853C23 /* libc10.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E202910198B00853C23 /* libc10.a */; };
+		37FD7E2A2910198B00853C23 /* libtorch_cpu.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E212910198B00853C23 /* libtorch_cpu.a */; };
+		37FD7E2B2910198B00853C23 /* libtorch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E222910198B00853C23 /* libtorch.a */; };
+		37FD7E2C2910198B00853C23 /* libclog.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E232910198B00853C23 /* libclog.a */; };
+		37FD7E2D2910198B00853C23 /* libcpuinfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E242910198B00853C23 /* libcpuinfo.a */; };
+		37FD7E2E2910198C00853C23 /* libXNNPACK.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E252910198B00853C23 /* libXNNPACK.a */; };
+		37FD7E2F2910198C00853C23 /* libpytorch_qnnpack.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37FD7E262910198B00853C23 /* libpytorch_qnnpack.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-        373FDD93291BE53D00DF4BEA /* libglog.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libglog.a; path = "../fc_base/glog-build/Release-iphoneos/libglog.a"; sourceTree = "<group>"; };
-        373FDD95291BE5A800DF4BEA /* libgflags_nothreads.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgflags_nothreads.a; path = "../fc_base/gflags-build/Release-iphoneos/libgflags_nothreads.a"; sourceTree = "<group>"; };
-        37C64C882912A94A00BFCE0B /* final.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = final.zip; sourceTree = "<group>"; };
-        37C64C8A2912ABE900BFCE0B /* units.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = units.txt; sourceTree = "<group>"; };
-        37C64C8C2912AD3300BFCE0B /* libkaldi-decoder.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libkaldi-decoder.a"; path = "../build/kaldi/Debug-iphoneos/libkaldi-decoder.a"; sourceTree = "<group>"; };
-        37C64C8E2912ADDD00BFCE0B /* libfst.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfst.a; path = "../fc_base/openfst-build/src/lib/Debug-iphoneos/libfst.a"; sourceTree = "<group>"; };
-        37C64C902912AE2B00BFCE0B /* libgflags_nothreads_debug.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgflags_nothreads_debug.a; path = "../fc_base/gflags-build/Debug-iphoneos/libgflags_nothreads_debug.a"; sourceTree = "<group>"; };
-        37C64C922912AE7E00BFCE0B /* libglogd.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libglogd.a; path = "../fc_base/glog-build/Debug-iphoneos/libglogd.a"; sourceTree = "<group>"; };
-        37C64C952912AFC900BFCE0B /* libpost_processor.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libpost_processor.a; path = "../build/post_processor/Debug-iphoneos/libpost_processor.a"; sourceTree = "<group>"; };
-        37C64C972912B06800BFCE0B /* libutils.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libutils.a; path = "../build/utils/Debug-iphoneos/libutils.a"; sourceTree = "<group>"; };
-        37C64C992912B0A000BFCE0B /* libfrontend.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfrontend.a; path = "../build/frontend/Debug-iphoneos/libfrontend.a"; sourceTree = "<group>"; };
-        37FD7DFF2910094300853C23 /* WenetDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WenetDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
-        37FD7E022910094300853C23 /* AppDelegate.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; tabWidth = 2; };
-        37FD7E042910094300853C23 /* SceneDelegate.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; tabWidth = 2; };
-        37FD7E062910094300853C23 /* ViewController.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; tabWidth = 2; };
-        37FD7E092910094300853C23 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-        37FD7E0B2910094500853C23 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-        37FD7E0E2910094500853C23 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-        37FD7E102910094500853C23 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-        37FD7E17291009EC00853C23 /* WenetDemo-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WenetDemo-Bridging-Header.h"; sourceTree = "<group>"; };
-        37FD7E18291009EC00853C23 /* wenet.mm */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.cpp.objcpp; path = wenet.mm; sourceTree = "<group>"; tabWidth = 2; };
-        37FD7E19291009EC00853C23 /* wenet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = wenet.h; sourceTree = "<group>"; };
-        37FD7E1C2910195900853C23 /* libdecoder.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdecoder.a; path = "../wenet/runtime/ios/build/decoder/Debug-iphoneos/libdecoder.a"; sourceTree = "<group>"; };
-        37FD7E1E2910198A00853C23 /* libeigen_blas.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libeigen_blas.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libeigen_blas.a; sourceTree = "<group>"; };
-        37FD7E1F2910198B00853C23 /* libpthreadpool.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libpthreadpool.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libpthreadpool.a; sourceTree = "<group>"; };
-        37FD7E202910198B00853C23 /* libc10.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libc10.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libc10.a; sourceTree = "<group>"; };
-        37FD7E212910198B00853C23 /* libtorch_cpu.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtorch_cpu.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libtorch_cpu.a; sourceTree = "<group>"; };
-        37FD7E222910198B00853C23 /* libtorch.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtorch.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libtorch.a; sourceTree = "<group>"; };
-        37FD7E232910198B00853C23 /* libclog.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclog.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libclog.a; sourceTree = "<group>"; };
-        37FD7E242910198B00853C23 /* libcpuinfo.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcpuinfo.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libcpuinfo.a; sourceTree = "<group>"; };
-        37FD7E252910198B00853C23 /* libXNNPACK.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libXNNPACK.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libXNNPACK.a; sourceTree = "<group>"; };
-        37FD7E262910198B00853C23 /* libpytorch_qnnpack.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libpytorch_qnnpack.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libpytorch_qnnpack.a; sourceTree = "<group>"; };
+		373FDD93291BE53D00DF4BEA /* libglog.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libglog.a; path = "../fc_base/glog-build/Release-iphoneos/libglog.a"; sourceTree = "<group>"; };
+		373FDD95291BE5A800DF4BEA /* libgflags_nothreads.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgflags_nothreads.a; path = "../fc_base/gflags-build/Release-iphoneos/libgflags_nothreads.a"; sourceTree = "<group>"; };
+		37C64C882912A94A00BFCE0B /* final.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = final.zip; sourceTree = "<group>"; };
+		37C64C8A2912ABE900BFCE0B /* units.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = units.txt; sourceTree = "<group>"; };
+		37C64C8C2912AD3300BFCE0B /* libkaldi-decoder.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libkaldi-decoder.a"; path = "../build/kaldi/Debug-iphoneos/libkaldi-decoder.a"; sourceTree = "<group>"; };
+		37C64C8E2912ADDD00BFCE0B /* libfst.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfst.a; path = "../fc_base/openfst-build/src/lib/Debug-iphoneos/libfst.a"; sourceTree = "<group>"; };
+		37C64C902912AE2B00BFCE0B /* libgflags_nothreads_debug.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libgflags_nothreads_debug.a; path = "../fc_base/gflags-build/Debug-iphoneos/libgflags_nothreads_debug.a"; sourceTree = "<group>"; };
+		37C64C922912AE7E00BFCE0B /* libglogd.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libglogd.a; path = "../fc_base/glog-build/Debug-iphoneos/libglogd.a"; sourceTree = "<group>"; };
+		37C64C952912AFC900BFCE0B /* libpost_processor.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libpost_processor.a; path = "../build/post_processor/Debug-iphoneos/libpost_processor.a"; sourceTree = "<group>"; };
+		37C64C972912B06800BFCE0B /* libutils.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libutils.a; path = "../build/utils/Debug-iphoneos/libutils.a"; sourceTree = "<group>"; };
+		37C64C992912B0A000BFCE0B /* libfrontend.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfrontend.a; path = "../build/frontend/Debug-iphoneos/libfrontend.a"; sourceTree = "<group>"; };
+		37FD7DFF2910094300853C23 /* WenetDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WenetDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		37FD7E022910094300853C23 /* AppDelegate.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; tabWidth = 2; };
+		37FD7E042910094300853C23 /* SceneDelegate.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; tabWidth = 2; };
+		37FD7E062910094300853C23 /* ViewController.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; tabWidth = 2; };
+		37FD7E092910094300853C23 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		37FD7E0B2910094500853C23 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		37FD7E0E2910094500853C23 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		37FD7E102910094500853C23 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		37FD7E17291009EC00853C23 /* WenetDemo-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WenetDemo-Bridging-Header.h"; sourceTree = "<group>"; };
+		37FD7E18291009EC00853C23 /* wenet.mm */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.cpp.objcpp; path = wenet.mm; sourceTree = "<group>"; tabWidth = 2; };
+		37FD7E19291009EC00853C23 /* wenet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = wenet.h; sourceTree = "<group>"; };
+		37FD7E1C2910195900853C23 /* libdecoder.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdecoder.a; path = "../wenet/runtime/ios/build/decoder/Debug-iphoneos/libdecoder.a"; sourceTree = "<group>"; };
+		37FD7E1E2910198A00853C23 /* libeigen_blas.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libeigen_blas.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libeigen_blas.a; sourceTree = "<group>"; };
+		37FD7E1F2910198B00853C23 /* libpthreadpool.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libpthreadpool.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libpthreadpool.a; sourceTree = "<group>"; };
+		37FD7E202910198B00853C23 /* libc10.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libc10.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libc10.a; sourceTree = "<group>"; };
+		37FD7E212910198B00853C23 /* libtorch_cpu.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtorch_cpu.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libtorch_cpu.a; sourceTree = "<group>"; };
+		37FD7E222910198B00853C23 /* libtorch.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libtorch.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libtorch.a; sourceTree = "<group>"; };
+		37FD7E232910198B00853C23 /* libclog.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclog.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libclog.a; sourceTree = "<group>"; };
+		37FD7E242910198B00853C23 /* libcpuinfo.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcpuinfo.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libcpuinfo.a; sourceTree = "<group>"; };
+		37FD7E252910198B00853C23 /* libXNNPACK.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libXNNPACK.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libXNNPACK.a; sourceTree = "<group>"; };
+		37FD7E262910198B00853C23 /* libpytorch_qnnpack.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libpytorch_qnnpack.a; path = ../wenet/runtime/ios/build/Pods/LibTorch/install/lib/libpytorch_qnnpack.a; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-        37FD7DFC2910094300853C23 /* Frameworks */ = {
-            isa = PBXFrameworksBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-                37C64C9A2912B0A000BFCE0B /* libfrontend.a in Frameworks */,
-                37C64C982912B06800BFCE0B /* libutils.a in Frameworks */,
-                37C64C962912AFC900BFCE0B /* libpost_processor.a in Frameworks */,
-                37C64C942912AF7F00BFCE0B /* libkaldi-decoder.a in Frameworks */,
-                37C64C8F2912ADDD00BFCE0B /* libfst.a in Frameworks */,
-                374FEB34291019EE00513F88 /* libeigen_blas.a in Frameworks */,
-                37FD7E282910198B00853C23 /* libpthreadpool.a in Frameworks */,
-                37FD7E292910198B00853C23 /* libc10.a in Frameworks */,
-                37FD7E2A2910198B00853C23 /* libtorch_cpu.a in Frameworks */,
-                37FD7E2B2910198B00853C23 /* libtorch.a in Frameworks */,
-                37FD7E2C2910198B00853C23 /* libclog.a in Frameworks */,
-                37FD7E2D2910198B00853C23 /* libcpuinfo.a in Frameworks */,
-                37FD7E2E2910198C00853C23 /* libXNNPACK.a in Frameworks */,
-                37FD7E2F2910198C00853C23 /* libpytorch_qnnpack.a in Frameworks */,
-                37FD7E1D2910195900853C23 /* libdecoder.a in Frameworks */,
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
+		37FD7DFC2910094300853C23 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				37C64C9A2912B0A000BFCE0B /* libfrontend.a in Frameworks */,
+				37C64C982912B06800BFCE0B /* libutils.a in Frameworks */,
+				37C64C962912AFC900BFCE0B /* libpost_processor.a in Frameworks */,
+				37C64C942912AF7F00BFCE0B /* libkaldi-decoder.a in Frameworks */,
+				37C64C8F2912ADDD00BFCE0B /* libfst.a in Frameworks */,
+				374FEB34291019EE00513F88 /* libeigen_blas.a in Frameworks */,
+				37FD7E282910198B00853C23 /* libpthreadpool.a in Frameworks */,
+				37FD7E292910198B00853C23 /* libc10.a in Frameworks */,
+				37FD7E2A2910198B00853C23 /* libtorch_cpu.a in Frameworks */,
+				37FD7E2B2910198B00853C23 /* libtorch.a in Frameworks */,
+				37FD7E2C2910198B00853C23 /* libclog.a in Frameworks */,
+				37FD7E2D2910198B00853C23 /* libcpuinfo.a in Frameworks */,
+				37FD7E2E2910198C00853C23 /* libXNNPACK.a in Frameworks */,
+				37FD7E2F2910198C00853C23 /* libpytorch_qnnpack.a in Frameworks */,
+				37FD7E1D2910195900853C23 /* libdecoder.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-        37C64C812912A21300BFCE0B /* model */ = {
-            isa = PBXGroup;
-            children = (
-                37C64C8A2912ABE900BFCE0B /* units.txt */,
-                37C64C882912A94A00BFCE0B /* final.zip */,
-            );
-            path = model;
-            sourceTree = "<group>";
-        };
-        37FD7DF62910094300853C23 = {
-            isa = PBXGroup;
-            children = (
-                37FD7E012910094300853C23 /* WenetDemo */,
-                37FD7E002910094300853C23 /* Products */,
-                37FD7E1B2910195900853C23 /* Frameworks */,
-            );
-            sourceTree = "<group>";
-        };
-        37FD7E002910094300853C23 /* Products */ = {
-            isa = PBXGroup;
-            children = (
-                37FD7DFF2910094300853C23 /* WenetDemo.app */,
-            );
-            name = Products;
-            sourceTree = "<group>";
-        };
-        37FD7E012910094300853C23 /* WenetDemo */ = {
-            isa = PBXGroup;
-            children = (
-                37C64C812912A21300BFCE0B /* model */,
-                37FD7E16291009B900853C23 /* wenet */,
-                37FD7E022910094300853C23 /* AppDelegate.swift */,
-                37FD7E042910094300853C23 /* SceneDelegate.swift */,
-                37FD7E062910094300853C23 /* ViewController.swift */,
-                37FD7E082910094300853C23 /* Main.storyboard */,
-                37FD7E0B2910094500853C23 /* Assets.xcassets */,
-                37FD7E0D2910094500853C23 /* LaunchScreen.storyboard */,
-                37FD7E102910094500853C23 /* Info.plist */,
-            );
-            path = WenetDemo;
-            sourceTree = "<group>";
-        };
-        37FD7E16291009B900853C23 /* wenet */ = {
-            isa = PBXGroup;
-            children = (
-                37FD7E18291009EC00853C23 /* wenet.mm */,
-                37FD7E19291009EC00853C23 /* wenet.h */,
-                37FD7E17291009EC00853C23 /* WenetDemo-Bridging-Header.h */,
-            );
-            path = wenet;
-            sourceTree = "<group>";
-        };
-        37FD7E1B2910195900853C23 /* Frameworks */ = {
-            isa = PBXGroup;
-            children = (
-                373FDD95291BE5A800DF4BEA /* libgflags_nothreads.a */,
-                373FDD93291BE53D00DF4BEA /* libglog.a */,
-                37C64C992912B0A000BFCE0B /* libfrontend.a */,
-                37C64C972912B06800BFCE0B /* libutils.a */,
-                37C64C952912AFC900BFCE0B /* libpost_processor.a */,
-                37C64C922912AE7E00BFCE0B /* libglogd.a */,
-                37C64C902912AE2B00BFCE0B /* libgflags_nothreads_debug.a */,
-                37C64C8E2912ADDD00BFCE0B /* libfst.a */,
-                37C64C8C2912AD3300BFCE0B /* libkaldi-decoder.a */,
-                37FD7E202910198B00853C23 /* libc10.a */,
-                37FD7E232910198B00853C23 /* libclog.a */,
-                37FD7E242910198B00853C23 /* libcpuinfo.a */,
-                37FD7E1E2910198A00853C23 /* libeigen_blas.a */,
-                37FD7E1F2910198B00853C23 /* libpthreadpool.a */,
-                37FD7E262910198B00853C23 /* libpytorch_qnnpack.a */,
-                37FD7E212910198B00853C23 /* libtorch_cpu.a */,
-                37FD7E222910198B00853C23 /* libtorch.a */,
-                37FD7E252910198B00853C23 /* libXNNPACK.a */,
-                37FD7E1C2910195900853C23 /* libdecoder.a */,
-            );
-            name = Frameworks;
-            sourceTree = "<group>";
-        };
+		37C64C812912A21300BFCE0B /* model */ = {
+			isa = PBXGroup;
+			children = (
+				37C64C8A2912ABE900BFCE0B /* units.txt */,
+				37C64C882912A94A00BFCE0B /* final.zip */,
+			);
+			path = model;
+			sourceTree = "<group>";
+		};
+		37FD7DF62910094300853C23 = {
+			isa = PBXGroup;
+			children = (
+				37FD7E012910094300853C23 /* WenetDemo */,
+				37FD7E002910094300853C23 /* Products */,
+				37FD7E1B2910195900853C23 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		37FD7E002910094300853C23 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				37FD7DFF2910094300853C23 /* WenetDemo.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		37FD7E012910094300853C23 /* WenetDemo */ = {
+			isa = PBXGroup;
+			children = (
+				37C64C812912A21300BFCE0B /* model */,
+				37FD7E16291009B900853C23 /* wenet */,
+				37FD7E022910094300853C23 /* AppDelegate.swift */,
+				37FD7E042910094300853C23 /* SceneDelegate.swift */,
+				37FD7E062910094300853C23 /* ViewController.swift */,
+				37FD7E082910094300853C23 /* Main.storyboard */,
+				37FD7E0B2910094500853C23 /* Assets.xcassets */,
+				37FD7E0D2910094500853C23 /* LaunchScreen.storyboard */,
+				37FD7E102910094500853C23 /* Info.plist */,
+			);
+			path = WenetDemo;
+			sourceTree = "<group>";
+		};
+		37FD7E16291009B900853C23 /* wenet */ = {
+			isa = PBXGroup;
+			children = (
+				37FD7E18291009EC00853C23 /* wenet.mm */,
+				37FD7E19291009EC00853C23 /* wenet.h */,
+				37FD7E17291009EC00853C23 /* WenetDemo-Bridging-Header.h */,
+			);
+			path = wenet;
+			sourceTree = "<group>";
+		};
+		37FD7E1B2910195900853C23 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				373FDD95291BE5A800DF4BEA /* libgflags_nothreads.a */,
+				373FDD93291BE53D00DF4BEA /* libglog.a */,
+				37C64C992912B0A000BFCE0B /* libfrontend.a */,
+				37C64C972912B06800BFCE0B /* libutils.a */,
+				37C64C952912AFC900BFCE0B /* libpost_processor.a */,
+				37C64C922912AE7E00BFCE0B /* libglogd.a */,
+				37C64C902912AE2B00BFCE0B /* libgflags_nothreads_debug.a */,
+				37C64C8E2912ADDD00BFCE0B /* libfst.a */,
+				37C64C8C2912AD3300BFCE0B /* libkaldi-decoder.a */,
+				37FD7E202910198B00853C23 /* libc10.a */,
+				37FD7E232910198B00853C23 /* libclog.a */,
+				37FD7E242910198B00853C23 /* libcpuinfo.a */,
+				37FD7E1E2910198A00853C23 /* libeigen_blas.a */,
+				37FD7E1F2910198B00853C23 /* libpthreadpool.a */,
+				37FD7E262910198B00853C23 /* libpytorch_qnnpack.a */,
+				37FD7E212910198B00853C23 /* libtorch_cpu.a */,
+				37FD7E222910198B00853C23 /* libtorch.a */,
+				37FD7E252910198B00853C23 /* libXNNPACK.a */,
+				37FD7E1C2910195900853C23 /* libdecoder.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-        37FD7DFE2910094300853C23 /* WenetDemo */ = {
-            isa = PBXNativeTarget;
-            buildConfigurationList = 37FD7E132910094500853C23 /* Build configuration list for PBXNativeTarget "WenetDemo" */;
-            buildPhases = (
-                37FD7DFB2910094300853C23 /* Sources */,
-                37FD7DFC2910094300853C23 /* Frameworks */,
-                37FD7DFD2910094300853C23 /* Resources */,
-            );
-            buildRules = (
-            );
-            dependencies = (
-            );
-            name = WenetDemo;
-            productName = WenetDemo;
-            productReference = 37FD7DFF2910094300853C23 /* WenetDemo.app */;
-            productType = "com.apple.product-type.application";
-        };
+		37FD7DFE2910094300853C23 /* WenetDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 37FD7E132910094500853C23 /* Build configuration list for PBXNativeTarget "WenetDemo" */;
+			buildPhases = (
+				37FD7DFB2910094300853C23 /* Sources */,
+				37FD7DFC2910094300853C23 /* Frameworks */,
+				37FD7DFD2910094300853C23 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = WenetDemo;
+			productName = WenetDemo;
+			productReference = 37FD7DFF2910094300853C23 /* WenetDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-        37FD7DF72910094300853C23 /* Project object */ = {
-            isa = PBXProject;
-            attributes = {
-                BuildIndependentTargetsInParallel = 1;
-                LastSwiftUpdateCheck = 1400;
-                LastUpgradeCheck = 1400;
-                TargetAttributes = {
-                    37FD7DFE2910094300853C23 = {
-                        CreatedOnToolsVersion = 14.0.1;
-                        LastSwiftMigration = 1400;
-                    };
-                };
-            };
-            buildConfigurationList = 37FD7DFA2910094300853C23 /* Build configuration list for PBXProject "WenetDemo" */;
-            compatibilityVersion = "Xcode 14.0";
-            developmentRegion = en;
-            hasScannedForEncodings = 0;
-            knownRegions = (
-                en,
-                Base,
-            );
-            mainGroup = 37FD7DF62910094300853C23;
-            productRefGroup = 37FD7E002910094300853C23 /* Products */;
-            projectDirPath = "";
-            projectRoot = "";
-            targets = (
-                37FD7DFE2910094300853C23 /* WenetDemo */,
-            );
-        };
+		37FD7DF72910094300853C23 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1400;
+				LastUpgradeCheck = 1400;
+				TargetAttributes = {
+					37FD7DFE2910094300853C23 = {
+						CreatedOnToolsVersion = 14.0.1;
+						LastSwiftMigration = 1400;
+					};
+				};
+			};
+			buildConfigurationList = 37FD7DFA2910094300853C23 /* Build configuration list for PBXProject "WenetDemo" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 37FD7DF62910094300853C23;
+			productRefGroup = 37FD7E002910094300853C23 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				37FD7DFE2910094300853C23 /* WenetDemo */,
+			);
+		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-        37FD7DFD2910094300853C23 /* Resources */ = {
-            isa = PBXResourcesBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-                37C64C8B2912ABE900BFCE0B /* units.txt in Resources */,
-                37FD7E0F2910094500853C23 /* LaunchScreen.storyboard in Resources */,
-                37FD7E0C2910094500853C23 /* Assets.xcassets in Resources */,
-                37C64C892912A94B00BFCE0B /* final.zip in Resources */,
-                37FD7E0A2910094300853C23 /* Main.storyboard in Resources */,
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
+		37FD7DFD2910094300853C23 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				37C64C8B2912ABE900BFCE0B /* units.txt in Resources */,
+				37FD7E0F2910094500853C23 /* LaunchScreen.storyboard in Resources */,
+				37FD7E0C2910094500853C23 /* Assets.xcassets in Resources */,
+				37C64C892912A94B00BFCE0B /* final.zip in Resources */,
+				37FD7E0A2910094300853C23 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-        37FD7DFB2910094300853C23 /* Sources */ = {
-            isa = PBXSourcesBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-                37FD7E072910094300853C23 /* ViewController.swift in Sources */,
-                37FD7E1A291009EC00853C23 /* wenet.mm in Sources */,
-                37FD7E032910094300853C23 /* AppDelegate.swift in Sources */,
-                37FD7E052910094300853C23 /* SceneDelegate.swift in Sources */,
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
+		37FD7DFB2910094300853C23 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				37FD7E072910094300853C23 /* ViewController.swift in Sources */,
+				37FD7E1A291009EC00853C23 /* wenet.mm in Sources */,
+				37FD7E032910094300853C23 /* AppDelegate.swift in Sources */,
+				37FD7E052910094300853C23 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXVariantGroup section */
-        37FD7E082910094300853C23 /* Main.storyboard */ = {
-            isa = PBXVariantGroup;
-            children = (
-                37FD7E092910094300853C23 /* Base */,
-            );
-            name = Main.storyboard;
-            sourceTree = "<group>";
-        };
-        37FD7E0D2910094500853C23 /* LaunchScreen.storyboard */ = {
-            isa = PBXVariantGroup;
-            children = (
-                37FD7E0E2910094500853C23 /* Base */,
-            );
-            name = LaunchScreen.storyboard;
-            sourceTree = "<group>";
-        };
+		37FD7E082910094300853C23 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				37FD7E092910094300853C23 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		37FD7E0D2910094500853C23 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				37FD7E0E2910094500853C23 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-        37FD7E112910094500853C23 /* Debug */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ALWAYS_SEARCH_USER_PATHS = NO;
-                CLANG_ANALYZER_NONNULL = YES;
-                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-                CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-                CLANG_ENABLE_MODULES = YES;
-                CLANG_ENABLE_OBJC_ARC = YES;
-                CLANG_ENABLE_OBJC_WEAK = YES;
-                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-                CLANG_WARN_BOOL_CONVERSION = YES;
-                CLANG_WARN_COMMA = YES;
-                CLANG_WARN_CONSTANT_CONVERSION = YES;
-                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-                CLANG_WARN_EMPTY_BODY = YES;
-                CLANG_WARN_ENUM_CONVERSION = YES;
-                CLANG_WARN_INFINITE_RECURSION = YES;
-                CLANG_WARN_INT_CONVERSION = YES;
-                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-                CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-                CLANG_WARN_STRICT_PROTOTYPES = YES;
-                CLANG_WARN_SUSPICIOUS_MOVE = YES;
-                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-                CLANG_WARN_UNREACHABLE_CODE = YES;
-                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-                COPY_PHASE_STRIP = NO;
-                DEBUG_INFORMATION_FORMAT = dwarf;
-                ENABLE_STRICT_OBJC_MSGSEND = YES;
-                ENABLE_TESTABILITY = YES;
-                GCC_C_LANGUAGE_STANDARD = gnu11;
-                GCC_DYNAMIC_NO_PIC = NO;
-                GCC_NO_COMMON_BLOCKS = YES;
-                GCC_OPTIMIZATION_LEVEL = 0;
-                GCC_PREPROCESSOR_DEFINITIONS = (
-                    "DEBUG=1",
-                    "$(inherited)",
-                );
-                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-                GCC_WARN_UNDECLARED_SELECTOR = YES;
-                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-                GCC_WARN_UNUSED_FUNCTION = YES;
-                GCC_WARN_UNUSED_VARIABLE = YES;
-                IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-                MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-                MTL_FAST_MATH = YES;
-                ONLY_ACTIVE_ARCH = YES;
-                SDKROOT = iphoneos;
-                SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-                SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-            };
-            name = Debug;
-        };
-        37FD7E122910094500853C23 /* Release */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ALWAYS_SEARCH_USER_PATHS = NO;
-                CLANG_ANALYZER_NONNULL = YES;
-                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-                CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-                CLANG_ENABLE_MODULES = YES;
-                CLANG_ENABLE_OBJC_ARC = YES;
-                CLANG_ENABLE_OBJC_WEAK = YES;
-                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-                CLANG_WARN_BOOL_CONVERSION = YES;
-                CLANG_WARN_COMMA = YES;
-                CLANG_WARN_CONSTANT_CONVERSION = YES;
-                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-                CLANG_WARN_EMPTY_BODY = YES;
-                CLANG_WARN_ENUM_CONVERSION = YES;
-                CLANG_WARN_INFINITE_RECURSION = YES;
-                CLANG_WARN_INT_CONVERSION = YES;
-                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-                CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-                CLANG_WARN_STRICT_PROTOTYPES = YES;
-                CLANG_WARN_SUSPICIOUS_MOVE = YES;
-                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-                CLANG_WARN_UNREACHABLE_CODE = YES;
-                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-                COPY_PHASE_STRIP = NO;
-                DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-                ENABLE_NS_ASSERTIONS = NO;
-                ENABLE_STRICT_OBJC_MSGSEND = YES;
-                GCC_C_LANGUAGE_STANDARD = gnu11;
-                GCC_NO_COMMON_BLOCKS = YES;
-                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-                GCC_WARN_UNDECLARED_SELECTOR = YES;
-                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-                GCC_WARN_UNUSED_FUNCTION = YES;
-                GCC_WARN_UNUSED_VARIABLE = YES;
-                IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-                MTL_ENABLE_DEBUG_INFO = NO;
-                MTL_FAST_MATH = YES;
-                SDKROOT = iphoneos;
-                SWIFT_COMPILATION_MODE = wholemodule;
-                SWIFT_OPTIMIZATION_LEVEL = "-O";
-                VALIDATE_PRODUCT = YES;
-            };
-            name = Release;
-        };
-        37FD7E142910094500853C23 /* Debug */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-                CLANG_CXX_LANGUAGE_STANDARD = "c++14";
-                CLANG_ENABLE_MODULES = YES;
-                CODE_SIGN_STYLE = Automatic;
-                CURRENT_PROJECT_VERSION = 1;
-                DEVELOPMENT_TEAM = LXGRKDMEQU;
-                GCC_C_LANGUAGE_STANDARD = gnu11;
-                GENERATE_INFOPLIST_FILE = YES;
-                HEADER_SEARCH_PATHS = (
-                    ../,
-                    "../fc_base/openfst-src/src/include",
-                    "../fc_base/gflags-build/include",
-                    "../fc_base/glog-build",
-                    "../fc_base/glog-src/src",
-                    ../kaldi,
-                    ../build/Pods/LibTorch/install/include,
-                );
-                INFOPLIST_FILE = WenetDemo/Info.plist;
-                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-                INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-                INFOPLIST_KEY_UIMainStoryboardFile = Main;
-                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-                IPHONEOS_DEPLOYMENT_TARGET = 14.6;
-                LD_RUNPATH_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "@executable_path/Frameworks",
-                );
-                LIBRARY_SEARCH_PATHS = (
-                    "../build/decoder/Debug-iphoneos",
-                    ../build/Pods/LibTorch/install/lib,
-                    "../fc_base/openfst-build/src/lib/Debug-iphoneos",
-                    "../fc_base/gflags-build/Debug-iphoneos",
-                    "../fc_base/glog-build/Debug-iphoneos",
-                    "../build/kaldi/Debug-iphoneos",
-                    "../build/post_processor/Debug-iphoneos",
-                    "../build/utils/Debug-iphoneos",
-                    "../build/frontend/Debug-iphoneos",
-                );
-                MARKETING_VERSION = 1.0;
-                OTHER_LDFLAGS = (
-                    "-ObjC",
-                    "-l\"XNNPACK\"",
-                    "-l\"c++\"",
-                    "-l\"c10\"",
-                    "-l\"clog\"",
-                    "-l\"cpuinfo\"",
-                    "-l\"eigen_blas\"",
-                    "-l\"pthreadpool\"",
-                    "-l\"pytorch_qnnpack\"",
-                    "-l\"stdc++\"",
-                    "-l\"torch\"",
-                    "-l\"torch_cpu\"",
-                    "-force_load",
-                    ../build/Pods/LibTorch/install/lib/libtorch.a,
-                    "-force_load",
-                    ../build/Pods/LibTorch/install/lib/libtorch_cpu.a,
-                    "-l\"gflags_nothreads_debug\"",
-                    "-l\"glogd\"",
-                );
-                PRODUCT_BUNDLE_IDENTIFIER = com.wenet.WenetDemo;
-                PRODUCT_NAME = "$(TARGET_NAME)";
-                SWIFT_EMIT_LOC_STRINGS = YES;
-                SWIFT_OBJC_BRIDGING_HEADER = "WenetDemo/wenet/WenetDemo-Bridging-Header.h";
-                SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-                SWIFT_VERSION = 5.0;
-                TARGETED_DEVICE_FAMILY = "1,2";
-            };
-            name = Debug;
-        };
-        37FD7E152910094500853C23 /* Release */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-                CLANG_CXX_LANGUAGE_STANDARD = "c++14";
-                CLANG_ENABLE_MODULES = YES;
-                CODE_SIGN_STYLE = Automatic;
-                CURRENT_PROJECT_VERSION = 1;
-                DEVELOPMENT_TEAM = LXGRKDMEQU;
-                GCC_C_LANGUAGE_STANDARD = gnu11;
-                GENERATE_INFOPLIST_FILE = YES;
-                HEADER_SEARCH_PATHS = (
-                    ../,
-                    "../fc_base/openfst-src/src/include",
-                    "../fc_base/gflags-build/include",
-                    "../fc_base/glog-build",
-                    "../fc_base/glog-src/src",
-                    ../kaldi,
-                    ../build/Pods/LibTorch/install/include,
-                );
-                INFOPLIST_FILE = WenetDemo/Info.plist;
-                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-                INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-                INFOPLIST_KEY_UIMainStoryboardFile = Main;
-                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-                IPHONEOS_DEPLOYMENT_TARGET = 14.6;
-                LD_RUNPATH_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "@executable_path/Frameworks",
-                );
-                LIBRARY_SEARCH_PATHS = (
-                    "../build/decoder/Release-iphoneos",
-                    ../build/Pods/LibTorch/install/lib,
-                    "../fc_base/openfst-build/src/lib/Release-iphoneos",
-                    "../fc_base/gflags-build/Release-iphoneos",
-                    "../fc_base/glog-build/Release-iphoneos",
-                    "../build/kaldi/Release-iphoneos",
-                    "../build/post_processor/Release-iphoneos",
-                    "../build/utils/Release-iphoneos",
-                    "../build/frontend/Release-iphoneos",
-                );
-                MARKETING_VERSION = 1.0;
-                OTHER_LDFLAGS = (
-                    "-ObjC",
-                    "-l\"XNNPACK\"",
-                    "-l\"c++\"",
-                    "-l\"c10\"",
-                    "-l\"clog\"",
-                    "-l\"cpuinfo\"",
-                    "-l\"eigen_blas\"",
-                    "-l\"pthreadpool\"",
-                    "-l\"pytorch_qnnpack\"",
-                    "-l\"stdc++\"",
-                    "-l\"torch\"",
-                    "-l\"torch_cpu\"",
-                    "-force_load",
-                    ../build/Pods/LibTorch/install/lib/libtorch.a,
-                    "-force_load",
-                    ../build/Pods/LibTorch/install/lib/libtorch_cpu.a,
-                    "-l\"gflags_nothreads\"",
-                    "-l\"glog\"",
-                );
-                PRODUCT_BUNDLE_IDENTIFIER = com.wenet.WenetDemo;
-                PRODUCT_NAME = "$(TARGET_NAME)";
-                SWIFT_EMIT_LOC_STRINGS = YES;
-                SWIFT_OBJC_BRIDGING_HEADER = "WenetDemo/wenet/WenetDemo-Bridging-Header.h";
-                SWIFT_VERSION = 5.0;
-                TARGETED_DEVICE_FAMILY = "1,2";
-            };
-            name = Release;
-        };
+		37FD7E112910094500853C23 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		37FD7E122910094500853C23 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		37FD7E142910094500853C23 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = BL92HWS38Y;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					../,
+					"../fc_base/openfst-src/src/include",
+					"../fc_base/gflags-build/include",
+					"../fc_base/glog-build",
+					"../fc_base/glog-src/src",
+					../kaldi,
+					../build/Pods/LibTorch/install/include,
+					"../fc_base/wetextprocessing-src/runtime",
+				);
+				INFOPLIST_FILE = WenetDemo/Info.plist;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Need microphone access for recording speech";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"../build/decoder/Debug-iphoneos",
+					../build/Pods/LibTorch/install/lib,
+					"../fc_base/openfst-build/src/lib/Debug-iphoneos",
+					"../fc_base/gflags-build/Debug-iphoneos",
+					"../fc_base/glog-build/Debug-iphoneos",
+					"../build/kaldi/Debug-iphoneos",
+					"../build/post_processor/Debug-iphoneos",
+					"../build/utils/Debug-iphoneos",
+					"../build/frontend/Debug-iphoneos",
+					"../build/fc_base/wetextprocessing-src/runtime/processor/Debug-iphoneos",
+					"../build/fc_base/wetextprocessing-src/runtime/utils/Debug-iphoneos",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-l\"XNNPACK\"",
+					"-l\"c++\"",
+					"-l\"c10\"",
+					"-l\"clog\"",
+					"-l\"cpuinfo\"",
+					"-l\"eigen_blas\"",
+					"-l\"pthreadpool\"",
+					"-l\"pytorch_qnnpack\"",
+					"-l\"stdc++\"",
+					"-l\"torch\"",
+					"-l\"torch_cpu\"",
+					"-force_load",
+					../build/Pods/LibTorch/install/lib/libtorch.a,
+					"-force_load",
+					../build/Pods/LibTorch/install/lib/libtorch_cpu.a,
+					"-l\"gflags_nothreads_debug\"",
+					"-l\"glogd\"",
+					"-l\"wetext_processor\"",
+					"-l\"wetext_utils\"",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.asr.WenetDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "WenetDemo/wenet/WenetDemo-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		37FD7E152910094500853C23 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = BL92HWS38Y;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					../,
+					"../fc_base/openfst-src/src/include",
+					"../fc_base/gflags-build/include",
+					"../fc_base/glog-build",
+					"../fc_base/glog-src/src",
+					../kaldi,
+					../build/Pods/LibTorch/install/include,
+					"../fc_base/wetextprocessing-src/runtime",
+				);
+				INFOPLIST_FILE = WenetDemo/Info.plist;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Need microphone access for recording speech";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"../build/decoder/Release-iphoneos",
+					../build/Pods/LibTorch/install/lib,
+					"../fc_base/openfst-build/src/lib/Release-iphoneos",
+					"../fc_base/gflags-build/Release-iphoneos",
+					"../fc_base/glog-build/Release-iphoneos",
+					"../build/kaldi/Release-iphoneos",
+					"../build/post_processor/Release-iphoneos",
+					"../build/utils/Release-iphoneos",
+					"../build/frontend/Release-iphoneos",
+					"../build/fc_base/wetextprocessing-src/runtime/processor/Release-iphoneos",
+					"../build/fc_base/wetextprocessing-src/runtime/utils/Release-iphoneos",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-l\"XNNPACK\"",
+					"-l\"c++\"",
+					"-l\"c10\"",
+					"-l\"clog\"",
+					"-l\"cpuinfo\"",
+					"-l\"eigen_blas\"",
+					"-l\"pthreadpool\"",
+					"-l\"pytorch_qnnpack\"",
+					"-l\"stdc++\"",
+					"-l\"torch\"",
+					"-l\"torch_cpu\"",
+					"-force_load",
+					../build/Pods/LibTorch/install/lib/libtorch.a,
+					"-force_load",
+					../build/Pods/LibTorch/install/lib/libtorch_cpu.a,
+					"-l\"gflags_nothreads\"",
+					"-l\"glog\"",
+					"-l\"wetext_processor\"",
+					"-l\"wetext_utils\"",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.asr.WenetDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "WenetDemo/wenet/WenetDemo-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-        37FD7DFA2910094300853C23 /* Build configuration list for PBXProject "WenetDemo" */ = {
-            isa = XCConfigurationList;
-            buildConfigurations = (
-                37FD7E112910094500853C23 /* Debug */,
-                37FD7E122910094500853C23 /* Release */,
-            );
-            defaultConfigurationIsVisible = 0;
-            defaultConfigurationName = Release;
-        };
-        37FD7E132910094500853C23 /* Build configuration list for PBXNativeTarget "WenetDemo" */ = {
-            isa = XCConfigurationList;
-            buildConfigurations = (
-                37FD7E142910094500853C23 /* Debug */,
-                37FD7E152910094500853C23 /* Release */,
-            );
-            defaultConfigurationIsVisible = 0;
-            defaultConfigurationName = Release;
-        };
+		37FD7DFA2910094300853C23 /* Build configuration list for PBXProject "WenetDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				37FD7E112910094500853C23 /* Debug */,
+				37FD7E122910094500853C23 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		37FD7E132910094500853C23 /* Build configuration list for PBXNativeTarget "WenetDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				37FD7E142910094500853C23 /* Debug */,
+				37FD7E152910094500853C23 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
-    };
-    rootObject = 37FD7DF72910094300853C23 /* Project object */;
+	};
+	rootObject = 37FD7DF72910094300853C23 /* Project object */;
 }

--- a/runtime/ios/WenetDemo/WenetDemo/ViewController.swift
+++ b/runtime/ios/WenetDemo/WenetDemo/ViewController.swift
@@ -44,7 +44,14 @@ class ViewController: UIViewController {
       return
     }
 
-    wenetModel = Wenet(modelPath: modelPath, dictPath: dictPath)
+    // ITN model paths (optional)
+    let itnTaggerPath = Bundle.main.path(forResource: "zh_itn_tagger", ofType: "fst")
+    let itnVerbalizerPath = Bundle.main.path(forResource: "zh_itn_verbalizer", ofType: "fst")
+
+    wenetModel = Wenet(modelPath: modelPath,
+                       dictPath: dictPath,
+                       itnTaggerPath: itnTaggerPath,
+                       itnVerbalizerPath: itnVerbalizerPath)
     wenetModel?.reset()
     print("Model initialized successfully.")
   }

--- a/runtime/ios/WenetDemo/WenetDemo/wenet/wenet.h
+++ b/runtime/ios/WenetDemo/WenetDemo/wenet/wenet.h
@@ -25,7 +25,7 @@
 @interface Wenet : NSObject
 
 - (nullable instancetype)initWithModelPath:
-(NSString*)modelPath DictPath:(NSString*)dictPath;  // NOLINT
+(NSString*)modelPath DictPath:(NSString*)dictPath ITNTaggerPath:(nullable NSString*)itnTaggerPath ITNVerbalizerPath:(nullable NSString*)itnVerbalizerPath;  // NOLINT
 
 - (void)reset;
 

--- a/runtime/ios/WenetDemo/WenetDemo/wenet/wenet.mm
+++ b/runtime/ios/WenetDemo/WenetDemo/wenet/wenet.mm
@@ -41,7 +41,7 @@ using namespace wenet;
 }
 
 - (nullable instancetype)initWithModelPath:
-(NSString*)modelPath DictPath:(NSString*)dictPath {
+(NSString*)modelPath DictPath:(NSString*)dictPath ITNTaggerPath:(nullable NSString*)itnTaggerPath ITNVerbalizerPath:(nullable NSString*)itnVerbalizerPath {
   self = [super init];
   if (self) {
     try {
@@ -58,8 +58,32 @@ using namespace wenet;
       (fst::SymbolTable::ReadText(dictPath.UTF8String));
 
       PostProcessOptions post_process_opts;
-      resource->post_processor =
-      std::make_shared<PostProcessor>(post_process_opts);
+      // Load ITN resources if paths are provided
+      if (itnTaggerPath != nil && itnVerbalizerPath != nil) {
+        NSString* taggerPath = [itnTaggerPath stringByStandardizingPath];
+        NSString* verbalizerPath = [itnVerbalizerPath stringByStandardizingPath];
+        NSFileManager* fileManager = [NSFileManager defaultManager];
+        if ([fileManager fileExistsAtPath:taggerPath] &&
+            [fileManager fileExistsAtPath:verbalizerPath]) {
+          LOG(INFO) << "Reading ITN fst";
+          NSLog(@"Reading ITN fst from: %@ and %@", taggerPath, verbalizerPath);
+          // IMPORTANT: Set itn = true BEFORE constructing PostProcessor
+          // because PostProcessOptions is passed as const reference
+          post_process_opts.itn = true;
+          auto postprocessor = std::make_shared<PostProcessor>(std::move(post_process_opts));
+          postprocessor->InitITNResource(taggerPath.UTF8String,
+                                         verbalizerPath.UTF8String);
+          resource->post_processor = postprocessor;
+        } else {
+          LOG(INFO) << "ITN files not found, skipping ITN";
+          NSLog(@"ITN files not found, skipping ITN");
+          resource->post_processor =
+          std::make_shared<PostProcessor>(std::move(post_process_opts));
+        }
+      } else {
+        resource->post_processor =
+        std::make_shared<PostProcessor>(std::move(post_process_opts));
+      }
 
       feature_config = std::make_shared<FeaturePipelineConfig>(80, 16000);
       feature_pipeline = std::make_shared<FeaturePipeline>(*feature_config);


### PR DESCRIPTION
[ios] Add ITN (Inverse Text Normalization) support for iOS runtime

- Add ITN parameters to Wenet initialization method in wenet.h/wenet.mm
- Load zh_itn_tagger.fst and zh_itn_verbalizer.fst for ITN processing
- Update ViewController.swift to pass ITN file paths
- Add debug logging to PostProcessor::Process for troubleshooting
- Update README.md with ITN download and setup instructions

ITN converts spoken numbers to written form (e.g., "二点五" → "2.5").

To enable ITN, download FST files from WeTextProcessing:
- https://github.com/wenet-e2e/WeTextProcessing/releases

Files modified:
- runtime/ios/WenetDemo/WenetDemo/wenet/wenet.h
- runtime/ios/WenetDemo/WenetDemo/wenet/wenet.mm
- runtime/ios/WenetDemo/WenetDemo/ViewController.swift
- runtime/ios/post_processor/post_processor.cc
- runtime/ios/README.md