### PR TITLE
docs: add Tesla T4/Turing hardware notes (device, dtype, use_sdpa)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@
 pip install git+https://github.com/wenet-e2e/wenet.git
 ```
 
+This pulls in `torch>=1.13.0` with no upper bound, so pip may install a torch
+build newer than your installed GPU driver supports. If you plan to use a GPU,
+verify it after install:
+
+``` sh
+python -c "import torch; print(torch.cuda.is_available())"
+```
+
+If this prints `False` on a machine with a GPU, torch silently falls back to
+CPU with no error. Reinstall a torch build matching your driver's CUDA
+version, e.g.:
+
+``` sh
+pip install torch==2.4.0+cu121 torchaudio==2.4.0+cu121 --index-url https://download.pytorch.org/whl/cu121 --force-reinstall
+```
+
 **Command-line usage** (use `-h` for parameters):
 
 ``` sh
@@ -37,6 +53,12 @@ wenet -m paraformer audio.wav
 
 You can set `-m` with `paraformer` or `firered` or `wenetspeech` for chinese,
 and set it to `whisper-large-v3` or `whisper-large-v3-turbo` for english.
+
+Note: this runs on **CPU by default** (`--device` defaults to `cpu`), even if
+a GPU is available. Pass `--device cuda` explicitly to use the GPU (Python API:
+`wenet.load_model(model_name, device='cuda')`). See
+[python usage](docs/python_package.md#gpuhardware-notes) for GPU/Turing (e.g.
+Tesla T4) specific notes on dtype and attention-backend options.
 
 
 **Python programming usage**:

--- a/docs/python_package.md
+++ b/docs/python_package.md
@@ -76,10 +76,13 @@ Measured on a Tesla T4 (16GB, Turing/sm_75), torch 2.4.0+cu121.
   46.6ms -> 33.1ms (~29%, cutting most of the bf16 slowdown above). This
   toggle only applies to WeNet's own Conformer models; Paraformer (SANM
   attention) does not have a `use_sdpa` code path.
-* **int8 dynamic quantization is CPU-only.** `torch.quantization.quantize_dynamic`
-  (used by `wenet/bin/export_onnx_cpu.py`/`export_jit.py`) works on CPU but
-  raises `NotImplementedError: Could not run 'quantized::linear_dynamic' with
+* **int8 dynamic quantization is CPU-only.** `wenet/bin/export_jit.py` uses
+  `torch.quantization.quantize_dynamic`, which works on CPU but raises
+  `NotImplementedError: Could not run 'quantized::linear_dynamic' with
   arguments from the 'CUDA' backend` if applied to a CUDA model — this is a
-  PyTorch backend limitation, not a WeNet bug. For GPU-side reduced precision,
-  see `wenet/bin/export_onnx_gpu.py --fp16` (ONNX export, a separate
-  fp16-only workflow).
+  PyTorch backend limitation, not a WeNet bug. (`wenet/bin/export_onnx_cpu.py`
+  quantizes separately via `onnxruntime.quantization.quantize_dynamic`, a
+  different, ONNX-graph-level API that isn't affected by this PyTorch
+  limitation.) For GPU-side reduced precision, see
+  `wenet/bin/export_onnx_gpu.py --fp16` (ONNX export, a separate fp16-only
+  workflow).

--- a/docs/python_package.md
+++ b/docs/python_package.md
@@ -43,3 +43,43 @@ model = wenet.load_model('chinese')
 result = model.transcribe('audio.wav')
 print(result['text'])
 ```
+
+## GPU/Hardware Notes
+
+Measured on a Tesla T4 (16GB, Turing/sm_75), torch 2.4.0+cu121.
+
+* **GPU is not the default.** `--device` (CLI) and `device` (`wenet.load_model`)
+  both default to `'cpu'`. On a GPU host, `wenet -m <model> audio.wav` still
+  runs on CPU unless you pass `--device cuda`. There is no warning when this
+  happens. Measured on paraformer: CUDA is **2.84x** faster than CPU
+  (0.205s vs 0.581s per utterance, cached model, T4).
+* **No dtype flag on the pip-installed CLI.** The `wenet` console command
+  (`wenet/cli/transcribe.py`) always runs fp32 and has no `--dtype`/`--fp16`
+  flag. The training-recipe script `wenet/bin/recognize.py` does expose
+  `--dtype {fp16,fp32,bf16}`, but that is a separate, more involved entry
+  point (local recipe checkout, not the pip package).
+* **bf16 can be slower than fp32 on Turing-class GPUs (e.g. T4).** T4 lacks
+  bf16 tensor-core acceleration. On WeNet's own Conformer models (e.g.
+  `wenetspeech`), casting to bf16 measured **~47% slower** than fp32
+  (46.6ms vs 31.7ms per forward pass). fp16 does not crash but shows no
+  speedup at batch size 1 with short audio (launch-overhead bound), though it
+  does cut VRAM by about 46%.
+* **`use_sdpa` is off by default in the shipped configs, and turning it on
+  helps most on bf16.** WeNet's own Conformer implementation supports a
+  `use_sdpa: true` toggle (`encoder_conf`/`decoder_conf`) that switches
+  attention from a manual matmul+softmax to
+  `torch.nn.functional.scaled_dot_product_attention`, using the same
+  checkpoint with no retraining. The `train.yaml` shipped with pretrained
+  models (e.g. `wenetspeech`) does not set this key, so it loads as `False`.
+  Enabling it measured 7-29% faster on a T4, with identical output text:
+  fp32 31.7ms -> 29.4ms (~7%), fp16 32.2ms -> 30.0ms (~7%), bf16
+  46.6ms -> 33.1ms (~29%, cutting most of the bf16 slowdown above). This
+  toggle only applies to WeNet's own Conformer models; Paraformer (SANM
+  attention) does not have a `use_sdpa` code path.
+* **int8 dynamic quantization is CPU-only.** `torch.quantization.quantize_dynamic`
+  (used by `wenet/bin/export_onnx_cpu.py`/`export_jit.py`) works on CPU but
+  raises `NotImplementedError: Could not run 'quantized::linear_dynamic' with
+  arguments from the 'CUDA' backend` if applied to a CUDA model — this is a
+  PyTorch backend limitation, not a WeNet bug. For GPU-side reduced precision,
+  see `wenet/bin/export_onnx_gpu.py --fp16` (ONNX export, a separate
+  fp16-only workflow).


### PR DESCRIPTION
## Motivation

Ran WeNet's pip-installed CLI/API on a real Tesla T4 (16GB, Turing/sm_75) and found several GPU-relevant behaviors that aren't documented anywhere, none of which involve any code or config changes:

- The README's headline quickstart (`wenet -m paraformer audio.wav`) never mentions GPU/device, and `--device` (CLI) / `device` (`wenet.load_model`) both default to `'cpu'` with no warning — on a GPU host this silently runs on CPU unless `--device cuda` is passed explicitly.
- `setup.py` pins `torch>=1.13.0` with no upper bound, so `pip install git+...` can pull a torch build newer than an older GPU driver supports, leaving `torch.cuda.is_available() == False` with no obvious error message tying it back to the install step.
- The pip-installed `wenet` CLI has no dtype flag at all (no `--dtype`/`--fp16`/`--bf16`), unlike the separate training-recipe script `wenet/bin/recognize.py`, which exposes `--dtype {fp16,fp32,bf16}`.
- On WeNet's own Conformer models (e.g. `wenetspeech`), the shipped `train.yaml` does not set `use_sdpa`, so it loads as `False` (manual matmul+softmax attention) by default. Enabling `use_sdpa: true` (same checkpoint, no retraining) measurably recovers most of the T4 bf16 slowdown.

## Changes

Doc-only, no code changes:

- `README.md`: note that the unpinned pip install can silently mismatch older drivers, with a verification command and a known-good reinstall example; note that the CLI/API run on CPU by default and how to opt into `--device cuda`.
- `docs/python_package.md`: new "GPU/Hardware Notes" section documenting, with numbers measured on a Tesla T4:
  - CUDA vs CPU: **2.84x** faster (0.205s vs 0.581s per utterance, cached paraformer model)
  - No dtype flag on the pip CLI vs. `wenet/bin/recognize.py`'s `--dtype {fp16,fp32,bf16}`
  - bf16 cast on WeNet Conformer: **~47% slower** than fp32 (46.6ms vs 31.7ms) — Turing has no bf16 tensor-core acceleration; fp16 shows no speedup at batch size 1 but cuts VRAM ~46%
  - `use_sdpa: true` (not set in shipped configs) sped things up 7-29% with identical output text: fp32 31.7ms→29.4ms, fp16 32.2ms→30.0ms, bf16 46.6ms→33.1ms — this only applies to WeNet's own Conformer models, not Paraformer (SANM attention has no `use_sdpa` path)
  - int8 dynamic quantization (`torch.quantization.quantize_dynamic`) is CPU-only; raises `NotImplementedError` on CUDA (PyTorch backend limitation, not a WeNet bug)

## Testing

- Verified all measurements above directly against this repo's public API (`wenet.load_model`/`model.transcribe`, `wenet.utils.init_model.init_model`+`model.decode`) on a real Tesla T4 16GB (driver 550.163.01, torch 2.4.0+cu121).
- `use_sdpa` toggle was validated by re-running the same checkpoint with `encoder_conf['use_sdpa']=True`/`decoder_conf['use_sdpa']=True` and confirming output text is byte-identical across all 8 dtype/use_sdpa combinations tested.
- No source files under `wenet/` were modified — only `README.md` and `docs/python_package.md`.