### PR TITLE
fix(examples): restore the vkw KWS script to a runnable state

### DIFF
--- a/examples/vkw2021/s0/local/vkw_kws_results.py
+++ b/examples/vkw2021/s0/local/vkw_kws_results.py
@@ -26,12 +26,11 @@ from torch.utils.data import DataLoader
 
 from wenet.dataset.dataset import Dataset
 from wenet.utils.checkpoint import load_checkpoint
-from wenet.utils.init_model import init_model
-from wenet.utils.init_tokenizer import init_tokenizer
-
 from wenet.utils.common import get_subsample
 from wenet.utils.ctc_utils import remove_duplicates_and_blank
 from wenet.utils.file_utils import read_symbol_table
+from wenet.utils.init_model import init_model
+from wenet.utils.init_tokenizer import init_tokenizer
 from wenet.utils.mask import make_pad_mask
 
 

--- a/examples/vkw2021/s0/local/vkw_kws_results.py
+++ b/examples/vkw2021/s0/local/vkw_kws_results.py
@@ -20,15 +20,17 @@ import logging
 import os
 
 import torch
+import torch.distributed as dist
 import yaml
 from torch.utils.data import DataLoader
 
 from wenet.dataset.dataset import Dataset
+from wenet.utils.checkpoint import load_checkpoint
 from wenet.utils.init_model import init_model
 from wenet.utils.init_tokenizer import init_tokenizer
 
 from wenet.utils.common import get_subsample
-from wenet.utils.common import remove_duplicates_and_blank
+from wenet.utils.ctc_utils import remove_duplicates_and_blank
 from wenet.utils.file_utils import read_symbol_table
 from wenet.utils.mask import make_pad_mask
 
@@ -186,7 +188,7 @@ if __name__ == '__main__':
     cv_conf['speed_perturb'] = False
     cv_conf['spec_aug'] = False
 
-    tokenizer = init_tokenizer(ali_conf, args.symbol_table, args.bpe_model)
+    tokenizer = init_tokenizer(configs)
     cv_dataset = Dataset(args.data_type,
                          args.input_data,
                          tokenizer,


### PR DESCRIPTION
`examples/vkw2021/s0/local/vkw_kws_results.py` cannot be run today — it fails at import time, and would fail twice more if it got past that. All of it is fallout from the tokenizer refactor in #2179 (commit `a3fbf41`), plus one import that has been missing since the script was added.

### 1. `ImportError` at import time

```python
from wenet.utils.common import remove_duplicates_and_blank
```

`remove_duplicates_and_blank` lives in `wenet/utils/ctc_utils.py`; `wenet/utils/common.py` does not define or re-export it. This raises before `argparse` ever runs, so the script cannot even print `--help`:

```
ImportError: cannot import name 'remove_duplicates_and_blank' from 'wenet.utils.common'
```

Every other caller in the tree already imports it from `ctc_utils` (`wenet/bin/recognize.py`, `wenet/bin/alignment.py`, …).

### 2. `NameError: name 'load_checkpoint' is not defined`

#2179 replaced the import block:

```diff
-from wenet.transformer.asr_model import init_asr_model
-from wenet.utils.checkpoint import load_checkpoint
+from wenet.utils.init_model import init_model
+from wenet.utils.init_tokenizer import init_tokenizer
```

but the call it fed is still there at line 209:

```python
model, configs = init_model(args, configs)
load_checkpoint(model, args.checkpoint)
```

### 3. `init_tokenizer` call is a stale 3-arg form referencing a variable from a different file

The same commit added:

```python
tokenizer = init_tokenizer(ali_conf, args.symbol_table, args.bpe_model)
```

Three separate problems in one line:

* `ali_conf` does not exist in this script — it is the dataset-config variable from the sibling `wenet/bin/alignment.py`, which this line was evidently adapted from. This file names its config `cv_conf`. → `NameError`.
* `init_tokenizer(configs)` takes exactly one argument (`wenet/utils/init_tokenizer.py:26`). → `TypeError` even if `ali_conf` existed.
* `args.bpe_model` is never declared by this script's parser (there is no `--bpe_model`). → `AttributeError` even if the arity matched.

The canonical form is unambiguous — **every** other call site in the repo, including the repo's own tests, uses the 1-arg form:

| call site | form |
|---|---|
| `wenet/bin/alignment.py:213` | `init_tokenizer(configs)` |
| `wenet/bin/train.py:86` | `init_tokenizer(configs)` |
| `wenet/bin/recognize.py:232` | `init_tokenizer(configs)` |
| `wenet/bin/recognize_onnx_gpu.py:140` | `init_tokenizer(configs)` |
| `wenet/cli/model.py:46` | `init_tokenizer(configs)` |
| `tools/onnx2horizonbin.py:417` | `init_tokenizer(configs)` |
| `test/wenet/utils/test_init_tokenizer.py` (×4) | `init_tokenizer(configs)` |
| `test/wenet/dataset/test_processor.py:155` | `init_tokenizer(configs)` |
| `test/wenet/text/test_paraformer_tokenizer.py:17` | `init_tokenizer(configs)` |
| **this file** | `init_tokenizer(ali_conf, args.symbol_table, args.bpe_model)` |

`alignment.py` is also the closest structural sibling (load yaml → build dataset conf → `init_tokenizer(configs)` → `Dataset(...)` → `init_model(args, configs)`), and it does the right thing, so this patch simply matches it.

### 4. `NameError: name 'dist' is not defined`

`dist.init_process_group(...)` is called at line 170 but `torch.distributed` was never imported. This one predates #2179. Fixed with the same import the rest of the repo uses (`wenet/bin/train.py:24`, `wenet/utils/train_utils.py:25`).

### Why CI never caught it

`.flake8` lists `F821` in `ignore`, so `undefined name` is suppressed repo-wide, and `examples/` scripts are not executed in CI. Running `pyflakes` directly on the file surfaces all of it.

## Verification

`pyflakes` on the file, before and after (this repo's pinned `pyflakes`, run directly so `F821` is not suppressed):

```
-- BEFORE (main) --
vkw_kws_results.py:87:13: local variable 'non_blank' is assigned to but never used
vkw_kws_results.py:169:9: undefined name 'dist'
vkw_kws_results.py:189:32: undefined name 'ali_conf'
vkw_kws_results.py:209:5: undefined name 'load_checkpoint'

-- AFTER (this PR) --
vkw_kws_results.py:89:13: local variable 'non_blank' is assigned to but never used
```

The remaining `non_blank` warning is pre-existing and left alone to keep this diff minimal.

Import check (real `wenet` package on `sys.path`; only third-party audio deps from `requirements.txt` stubbed, since the failure is inside `wenet` itself):

```
-- BEFORE (main) --
    ImportError: cannot import name 'remove_duplicates_and_blank' from 'wenet.utils.common'

-- AFTER (this PR) --
    OK - module imported, argparse block reachable
```

`flake8` with the repo's own config passes on the patched file (exit 0).

Diff is +4/-2 in one file; no behaviour outside this script is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
