### PR TITLE
fix(tools): call init_model with (args, configs) in latency_metrics.py

### DIFF
--- a/tools/latency_metrics.py
+++ b/tools/latency_metrics.py
@@ -11,24 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import argparse
 import logging
+import os
+
 import librosa
+import matplotlib.font_manager as fm
+import matplotlib.pyplot as plt
+import numpy as np
 import torch
 import torchaudio
+import torchaudio.compliance.kaldi as kaldi
 import yaml
 
-import numpy as np
-import matplotlib.pyplot as plt
-import matplotlib.font_manager as fm
-import torchaudio.compliance.kaldi as kaldi
-
-from wenet.utils.init_model import init_model
 from wenet.utils.checkpoint import load_checkpoint
-from wenet.utils.file_utils import read_symbol_table
-from wenet.utils.mask import make_pad_mask
 from wenet.utils.common import replace_duplicates_with_blank
+from wenet.utils.file_utils import read_symbol_table
+from wenet.utils.init_model import init_model
+from wenet.utils.mask import make_pad_mask
 
 
 def get_args():

--- a/tools/latency_metrics.py
+++ b/tools/latency_metrics.py
@@ -96,7 +96,7 @@ def main():
     use_cuda = args.gpu >= 0 and torch.cuda.is_available()
     device = torch.device('cuda' if use_cuda else 'cpu')
 
-    model = init_model(conf)
+    model, conf = init_model(args, conf)
     load_checkpoint(model, args.ckpt)
     model = model.eval().to(device)
 


### PR DESCRIPTION
### Problem

`tools/latency_metrics.py` cannot run at all — it dies on the model-loading line:

```python
# tools/latency_metrics.py:99
model = init_model(conf)
```

but `init_model` has taken two arguments and returned a pair for a long time now:

```python
# wenet/utils/init_model.py:184
def init_model(args, configs):
    ...
    return model, configs
```

Every other call site in the tree already does it the right way — 13 of them:

```
wenet/bin/alignment.py:223        model, configs = init_model(args, configs)
wenet/bin/export_ipex.py:56       model, configs = init_model(args, configs)
wenet/bin/export_jit.py:49        model, configs = init_model(args, configs)
wenet/bin/export_onnx_bpu.py:1053 model, configs = init_model(args, configs)
wenet/bin/export_onnx_cpu.py:426  model, configs = init_model(args, configs)
wenet/bin/export_onnx_gpu.py:1218 model, configs = init_model(args, configs)
wenet/bin/recognize.py:245        model, configs = init_model(args, configs)
wenet/bin/train.py:100            model, configs = init_model(args, configs)
wenet/cli/model.py:98             model, configs = init_model(args, configs)
tools/onnx2horizonbin.py:415      model = init_model(args, configs)
examples/vkw2021/s0/local/vkw_kws_results.py:208
test/wenet/models/whisper/test_whisper.py:133
test/wenet/utils/test_init_model.py:64
```

`tools/latency_metrics.py:99` is the only one left behind — and it is broken twice over:
the missing `args`, and the un-unpacked return value (`model` would be bound to the whole
tuple, so `model.encoder` on the next line would fail even if the call succeeded).

### Fix

```python
model, conf = init_model(args, conf)
```

`args` here is the script's own `argparse.Namespace`. Everything `init_model` reads off it
is `hasattr`-guarded (`use_lora`, `checkpoint`, `enc_init`, `lora_ckpt_path`,
`only_optimize_lora`), and `init_speech_model` does not touch `args` at all, so a Namespace
without those attributes takes the plain path — no behavior added. In particular this script
declares `--ckpt`, not `--checkpoint`, so `init_model` loads nothing and the script's own
`load_checkpoint(model, args.ckpt)` on the following line still does the loading, exactly as before.

Unpacking into `conf` also matches the other call sites and matters here: `conf` is read again
below for `conf['dataset_conf'][...]` (L116/L123-125), and now gets the post-processed configs
(`configs['model']`, `configs['init_infos']`) that `init_model` fills in.

### Verification

The defect is a signature mismatch, so no ASR run is required to show it. I pulled
`init_model`'s signature out of `main` (`a54b90b`) via AST and replayed both call shapes
through `inspect.Signature.bind`:

```
   TypeError call site tools/latency_metrics.py:99  init_model(conf)           (args, configs)
              -> missing a required argument: 'configs'
   OK        sibling   wenet/bin/recognize.py:245   init_model(args, configs)  (args, configs)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
