### PR TITLE
fix(gigaspeech): repair the two skip warnings in extract_meta.py

### DIFF
--- a/examples/gigaspeech/s0/local/extract_meta.py
+++ b/examples/gigaspeech/s0/local/extract_meta.py
@@ -50,12 +50,12 @@ def meta_analysis(input_json, output_dir):
                         assert ('opus' == long_audio['format'])
                         assert (16000 == long_audio['sample_rate'])
                     except AssertionError:
-                        print(f'Warning: {aid} something is wrong, maybe'
+                        print(f'Warning: {aid} something is wrong, maybe '
                               'AssertionError, skipped')
                         continue
                     except Warning:
-                        print(f'Warning: {aid} something is wrong, maybe the'
-                              'error path: {long_audio_path}, skipped')
+                        print(f'Warning: {aid} something is wrong, maybe the '
+                              f'error path: {long_audio_path}, skipped')
                         continue
                     else:
                         wavscp.write(f'{aid}\t{long_audio_path}\n')


### PR DESCRIPTION
### Problem

`examples/gigaspeech/s0/local/extract_meta.py` builds two skip warnings from
implicitly concatenated fragments, and both come out malformed:

```python
                    except AssertionError:
                        print(f'Warning: {aid} something is wrong, maybe'
                              'AssertionError, skipped')
                        continue
                    except Warning:
                        print(f'Warning: {aid} something is wrong, maybe the'
                              'error path: {long_audio_path}, skipped')
                        continue
```

Two distinct defects:

1. **Missing `f` prefix** on the second fragment of the `except Warning` message, so
   the path of the file that was skipped prints as the literal `{long_audio_path}` —
   which is the only actionable detail in that warning.
2. **Missing trailing space** on both first fragments, so the words run together.

### Verification

```
BEFORE 1: Warning: POD1000000004 something is wrong, maybeAssertionError, skipped
AFTER  1: Warning: POD1000000004 something is wrong, maybe AssertionError, skipped

BEFORE 2: Warning: POD1000000004 something is wrong, maybe theerror path: {long_audio_path}, skipped
AFTER  2: Warning: POD1000000004 something is wrong, maybe the error path: /data/gigaspeech/audio/x.opus, skipped
```

### Change

Two lines, diagnostics only — no change to which segments are kept or skipped.
`flake8` reports nothing new (the only messages in this file are pre-existing
missing-docstring notes).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
