### PR TITLE
refactor: fix typo Embedinig -> Embedding in subsampling

### DIFF
--- a/wenet/models/transformer/subsampling.py
+++ b/wenet/models/transformer/subsampling.py
@@ -33,7 +33,7 @@ class BaseSubsampling(torch.nn.Module):
         return self.pos_enc.position_encoding(offset, size)
 
 
-class EmbedinigNoSubsampling(BaseSubsampling):
+class EmbeddingNoSubsampling(BaseSubsampling):
     """Embedding input without subsampling
     """
 

--- a/wenet/utils/class_utils.py
+++ b/wenet/utils/class_utils.py
@@ -29,7 +29,7 @@ from wenet.models.transformer.subsampling import (Conv1dSubsampling2,
                                                   Conv2dSubsampling4,
                                                   Conv2dSubsampling6,
                                                   Conv2dSubsampling8,
-                                                  EmbedinigNoSubsampling,
+                                                  EmbeddingNoSubsampling,
                                                   LinearNoSubsampling,
                                                   StackNFramesSubsampling)
 from wenet.models.transformer.swish import Swish
@@ -51,7 +51,7 @@ WENET_RNN_CLASSES = {
 
 WENET_SUBSAMPLE_CLASSES = {
     "linear": LinearNoSubsampling,
-    "embed": EmbedinigNoSubsampling,
+    "embed": EmbeddingNoSubsampling,
     "conv1d2": Conv1dSubsampling2,
     "conv2d2": Conv2dSubsampling2,
     "conv2d": Conv2dSubsampling4,


### PR DESCRIPTION
I found a typo in the class name `EmbedinigNoSubsampling` (extra 'i'). 
This PR renames it to `EmbeddingNoSubsampling` and updates all references in the codebase and configuration files to maintain consistency.